### PR TITLE
feat: improve worktree management

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,13 @@
 # Repository Guidelines
 
 **Important:** Every text in this repository must be sharp, concise, straight to the point. Each word must be carefully weighted and chosen.
+
+## AlignFirst - Ticket ID, Commit Message, Branch Name
+
+_Ticket ID_: Format is numeric. Use the ticket ID if explicitly provided. Otherwise, deduce it from the current branch name (no confirmation needed). If the branch name is unavailable, get it via `git branch --show-current`. Only ask the user as a last resort.
+
+Commit message convention: we use conventional commit, e.g., `feat: [#123] add new feature`. Always prefix the ticket ID with a `#` sign. Do not add a "Co-Authored-By:" line.
+
+Branch naming convention: `<type>/<ticket-id>` (with type from conventional commit, e.g., `feat/123`, `fix/123`, `refactor/123`, `chore/123`).
+
+Add `docs/code-style.md` and `docs/code-quality.md` to every plan.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,23 @@
 # alignfirst monorepo
 
-Three companion products for AI-assisted software work:
+Companion products for AI-assisted software work. They can be used independently.
 
-- **AlignFirst skills** — collaborative spec/plan/AAD/review protocols. See [alignfirst-skills.md](alignfirst-skills.md).
-- **`@paleo/worktree-env`** — kernel for worktree-based concurrent local environments. See [packages/worktree-env/README.md](packages/worktree-env/README.md).
-- **`@paleo/docmap`** — lightweight documentation system for AI agents and humans. See [packages/docmap/README.md](packages/docmap/README.md).
+## AlignFirst skills
 
-They can be used independently.
+Collaborative spec/plan/AAD/review protocols. See [alignfirst-skills.md](alignfirst-skills.md).
+
+## Agent-discoverable documentation
+
+`@paleo/docmap` — a lightweight table of contents that lets agents navigate documentation files. This way we have one set of docs, shared by humans and AI agents. See [packages/docmap/README.md](packages/docmap/README.md).
+
+## Local environments with worktrees
+
+`@paleo/worktree-env` — run multiple dev environments side by side using git worktrees. See [packages/worktree-env/README.md](packages/worktree-env/README.md).
+
+## Autonomous agent (experimental)
+
+We're currently working on building an AI developer with _OpenClaw_. See [autonomous-agent.md](autonomous-agent.md).
+
+## License
+
+CC0 1.0 Universal.

--- a/alignfirst-skills.md
+++ b/alignfirst-skills.md
@@ -150,19 +150,6 @@ Specs, plans, and summaries should be written in well-organized (git-ignored) lo
 1. The context window is limited, the compression mechanism is opaque, and we want to be able to continue an unfinished task in a fresh session.
 2. It's a way to keep track of what was agreed upon with the agent and what has been done.
 
-## AlignFirst Coaching (experimental)
-
-```bash
-npx skills add https://github.com/paleo/alignfirst --global --skill alignfirst-coaching
-```
-
-Optional environment variables:
-
-```bash
-export ALIGNFIRST_AGENT_LOG_DIR=path/to/directory # Write input/output logs
-export ALIGNFIRST_AGENT_SKIP_PERMISSIONS=1        # Use --dangerously-skip-permissions instead of --permission-mode auto
-```
-
 ## Upgrade from v1 or v2
 
 1. Install the docmap skill:

--- a/autonomous-agent.md
+++ b/autonomous-agent.md
@@ -1,0 +1,20 @@
+# Autonomous agent
+
+## AlignFirst Coaching
+
+```bash
+npx skills add https://github.com/paleo/alignfirst --global --skill alignfirst-coaching
+```
+
+Optional environment variables:
+
+```bash
+export ALIGNFIRST_AGENT_LOG_DIR=path/to/directory # Write input/output logs
+export ALIGNFIRST_AGENT_SKIP_PERMISSIONS=1        # Use --dangerously-skip-permissions instead of --permission-mode auto
+```
+
+## Coaching by OpenClaw (experimental)
+
+The `alignfirst-coaching` skill ships a reference that teaches OpenClaw how to drive AlignFirst from chat (Slack, Discord): interpreting user messages as project work, delegating to the coding agent, managing worktrees, branches, commits, and PRs. Still in development.
+
+See [skills/alignfirst-coaching/references/coaching-by-openclaw.md](skills/alignfirst-coaching/references/coaching-by-openclaw.md).

--- a/biome.json
+++ b/biome.json
@@ -67,7 +67,7 @@
     "includes": [
       "**",
       "!**/.local",
-      "!**/.local-data",
+      "!**/.local-wt",
       "!**/.plans",
       "!**/dist",
       "!**/node_modules",

--- a/docs/code-quality.md
+++ b/docs/code-quality.md
@@ -1,0 +1,108 @@
+---
+title: Code Quality & Refactoring
+summary: Code quality principles and refactoring guidelines.
+read_when:
+  - refactoring or improving code quality
+---
+
+# Code Quality & Refactoring
+
+## Code Quality Process
+
+A developer in our team just finished an implementation. But he is a newcomer, so you need to ensure that the code is clean, maintainable, and efficient, as it may not meet our standards yet.
+
+Read the files that were modified, if it's all good just say it's OK. Otherwise, improve the implementation, apply the following principles to ensure the code is clean, maintainable, and efficient.
+
+### SRP - Single Responsibility Principle
+
+For example, this code:
+
+```ts
+export function myFunction() {
+  // Check something
+  // ... 20 lines ...
+
+  // Do something
+  // ... 20 lines ...
+}
+```
+
+… should be refactored in:
+
+```ts
+export function myFunction() {
+  checkSomething();
+  doSomething();
+}
+
+function checkSomething() {
+  // ... 20 lines ...
+}
+
+function doSomething() {
+  // ... 20 lines ...
+}
+```
+
+Guidelines:
+
+- Always write the sub-function _after_ the caller function.
+- Do not export a function unless it is imported from outside the source file.
+- Apply the _Single Responsibility Principle_ when dividing code: one function for one concern.
+- Avoid exceeding the height of one screen (~50 lines) for function implementations.
+- Keep code clean and self-explanatory rather than adding explanatory comments.
+- When there is an ArkType, declare it outside the function, just before the function.
+
+### DRY - Don't Repeat Yourself
+
+Each time you see duplicated logic, take the time to refactor it into a reusable function.
+
+### YAGNI - You Aren't Gonna Need It
+
+Do not keep unused code such as variables, functions, implementations, etc.
+
+## Orange Flags
+
+- Most of the time, fallbacks to empty string or zero are not there for a good reason: look for `?? ""` and `?? 0` and ensure it is a proper use. If not, take the time to understand the typing and find an elegant way to handle the compiling issue.
+  - Notice: A good use case for `?? ""` is when we want an empty string value in the UI.
+- Type assertions (`as SomeType`) are often a sign of misunderstood typing.
+- In general, avoid using `any` and find the proper type. Sometimes we really want to use `any` so it's allowed but then we want a comment to explain why.
+- Do not use `ReturnType<T>` or `Parameters<T>` if you can import the actual type.
+- Do not use `SomeType["someMemberName"]` if you can import the actual type.
+
+## Remove Unnecessary Comments
+
+Remove inline comments that are redundant with the code itself.
+
+Only keep inline comments that document hacks, TODOs, or exceptional situations, or when the code's purpose isn't obvious from its structure.
+
+Never repeat the code in comments. The following comment must be removed:
+
+```ts
+// Create a new task
+createANewTask();
+```
+
+Other examples of inline comments that are obvious and must be removed:
+
+```ts
+// Validate that there is a file
+if (!file) throw new ApiError(400);
+
+// Validate and parse the request body according to the expected schema
+const validated = UploadBodyAT.assert(body);
+```
+
+JSDoc comments should only be used when they add meaningful information. Example of a comment that must be entirely removed because everything is obvious:
+
+```ts
+/**
+ * This function adds two numbers
+ * @param a - The first number
+ * @param b - The second number
+ * @returns The sum of the two numbers
+ */
+function addTwoNumbers(a: number, b: number) {
+  return a + b;
+}
+```

--- a/docs/code-style.md
+++ b/docs/code-style.md
@@ -20,10 +20,42 @@ read_when:
 
 The general rule is: **Usage comes first**, implementation comes after. Except for inheritance: for example, when an interface _extends_ another, write the parent interface first.
 
-- Order code: (1) exported and internal vars, (2) type definitions (public first, then private), (3) exported/public functions, (4) internal/helper functions
-- Follow function order: Calling functions first, helper functions after
-- Type definition ordering: types shared by several functions go at the top of the file (after imports and module-level constants), public types first, then private types. Apply the "usage comes first" principle recursively within each group (a type used as a member of another type comes after it).
+- Order code top-down: each file reads as a story, from entry point to leaves. The reader meets the highest-level thing first, then drills down into its dependencies:
+
+  ```ts
+  // 1. Imports
+  import { ... } from "...";
+
+  // 2. Module-level constants and variables (exported first, then internal)
+  export const PUBLIC_CONST = ...;
+  const INTERNAL_CONST = ...;
+
+  // 3. Shared types — main type first, then types it references
+  export interface MainType {
+    detail: DetailType;
+  }
+  export interface DetailType { ... }
+
+  // 4. Entry-point (exported) function
+  export function doThing() {
+    stepOne();
+    stepTwo();
+  }
+
+  // 5. Internal functions called by the entry point, in call order
+  function stepOne() {
+    stepOneHelper();
+  }
+  function stepOneHelper() { ... }
+
+  function stepTwo() { ... }
+  ```
+
+- Module-level constants and variables (`const`, `let`, `var` value declarations at the top of the file — both exported and internal) MUST be placed immediately after imports, before any type definitions, functions, or classes. This is the first thing a reader sees and treats them as the file's configuration surface.
+- Functions: write the caller first, then the functions it calls, recursively. A helper appears _just below_ its caller, not grouped at the bottom of the file. If a helper is called by several siblings, place it after its first caller.
+- Types: write the main (top-level) type first, then the types it references, recursively. Same "usage comes first" principle as functions.
 - Types attached to a single function (or class, or other declaration) — i.e. used only in that one signature, like a `MyComponentProps` interface used only by `MyComponent` — must be placed immediately before that declaration, not in the top type block.
+- Exports are not a sorting criterion on their own: a `function` being `export`ed does not pull it to the top — its position is determined by who calls it. The entry points of a file are usually exported, which is why they tend to appear first, but that is a consequence of the top-down rule, not the rule itself.
 
 ## Code Quality Standards
 

--- a/docs/code-style.md
+++ b/docs/code-style.md
@@ -1,0 +1,81 @@
+---
+title: Code Style Guidelines
+summary: Code style conventions and formatting rules. Always read before writing code, even for code inside a spec or a plan.
+read_when:
+  - writing or reviewing code
+  - writing code inside a spec or a plan
+---
+
+# Code Style Guidelines
+
+## General Rules
+
+- Use UTF-8 encoding with 2-space indentation, 100-char line width
+- Dead (unused) code SHOULD NOT be kept (_YAGNI principle_).
+- Multiple consecutive blank lines SHOULD NOT be written.
+- Changes to linter rules MUST be discussed before being implemented.
+- Code SHOULD NOT contain commented out code, unless accompanied by a valid explanation in comments.
+
+## Code Organization
+
+The general rule is: **Usage comes first**, implementation comes after. Except for inheritance: for example, when an interface _extends_ another, write the parent interface first.
+
+- Order code: (1) exported and internal vars, (2) type definitions (public first, then private), (3) exported/public functions, (4) internal/helper functions
+- Follow function order: Calling functions first, helper functions after
+- Type definition ordering: types shared by several functions go at the top of the file (after imports and module-level constants), public types first, then private types. Apply the "usage comes first" principle recursively within each group (a type used as a member of another type comes after it).
+- Types attached to a single function (or class, or other declaration) — i.e. used only in that one signature, like a `MyComponentProps` interface used only by `MyComponent` — must be placed immediately before that declaration, not in the top type block.
+
+## Code Quality Standards
+
+- Strive for elegant solutions from the first implementation
+- Avoid redundant operations, especially expensive ones like image conversion
+- Avoid duplicated code and logic
+- Pass previously calculated values between functions instead of recalculating
+- Use early returns to simplify code flow when possible
+- For code that leaves the current flow (`throw`, `return`, `continue`, `break`), when it fits on one line, write it on one line (e.g., `if (!condition) return false;` instead of multi-line format)
+- Use function and variable names that clearly convey intent, reducing the need for comments
+- Keep functions small with a single responsibility
+- Avoid using `any`, take the time to find the proper type. If you fail to find a type, then always insert a `/* FIXME */` after your `any`. For example: `let myVariable: any /* FIXME */;`.
+- Export only functions (or variables, classes) that are imported from elsewhere. By default, do not export.
+- When an interface is used in the signature of an exported function or component, that interface must also be exported.
+
+## Imports
+
+- Always use ESM import syntax for imports (e.g., `import { X } from "y.js"` instead of `require`)
+- Avoid import modules recursively.
+
+## TypeScript, JavaScript
+
+- Use the semicolon syntax.
+- Prefer double quotes `"`.
+- Never use `enum` and `namespace`.
+- Prefer `const` over `let`.
+- Prefer `undefined` over `null`.
+- Prefer `??` over `||`.
+- Prefer `++i` and `--i` over `i++` and `i--`.
+- Prefer `new Error()` over `Error()`.
+- At the top level, prefer the `function` and `class` declarative syntax over creating them as constants.
+- Keep an empty line between top-level functions, classes, interfaces.
+- Implementation of a getter or setter (EcmaScript 5 syntax) must never throw exceptions.
+- Prefer `interface` declarations over `type` aliases.
+- Prefer a single capital letter for generics parameters, such as `T`, `K`, etc.
+- We don't want to differentiate between an absent property and a property with an `undefined` value.
+- Use camelCase for string literal values in TypeScript union types (e.g., `"normal" | "gracefulShutdown" | "backupMode"` instead of `"normal" | "graceful-shutdown" | "backup-mode"`).
+- Never use an empty string `""` as a default value unless you really mean an empty string. If a variable might not have a value, use `undefined` or throw an error if the absence of value indicates a problem.
+- The existence of string, number, boolean values (and identifiers when they are string or number) must NEVER be tested by coercing to boolean. Use explicit comparisons with `undefined` or `null`.
+- The existence of objects and arrays CAN be done by coercing to boolean.
+- Never explicitly assign or return `undefined` when it's the default value. Use `return;` instead of `return undefined;` and `let myVariable;` instead of `let myVariable = undefined;`. However, explicitly passing `undefined` is fine when intentionally setting a value.
+- Avoid using `as any` or any kind of type assertion. Always make the effort to find the proper type. Except when the type is incorrect or truly unknown: then justify your decision with an inline comment.
+- Never re-export, except from the package's main file.
+- Avoid using inline `import("some-package-or-module").SomeType`, prefer using direct imports at the top of the file.
+- Avoid using inline `await import("some-package-or-module")`, prefer static imports at the top of the file. Except when there is a valid reason to do so, then justify your decision with an inline comment.
+
+## OOP
+
+- Prefer functions over classes.
+- Prefer writing functions with a context object instead of a class
+- Avoid class inheritance, except in the context of a framework that requires it.
+
+## Adding a package dependency
+
+Every time you need to add a dependency or a devDependency, always search for it in the codebase first, then use the same version as in the codebase.

--- a/packages/docmap/src/formatter.ts
+++ b/packages/docmap/src/formatter.ts
@@ -3,9 +3,6 @@ import { join, relative, resolve, sep } from "node:path";
 import { extractFallbackTitle, extractMetadata, stripFrontmatter } from "./parser.js";
 
 const SHELL_SAFE_NAME = /^[\w.-]+$/;
-function validateName(name: string): string | undefined {
-  return SHELL_SAFE_NAME.test(name) ? undefined : "Name contains spaces or special characters";
-}
 
 export interface FileEntry {
   name: string;
@@ -26,6 +23,41 @@ export interface FormatResult {
   lines: string[];
   hasSubdirList: boolean;
   hasFiles: boolean;
+}
+
+export interface CheckIssue {
+  path: string;
+  message: string;
+}
+
+export function checkAll(dirPath: string, relDir: string): CheckIssue[] {
+  const issues: CheckIssue[] = [];
+  let entries: Dirent<string>[];
+  try {
+    entries = readdirSync(dirPath, { withFileTypes: true });
+  } catch {
+    return issues;
+  }
+
+  for (const entry of entries) {
+    const rel = relDir ? `docs/${relDir}/${entry.name}` : `docs/${entry.name}`;
+    const nameWarning = validateName(entry.name);
+
+    if (entry.isDirectory()) {
+      if (nameWarning) issues.push({ path: rel, message: nameWarning });
+      const subRel = relDir ? `${relDir}/${entry.name}` : entry.name;
+      issues.push(...checkAll(join(dirPath, entry.name), subRel));
+    } else if (entry.name.endsWith(".md") && !shouldSkipFile(entry.name)) {
+      if (nameWarning) issues.push({ path: rel, message: nameWarning });
+      const content = readFileSync(join(dirPath, entry.name), "utf-8");
+      const meta = extractMetadata(content);
+      if (meta.error) issues.push({ path: rel, message: meta.error });
+      const title = meta.title ?? extractFallbackTitle(content);
+      if (!title) issues.push({ path: rel, message: "Missing title" });
+    }
+  }
+
+  return issues;
 }
 
 export function listDirectory(dirPath: string): DirectoryListing {
@@ -74,6 +106,33 @@ export function listDirectory(dirPath: string): DirectoryListing {
   return { subdirs, files, subdirWarnings };
 }
 
+export function formatDirectory(
+  dirPath: string,
+  title: string,
+  result: DirectoryListing,
+  relDir: string,
+): FormatResult {
+  const lines: string[] = [];
+  const titleDisplay = title.includes("/") ? `\`${title}\`` : title;
+
+  lines.push(`# ${titleDisplay}`);
+  lines.push("");
+
+  if (result.subdirs.length > 0) {
+    lines.push("## Sub-directories");
+    lines.push("");
+    lines.push(...formatSubdirTree(dirPath, result.subdirs, "", result.subdirWarnings));
+    lines.push("");
+  }
+
+  if (result.files.length > 0) {
+    lines.push(...formatFileBullets(result.files, relDir));
+    lines.push("");
+  }
+
+  return { lines, hasSubdirList: result.subdirs.length > 0, hasFiles: result.files.length > 0 };
+}
+
 export function formatRecursive(
   dirPath: string,
   title: string,
@@ -104,33 +163,6 @@ export function formatRecursive(
   }
 
   return { lines, hasSubdirList: false, hasFiles };
-}
-
-export function formatDirectory(
-  dirPath: string,
-  title: string,
-  result: DirectoryListing,
-  relDir: string,
-): FormatResult {
-  const lines: string[] = [];
-  const titleDisplay = title.includes("/") ? `\`${title}\`` : title;
-
-  lines.push(`# ${titleDisplay}`);
-  lines.push("");
-
-  if (result.subdirs.length > 0) {
-    lines.push("## Sub-directories");
-    lines.push("");
-    lines.push(...formatSubdirTree(dirPath, result.subdirs, "", result.subdirWarnings));
-    lines.push("");
-  }
-
-  if (result.files.length > 0) {
-    lines.push(...formatFileBullets(result.files, relDir));
-    lines.push("");
-  }
-
-  return { lines, hasSubdirList: result.subdirs.length > 0, hasFiles: result.files.length > 0 };
 }
 
 export function formatFileBullets(files: FileEntry[], relDir: string): string[] {
@@ -189,7 +221,6 @@ export function readDocFile(
   if (normalized === "docs" || normalized.startsWith("docs/"))
     normalized = normalized.slice("docs".length).replace(/^\/+/, "");
 
-  // Try as a direct path under docs/
   const resolvedBase = resolve(baseDir);
   const resolvedTarget = resolve(resolvedBase, normalized);
   if (isUnder(resolvedBase, resolvedTarget)) {
@@ -201,7 +232,6 @@ export function readDocFile(
     }
   }
 
-  // Search recursively for a file whose relative path ends with the given suffix
   const allFiles = getAllFiles();
   const found = allFiles.find((rel) => rel === normalized || rel.endsWith(`/${normalized}`));
   if (!found) return { path: fileArg, content: `⚠ File not found: ${fileArg}` };
@@ -229,39 +259,8 @@ export function collectAllFiles(dirPath: string, prefix: string): string[] {
   return result;
 }
 
-export interface CheckIssue {
-  path: string;
-  message: string;
-}
-
-export function checkAll(dirPath: string, relDir: string): CheckIssue[] {
-  const issues: CheckIssue[] = [];
-  let entries: Dirent<string>[];
-  try {
-    entries = readdirSync(dirPath, { withFileTypes: true });
-  } catch {
-    return issues;
-  }
-
-  for (const entry of entries) {
-    const rel = relDir ? `docs/${relDir}/${entry.name}` : `docs/${entry.name}`;
-    const nameWarning = validateName(entry.name);
-
-    if (entry.isDirectory()) {
-      if (nameWarning) issues.push({ path: rel, message: nameWarning });
-      const subRel = relDir ? `${relDir}/${entry.name}` : entry.name;
-      issues.push(...checkAll(join(dirPath, entry.name), subRel));
-    } else if (entry.name.endsWith(".md") && !shouldSkipFile(entry.name)) {
-      if (nameWarning) issues.push({ path: rel, message: nameWarning });
-      const content = readFileSync(join(dirPath, entry.name), "utf-8");
-      const meta = extractMetadata(content);
-      if (meta.error) issues.push({ path: rel, message: meta.error });
-      const title = meta.title ?? extractFallbackTitle(content);
-      if (!title) issues.push({ path: rel, message: "Missing title" });
-    }
-  }
-
-  return issues;
+function validateName(name: string): string | undefined {
+  return SHELL_SAFE_NAME.test(name) ? undefined : "Name contains spaces or special characters";
 }
 
 function shouldSkipFile(name: string): boolean {

--- a/packages/docmap/src/parser.ts
+++ b/packages/docmap/src/parser.ts
@@ -64,13 +64,6 @@ export function extractMetadata(content: string): Metadata {
   return { title, summary, readWhen, error: undefined };
 }
 
-export function stripFrontmatter(content: string): string {
-  if (!content.startsWith("---")) return content;
-  const closingIndex = content.indexOf("\n---", 3);
-  if (closingIndex === -1) return content;
-  return content.slice(closingIndex + 4).replace(/^\n+/, "");
-}
-
 export function extractFallbackTitle(content: string): string | undefined {
   const body = stripFrontmatter(content);
   const lines = body.split("\n");
@@ -107,4 +100,11 @@ export function extractFallbackTitle(content: string): string | undefined {
   }
 
   return undefined;
+}
+
+export function stripFrontmatter(content: string): string {
+  if (!content.startsWith("---")) return content;
+  const closingIndex = content.indexOf("\n---", 3);
+  if (closingIndex === -1) return content;
+  return content.slice(closingIndex + 4).replace(/^\n+/, "");
 }

--- a/packages/worktree-env/README.md
+++ b/packages/worktree-env/README.md
@@ -41,7 +41,7 @@ import { runSetupWorktree, helpers } from "@paleo/worktree-env";
 await runSetupWorktree({
   basePort: 8100,
   portNames: ["server", "frontend", "db"],
-  devServerPidFiles: [".local-data/dev-server.pid"],
+  devServerPidFiles: [".local-wt/dev-server.pid"],
   configFiles: [
     {
       path: ".env",
@@ -72,8 +72,8 @@ await runDevServer({
       name: "dev",
       exec: { command: "npm", args: ["run", "dev"] },
       port: helpers.readPortFromEnvFile(".env", "PORT"),
-      pidFile: ".local-data/dev-server.pid",
-      logFile: ".local-data/logs/dev-server.log",
+      pidFile: ".local-wt/dev-server.pid",
+      logFile: ".local-wt/logs/dev-server.log",
       detectSuccess: (log) => log.includes("Server is ready on port"),
     },
   ],

--- a/packages/worktree-env/README.md
+++ b/packages/worktree-env/README.md
@@ -43,7 +43,8 @@ await runSetupWorktree({
   basePort: 8100,
   portNames: ["server", "frontend", "db"],
   sharedDirs: [".local", ".plans"],
-  localWt: ".local-wt",
+  runtimeDir: ".local-wt",
+  registryDir: ".local/wt-registry",
   configFiles: [
     {
       path: ".env",
@@ -62,7 +63,7 @@ await runSetupWorktree({
 });
 ```
 
-Setup runs in two phases: a fast foreground Part 1 creates the worktree and config, then a detached Part 2 runs `finalizeWorktree` and writes progress to `<localWt>/wt-setup.log`. If Part 2 fails, `cd` into the worktree and run `setup-worktree --here` — it is idempotent and retries the finalize step. To block until Part 2 finishes (CI, agent orchestration), run `setup-worktree --wait <slot>` — exits 0 on `READY`, 1 on `FAILED`.
+Setup runs in two phases: a fast foreground Part 1 creates the worktree and config, then a detached Part 2 runs `finalizeWorktree` and writes progress to `<runtimeDir>/wt-setup.log`. If Part 2 fails, `cd` into the worktree and run `setup-worktree --here` — it is idempotent and retries the finalize step. To block until Part 2 finishes (CI, agent orchestration), run `setup-worktree --wait` from inside the worktree (or `setup-worktree --wait --slot 8110` from anywhere) — exits 0 on `READY`, 1 on `FAILED`.
 
 `--evict` is best-effort: the cap check and the subsequent register are not atomic, so two concurrent `dev:up --evict` from different worktrees can both pass the check and end up at `devLimit + 1` live servers. The window is narrow; if it matters, `dev:list` + `dev:down` deterministically.
 
@@ -71,7 +72,8 @@ import { runDevServer, helpers } from "@paleo/worktree-env";
 
 await runDevServer({
   basePort: 8100,
-  localWt: ".local-wt",
+  runtimeDir: ".local-wt",
+  registryDir: ".local/wt-registry",
   devLimit: 5,
   servers: [
     {

--- a/packages/worktree-env/README.md
+++ b/packages/worktree-env/README.md
@@ -28,6 +28,7 @@ The agent reads the skill, adapts the reference scripts to your stack, installs 
 ```sh
 npm run setup-worktree -- --create feat/42   # new branch + worktree + isolated env
 npm run dev:up                               # start dev server in the background
+npm run dev:up -- --evict                    # if devLimit is reached, evict the oldest dev-server and start
 npm run dev:list                             # active dev-servers across all worktrees
 npm run dev:down                             # stop dev server (infrastructure stays up)
 npm run setup-worktree -- --remove feat/42   # full teardown

--- a/packages/worktree-env/README.md
+++ b/packages/worktree-env/README.md
@@ -62,7 +62,9 @@ await runSetupWorktree({
 });
 ```
 
-Setup runs in two phases: a fast foreground Part 1 creates the worktree and config, then a detached Part 2 runs `finalizeWorktree` and writes progress to `<localWt>/wt-setup.log`. If Part 2 fails, `cd` into the worktree and run `setup-worktree --here` — it is idempotent and retries the finalize step.
+Setup runs in two phases: a fast foreground Part 1 creates the worktree and config, then a detached Part 2 runs `finalizeWorktree` and writes progress to `<localWt>/wt-setup.log`. If Part 2 fails, `cd` into the worktree and run `setup-worktree --here` — it is idempotent and retries the finalize step. To block until Part 2 finishes (CI, agent orchestration), run `setup-worktree --wait <slot>` — exits 0 on `READY`, 1 on `FAILED`.
+
+`--evict` is best-effort: the cap check and the subsequent register are not atomic, so two concurrent `dev:up --evict` from different worktrees can both pass the check and end up at `devLimit + 1` live servers. The window is narrow; if it matters, `dev:list` + `dev:down` deterministically.
 
 ```ts
 import { runDevServer, helpers } from "@paleo/worktree-env";

--- a/packages/worktree-env/README.md
+++ b/packages/worktree-env/README.md
@@ -41,7 +41,8 @@ import { runSetupWorktree, helpers } from "@paleo/worktree-env";
 await runSetupWorktree({
   basePort: 8100,
   portNames: ["server", "frontend", "db"],
-  devServerPidFiles: [".local-wt/dev-server.pid"],
+  sharedDirs: [".local", ".plans"],
+  localWt: ".local-wt",
   configFiles: [
     {
       path: ".env",
@@ -52,28 +53,28 @@ await runSetupWorktree({
         }),
     },
   ],
-  setupWorktreeData: async ({ currentWorktree }) => {
-    // Create per-worktree directories, copy seed data, start containers, etc.
+  finalizeWorktree: async ({ currentWorktree }) => {
+    // MUST be idempotent. Install deps, start containers, seed a database, etc.
   },
-  installAndBuild: async () => {},
   printSummary: ({ slot, branch, owner, ports }) =>
     `Slot ${slot} (${branch}${owner ? `, ${owner}` : ""}) — server :${ports.server}`,
 });
 ```
+
+Setup runs in two phases: a fast foreground Part 1 creates the worktree and config, then a detached Part 2 runs `finalizeWorktree` and writes progress to `<localWt>/wt-setup.log`. If Part 2 fails, `cd` into the worktree and run `setup-worktree --here` — it is idempotent and retries the finalize step.
 
 ```ts
 import { runDevServer, helpers } from "@paleo/worktree-env";
 
 await runDevServer({
   basePort: 8100,
+  localWt: ".local-wt",
   devLimit: 5,
   servers: [
     {
       name: "dev",
       exec: { command: "npm", args: ["run", "dev"] },
       port: helpers.readPortFromEnvFile(".env", "PORT"),
-      pidFile: ".local-wt/dev-server.pid",
-      logFile: ".local-wt/logs/dev-server.log",
       detectSuccess: (log) => log.includes("Server is ready on port"),
     },
   ],

--- a/packages/worktree-env/src/cli.ts
+++ b/packages/worktree-env/src/cli.ts
@@ -2,11 +2,129 @@ import { parseArgs, type ParseArgsConfig } from "node:util";
 
 import { ConfigError } from "./errors.js";
 
+export interface SetupArgs {
+  help?: boolean;
+  use?: string;
+  create?: string;
+  here?: boolean;
+  owner?: string;
+  "set-owner"?: string;
+  remove?: string;
+  "remove-here"?: boolean;
+  "no-remote-check"?: boolean;
+  slot?: string;
+  force?: boolean;
+  verbose?: boolean;
+}
+
+export interface DevServerArgs {
+  help?: boolean;
+  stop?: boolean;
+  list?: boolean;
+  all?: boolean;
+}
+
 interface OptionDef {
   type: "boolean" | "string";
   short?: string;
   arg?: string;
   description: string;
+}
+
+export function parseSetupArgs(argv?: string[]): SetupArgs {
+  return parseOptions<SetupArgs>(argv, SETUP_OPTIONS);
+}
+
+export function parseDevServerArgs(argv?: string[]): DevServerArgs {
+  return parseOptions<DevServerArgs>(argv, DEV_SERVER_OPTIONS);
+}
+
+export function printSetupHelp(): void {
+  console.log(
+    formatHelp(
+      "setup-worktree [options]",
+      "Manage worktree lifecycle: creation, local environment setup, and removal.",
+      SETUP_OPTIONS,
+    ),
+  );
+}
+
+export function printDevServerHelp(): void {
+  console.log(
+    formatHelp(
+      "dev-server [options]",
+      "Start, stop, or list background dev-server processes.",
+      DEV_SERVER_OPTIONS,
+    ),
+  );
+}
+
+export function validateSetupFlags(args: SetupArgs): void {
+  const modeFlags = [
+    args.use,
+    args.create,
+    args.here,
+    isRemoveMode(args),
+    isSetOwnerMode(args),
+  ].filter(Boolean);
+  if (modeFlags.length > 1) {
+    throw new ConfigError(
+      "Error: --use, --create, --here, --remove, --remove-here, and --set-owner are mutually exclusive.",
+    );
+  }
+  if (args.remove !== undefined && args["remove-here"]) {
+    throw new ConfigError("Error: --remove and --remove-here are mutually exclusive.");
+  }
+  if ((args.slot !== undefined || args.force) && !isSetupMode(args)) {
+    throw new ConfigError(
+      "Error: --slot and --force can only be used with --use, --create, or --here.",
+    );
+  }
+  if (args.owner !== undefined && !isSetupMode(args)) {
+    throw new ConfigError("Error: --owner is only valid with --use, --create, or --here.");
+  }
+  if (args["no-remote-check"] && !isRemoveMode(args)) {
+    throw new ConfigError("Error: --no-remote-check is only valid with --remove or --remove-here.");
+  }
+}
+
+export function validateDevServerFlags(args: DevServerArgs): void {
+  if (args.all && !args.stop) {
+    throw new ConfigError("Error: --all requires --stop.");
+  }
+  if (args.list && (args.stop || args.all)) {
+    throw new ConfigError("Error: --list is mutually exclusive with --stop and --all.");
+  }
+}
+
+export function isSetupMode(args: SetupArgs): boolean {
+  return args.use !== undefined || args.create !== undefined || Boolean(args.here);
+}
+
+export function isRemoveMode(args: SetupArgs): boolean {
+  return args.remove !== undefined || Boolean(args["remove-here"]);
+}
+
+export function isSetOwnerMode(args: SetupArgs): boolean {
+  return args["set-owner"] !== undefined;
+}
+
+function parseOptions<T>(argv: string[] | undefined, options: Record<string, OptionDef>): T {
+  const cfg: ParseArgsConfig = { options: options as ParseArgsConfig["options"], strict: true };
+  if (argv) cfg.args = argv;
+  const { values } = parseArgs(cfg);
+  return values as T;
+}
+
+function formatHelp(usage: string, intro: string, options: Record<string, OptionDef>): string {
+  const lines = [`Usage: ${usage}`, "", intro, ""];
+  for (const [name, opt] of Object.entries(options)) {
+    const shortFlag = opt.short ? `-${opt.short}, ` : "";
+    const argSuffix = opt.arg ? ` <${opt.arg}>` : "";
+    const flag = `${shortFlag}--${name}${argSuffix}`;
+    lines.push(`  ${flag.padEnd(28)} ${opt.description}`);
+  }
+  return lines.join("\n");
 }
 
 const SETUP_OPTIONS: Record<string, OptionDef> = {
@@ -70,121 +188,3 @@ const DEV_SERVER_OPTIONS: Record<string, OptionDef> = {
   list: { type: "boolean", description: "List active dev-servers across all worktrees" },
   all: { type: "boolean", description: "Apply --stop to every active dev-server" },
 };
-
-export interface SetupArgs {
-  help?: boolean;
-  use?: string;
-  create?: string;
-  here?: boolean;
-  owner?: string;
-  "set-owner"?: string;
-  remove?: string;
-  "remove-here"?: boolean;
-  "no-remote-check"?: boolean;
-  slot?: string;
-  force?: boolean;
-  verbose?: boolean;
-}
-
-export interface DevServerArgs {
-  help?: boolean;
-  stop?: boolean;
-  list?: boolean;
-  all?: boolean;
-}
-
-function parseOptions<T>(argv: string[] | undefined, options: Record<string, OptionDef>): T {
-  const cfg: ParseArgsConfig = { options: options as ParseArgsConfig["options"], strict: true };
-  if (argv) cfg.args = argv;
-  const { values } = parseArgs(cfg);
-  return values as T;
-}
-
-export function parseSetupArgs(argv?: string[]): SetupArgs {
-  return parseOptions<SetupArgs>(argv, SETUP_OPTIONS);
-}
-
-export function parseDevServerArgs(argv?: string[]): DevServerArgs {
-  return parseOptions<DevServerArgs>(argv, DEV_SERVER_OPTIONS);
-}
-
-function formatHelp(usage: string, intro: string, options: Record<string, OptionDef>): string {
-  const lines = [`Usage: ${usage}`, "", intro, ""];
-  for (const [name, opt] of Object.entries(options)) {
-    const shortFlag = opt.short ? `-${opt.short}, ` : "";
-    const argSuffix = opt.arg ? ` <${opt.arg}>` : "";
-    const flag = `${shortFlag}--${name}${argSuffix}`;
-    lines.push(`  ${flag.padEnd(28)} ${opt.description}`);
-  }
-  return lines.join("\n");
-}
-
-export function printSetupHelp(): void {
-  console.log(
-    formatHelp(
-      "setup-worktree [options]",
-      "Manage worktree lifecycle: creation, local environment setup, and removal.",
-      SETUP_OPTIONS,
-    ),
-  );
-}
-
-export function printDevServerHelp(): void {
-  console.log(
-    formatHelp(
-      "dev-server [options]",
-      "Start, stop, or list background dev-server processes.",
-      DEV_SERVER_OPTIONS,
-    ),
-  );
-}
-
-export function isSetupMode(args: SetupArgs): boolean {
-  return args.use !== undefined || args.create !== undefined || Boolean(args.here);
-}
-
-export function isRemoveMode(args: SetupArgs): boolean {
-  return args.remove !== undefined || Boolean(args["remove-here"]);
-}
-
-export function isSetOwnerMode(args: SetupArgs): boolean {
-  return args["set-owner"] !== undefined;
-}
-
-export function validateSetupFlags(args: SetupArgs): void {
-  const modeFlags = [
-    args.use,
-    args.create,
-    args.here,
-    isRemoveMode(args),
-    isSetOwnerMode(args),
-  ].filter(Boolean);
-  if (modeFlags.length > 1) {
-    throw new ConfigError(
-      "Error: --use, --create, --here, --remove, --remove-here, and --set-owner are mutually exclusive.",
-    );
-  }
-  if (args.remove !== undefined && args["remove-here"]) {
-    throw new ConfigError("Error: --remove and --remove-here are mutually exclusive.");
-  }
-  if ((args.slot !== undefined || args.force) && !isSetupMode(args)) {
-    throw new ConfigError(
-      "Error: --slot and --force can only be used with --use, --create, or --here.",
-    );
-  }
-  if (args.owner !== undefined && !isSetupMode(args)) {
-    throw new ConfigError("Error: --owner is only valid with --use, --create, or --here.");
-  }
-  if (args["no-remote-check"] && !isRemoveMode(args)) {
-    throw new ConfigError("Error: --no-remote-check is only valid with --remove or --remove-here.");
-  }
-}
-
-export function validateDevServerFlags(args: DevServerArgs): void {
-  if (args.all && !args.stop) {
-    throw new ConfigError("Error: --all requires --stop.");
-  }
-  if (args.list && (args.stop || args.all)) {
-    throw new ConfigError("Error: --list is mutually exclusive with --stop and --all.");
-  }
-}

--- a/packages/worktree-env/src/cli.ts
+++ b/packages/worktree-env/src/cli.ts
@@ -15,6 +15,7 @@ export interface SetupArgs {
   slot?: string;
   force?: boolean;
   verbose?: boolean;
+  __finalize?: string;
 }
 
 export interface DevServerArgs {
@@ -66,6 +67,7 @@ export function validateSetupFlags(args: SetupArgs): void {
     args.here,
     isRemoveMode(args),
     isSetOwnerMode(args),
+    isFinalizeMode(args),
   ].filter(Boolean);
   if (modeFlags.length > 1) {
     throw new ConfigError(
@@ -109,6 +111,10 @@ export function isSetOwnerMode(args: SetupArgs): boolean {
   return args["set-owner"] !== undefined;
 }
 
+export function isFinalizeMode(args: SetupArgs): boolean {
+  return args.__finalize !== undefined;
+}
+
 function parseOptions<T>(argv: string[] | undefined, options: Record<string, OptionDef>): T {
   const cfg: ParseArgsConfig = { options: options as ParseArgsConfig["options"], strict: true };
   if (argv) cfg.args = argv;
@@ -119,6 +125,7 @@ function parseOptions<T>(argv: string[] | undefined, options: Record<string, Opt
 function formatHelp(usage: string, intro: string, options: Record<string, OptionDef>): string {
   const lines = [`Usage: ${usage}`, "", intro, ""];
   for (const [name, opt] of Object.entries(options)) {
+    if (opt.description === "") continue;
     const shortFlag = opt.short ? `-${opt.short}, ` : "";
     const argSuffix = opt.arg ? ` <${opt.arg}>` : "";
     const flag = `${shortFlag}--${name}${argSuffix}`;
@@ -180,6 +187,7 @@ const SETUP_OPTIONS: Record<string, OptionDef> = {
     description: "Overwrite existing config files and re-provision the database",
   },
   verbose: { type: "boolean", short: "v", description: "Show intermediate output" },
+  __finalize: { type: "string", arg: "slot", description: "" },
 };
 
 const DEV_SERVER_OPTIONS: Record<string, OptionDef> = {

--- a/packages/worktree-env/src/cli.ts
+++ b/packages/worktree-env/src/cli.ts
@@ -78,6 +78,7 @@ export interface SetupArgs {
   slot?: string;
   force?: boolean;
   verbose?: boolean;
+  /** @internal Set by `runSetupWorktree` when it re-spawns itself to run the finalize phase. */
   __finalize?: string;
 }
 
@@ -141,10 +142,11 @@ export function validateSetupFlags(args: SetupArgs): void {
   if (args.remove !== undefined && args["remove-here"]) {
     throw new ConfigError("Error: --remove and --remove-here are mutually exclusive.");
   }
-  if ((args.slot !== undefined || args.force) && !isSetupMode(args)) {
-    throw new ConfigError(
-      "Error: --slot and --force can only be used with --use, --create, or --here.",
-    );
+  if (args.slot !== undefined && !isSetupMode(args)) {
+    throw new ConfigError("Error: --slot can only be used with --use, --create, or --here.");
+  }
+  if (args.force && !isSetupMode(args) && !isFinalizeMode(args)) {
+    throw new ConfigError("Error: --force can only be used with --use, --create, or --here.");
   }
   if (args.owner !== undefined && !isSetupMode(args)) {
     throw new ConfigError("Error: --owner is only valid with --use, --create, or --here.");
@@ -162,7 +164,8 @@ export function validateDevServerFlags(args: DevServerArgs): void {
     throw new ConfigError("Error: --list is mutually exclusive with --stop and --all.");
   }
   if (args.evict && (args.stop || args.list || args.all)) {
-    throw new ConfigError("Error: --evict cannot be combined with --stop, --list, or --all.");
+    const conflict = args.stop ? "--stop" : args.list ? "--list" : "--all";
+    throw new ConfigError(`Error: --evict cannot be combined with ${conflict}.`);
   }
 }
 

--- a/packages/worktree-env/src/cli.ts
+++ b/packages/worktree-env/src/cli.ts
@@ -54,6 +54,15 @@ const SETUP_OPTIONS: Record<string, OptionDef> = {
     description: "Overwrite existing config files and re-provision the database",
   },
   verbose: { type: "boolean", short: "v", description: "Show intermediate output" },
+  wait: {
+    type: "boolean",
+    description:
+      "Wait for the background finalize to reach READY (exit 0, prints the worktree summary) or FAILED (exit 1). Uses the current worktree's slot, or --slot PORT to target another.",
+  },
+  info: {
+    type: "boolean",
+    description: "Print the worktree summary (ports, branch, readiness) for the current worktree.",
+  },
   __finalize: { type: "string", arg: "slot", description: "" },
 };
 
@@ -78,6 +87,8 @@ export interface SetupArgs {
   slot?: string;
   force?: boolean;
   verbose?: boolean;
+  wait?: boolean;
+  info?: boolean;
   /** @internal Set by `runSetupWorktree` when it re-spawns itself to run the finalize phase. */
   __finalize?: string;
 }
@@ -133,17 +144,21 @@ export function validateSetupFlags(args: SetupArgs): void {
     isRemoveMode(args),
     isSetOwnerMode(args),
     isFinalizeMode(args),
+    isWaitMode(args),
+    isInfoMode(args),
   ].filter(Boolean);
   if (modeFlags.length > 1) {
     throw new ConfigError(
-      "Error: --use, --create, --here, --remove, --remove-here, and --set-owner are mutually exclusive.",
+      "Error: --use, --create, --here, --remove, --remove-here, --set-owner, --wait, and --info are mutually exclusive.",
     );
   }
   if (args.remove !== undefined && args["remove-here"]) {
     throw new ConfigError("Error: --remove and --remove-here are mutually exclusive.");
   }
-  if (args.slot !== undefined && !isSetupMode(args)) {
-    throw new ConfigError("Error: --slot can only be used with --use, --create, or --here.");
+  if (args.slot !== undefined && !isSetupMode(args) && !isWaitMode(args)) {
+    throw new ConfigError(
+      "Error: --slot can only be used with --use, --create, --here, or --wait.",
+    );
   }
   if (args.force && !isSetupMode(args) && !isFinalizeMode(args)) {
     throw new ConfigError("Error: --force can only be used with --use, --create, or --here.");
@@ -183,6 +198,14 @@ export function isSetOwnerMode(args: SetupArgs): boolean {
 
 export function isFinalizeMode(args: SetupArgs): boolean {
   return args.__finalize !== undefined;
+}
+
+export function isWaitMode(args: SetupArgs): boolean {
+  return Boolean(args.wait);
+}
+
+export function isInfoMode(args: SetupArgs): boolean {
+  return Boolean(args.info);
 }
 
 function parseOptions<T>(argv: string[] | undefined, options: Record<string, OptionDef>): T {

--- a/packages/worktree-env/src/cli.ts
+++ b/packages/worktree-env/src/cli.ts
@@ -23,6 +23,7 @@ export interface DevServerArgs {
   stop?: boolean;
   list?: boolean;
   all?: boolean;
+  evict?: boolean;
 }
 
 interface OptionDef {
@@ -96,6 +97,9 @@ export function validateDevServerFlags(args: DevServerArgs): void {
   }
   if (args.list && (args.stop || args.all)) {
     throw new ConfigError("Error: --list is mutually exclusive with --stop and --all.");
+  }
+  if (args.evict && (args.stop || args.list || args.all)) {
+    throw new ConfigError("Error: --evict cannot be combined with --stop, --list, or --all.");
   }
 }
 
@@ -195,4 +199,5 @@ const DEV_SERVER_OPTIONS: Record<string, OptionDef> = {
   stop: { type: "boolean", description: "Stop dev servers in the current worktree" },
   list: { type: "boolean", description: "List active dev-servers across all worktrees" },
   all: { type: "boolean", description: "Apply --stop to every active dev-server" },
+  evict: { type: "boolean", description: "Evict the oldest dev-server when the cap is reached" },
 };

--- a/packages/worktree-env/src/cli.ts
+++ b/packages/worktree-env/src/cli.ts
@@ -1,6 +1,69 @@
 import { parseArgs, type ParseArgsConfig } from "node:util";
-
 import { ConfigError } from "./errors.js";
+
+const SETUP_OPTIONS: Record<string, OptionDef> = {
+  help: { type: "boolean", short: "h", description: "Show this help message" },
+  use: {
+    type: "string",
+    arg: "branch",
+    description: "Create a worktree for an existing branch, then set up the local environment",
+  },
+  create: {
+    type: "string",
+    arg: "branch",
+    description:
+      "Create a new branch + worktree, then set up the local environment. If the branch already exists, appends a numeric suffix (-2, -3, ...)",
+  },
+  here: {
+    type: "boolean",
+    description: "Set up the local environment in the current linked worktree",
+  },
+  owner: {
+    type: "string",
+    arg: "name",
+    description: "Owner of the slot (free-form label, optional)",
+  },
+  "set-owner": {
+    type: "string",
+    arg: "name",
+    description: "Update the owner of the current linked worktree's slot (no rebuild)",
+  },
+  remove: {
+    type: "string",
+    arg: "branch",
+    description: "Remove a worktree by branch name (stop dev server, free slot, delete directory)",
+  },
+  "remove-here": {
+    type: "boolean",
+    description:
+      "Remove the current linked worktree (same as --remove, but for the worktree you are in)",
+  },
+  "no-remote-check": {
+    type: "boolean",
+    description:
+      "Skip remote branch verification when removing (use with --remove or --remove-here)",
+  },
+  slot: {
+    type: "string",
+    short: "s",
+    arg: "port",
+    description: "Use a specific slot instead of auto-assigning",
+  },
+  force: {
+    type: "boolean",
+    description: "Overwrite existing config files and re-provision the database",
+  },
+  verbose: { type: "boolean", short: "v", description: "Show intermediate output" },
+  __finalize: { type: "string", arg: "slot", description: "" },
+};
+
+const DEV_SERVER_OPTIONS: Record<string, OptionDef> = {
+  help: { type: "boolean", short: "h", description: "Show this help message" },
+  stop: { type: "boolean", description: "Stop dev servers in the current worktree" },
+  list: { type: "boolean", description: "List active dev-servers across all worktrees" },
+  all: { type: "boolean", description: "Apply --stop to every active dev-server" },
+  evict: { type: "boolean", description: "Evict the oldest dev-server when the cap is reached" },
+};
 
 export interface SetupArgs {
   help?: boolean;
@@ -137,67 +200,3 @@ function formatHelp(usage: string, intro: string, options: Record<string, Option
   }
   return lines.join("\n");
 }
-
-const SETUP_OPTIONS: Record<string, OptionDef> = {
-  help: { type: "boolean", short: "h", description: "Show this help message" },
-  use: {
-    type: "string",
-    arg: "branch",
-    description: "Create a worktree for an existing branch, then set up the local environment",
-  },
-  create: {
-    type: "string",
-    arg: "branch",
-    description:
-      "Create a new branch + worktree, then set up the local environment. If the branch already exists, appends a numeric suffix (-2, -3, ...)",
-  },
-  here: {
-    type: "boolean",
-    description: "Set up the local environment in the current linked worktree",
-  },
-  owner: {
-    type: "string",
-    arg: "name",
-    description: "Owner of the slot (free-form label, optional)",
-  },
-  "set-owner": {
-    type: "string",
-    arg: "name",
-    description: "Update the owner of the current linked worktree's slot (no rebuild)",
-  },
-  remove: {
-    type: "string",
-    arg: "branch",
-    description: "Remove a worktree by branch name (stop dev server, free slot, delete directory)",
-  },
-  "remove-here": {
-    type: "boolean",
-    description:
-      "Remove the current linked worktree (same as --remove, but for the worktree you are in)",
-  },
-  "no-remote-check": {
-    type: "boolean",
-    description:
-      "Skip remote branch verification when removing (use with --remove or --remove-here)",
-  },
-  slot: {
-    type: "string",
-    short: "s",
-    arg: "port",
-    description: "Use a specific slot instead of auto-assigning",
-  },
-  force: {
-    type: "boolean",
-    description: "Overwrite existing config files and re-provision the database",
-  },
-  verbose: { type: "boolean", short: "v", description: "Show intermediate output" },
-  __finalize: { type: "string", arg: "slot", description: "" },
-};
-
-const DEV_SERVER_OPTIONS: Record<string, OptionDef> = {
-  help: { type: "boolean", short: "h", description: "Show this help message" },
-  stop: { type: "boolean", description: "Stop dev servers in the current worktree" },
-  list: { type: "boolean", description: "List active dev-servers across all worktrees" },
-  all: { type: "boolean", description: "Apply --stop to every active dev-server" },
-  evict: { type: "boolean", description: "Evict the oldest dev-server when the cap is reached" },
-};

--- a/packages/worktree-env/src/dev-server.ts
+++ b/packages/worktree-env/src/dev-server.ts
@@ -29,7 +29,13 @@ export interface DevServerConfig {
   /** Anchor port for the slot range. Used to synthesize the main worktree's slot. */
   basePort: number;
   /** Per-worktree runtime directory, relative to the worktree root (e.g. `.local-wt`). */
-  localWt: string;
+  runtimeDir: string;
+  /**
+   * Shared registry directory, relative to a worktree root (e.g. `.local/wt-registry`).
+   * Holds `slots.json` and `dev-servers.json`. Must resolve to the same physical directory
+   * across linked worktrees — typically via a symlink (e.g. `.local`).
+   */
+  registryDir: string;
   /** Maximum concurrent dev-servers across all worktrees. Omit for no limit. */
   devLimit?: number;
   /** One entry per process to spawn. Started in array order. */
@@ -42,7 +48,7 @@ export interface DevServerConfig {
 
 /** Describes one process to spawn. */
 export interface ServerDescriptor {
-  /** Short label used in logs and the registry. Derives `<localWt>/<name>.pid` and `<localWt>/logs/<name>.log`. */
+  /** Short label used in logs and the registry. Derives `<runtimeDir>/<name>.pid` and `<runtimeDir>/logs/<name>.log`. */
   name: string;
   /** Command and arguments passed to `child_process.spawn`. */
   exec: { command: string; args: string[] };
@@ -54,12 +60,12 @@ export interface ServerDescriptor {
   detectError?: (logContent: string) => string | false;
 }
 
-function pidFileFor(localWt: string, name: string): string {
-  return join(localWt, `${name}.pid`);
+function pidFileFor(runtimeDir: string, name: string): string {
+  return join(runtimeDir, `${name}.pid`);
 }
 
-function logFileFor(localWt: string, name: string): string {
-  return join(localWt, "logs", `${name}.log`);
+function logFileFor(runtimeDir: string, name: string): string {
+  return join(runtimeDir, "logs", `${name}.log`);
 }
 
 /** Context passed to {@link DevServerConfig.printSummary}. */
@@ -95,13 +101,14 @@ export async function runDevServer(config: DevServerConfig): Promise<void> {
   const { mainWorktree } = detectWorktree();
 
   if (args.list) {
-    listDevServers(mainWorktree);
+    listDevServers(mainWorktree, config.registryDir);
     return;
   }
   if (args.stop && args.all) {
     await stopAllRegistered({
       mainWorktree,
-      pidFiles: config.servers.map((s) => pidFileFor(config.localWt, s.name)),
+      registryDir: config.registryDir,
+      runtimeDir: config.runtimeDir,
     });
     return;
   }
@@ -127,13 +134,13 @@ async function start(
   const pids: number[] = [];
   for (const server of config.servers) {
     console.log(`Starting ${server.name} dev server...`);
-    pids.push(spawnServer(server, config.localWt));
+    pids.push(spawnServer(server, config.runtimeDir));
   }
 
   try {
     const pollables: PollableServer[] = config.servers.map((s) => ({
       name: s.name,
-      logFile: logFileFor(config.localWt, s.name),
+      logFile: logFileFor(config.runtimeDir, s.name),
       detectSuccess: s.detectSuccess,
       detectError: s.detectError,
     }));
@@ -148,12 +155,12 @@ async function start(
     throw err;
   }
 
-  const slot = resolveCurrentSlot(config.basePort);
+  const slot = resolveCurrentSlot(config.basePort, config.registryDir);
   const pidMap: Record<string, number> = {};
   config.servers.forEach((server, i) => {
     pidMap[server.name] = pids[i];
   });
-  registerDevServer(mainWorktree, {
+  registerDevServer(mainWorktree, config.registryDir, {
     slot: slot.slot,
     worktree: slot.worktree,
     branch: slot.branch,
@@ -179,7 +186,7 @@ async function start(
       config.servers,
       config.servers.map((s) => s.port),
       pids,
-      config.localWt,
+      config.runtimeDir,
     );
   }
 }
@@ -194,7 +201,7 @@ async function enforceCap(
 ): Promise<void> {
   const limit = config.devLimit;
   if (limit === undefined) return;
-  const active = pruneAndPersist(mainWorktree).servers;
+  const active = pruneAndPersist(mainWorktree, config.registryDir).servers;
   if (active.length < limit) return;
 
   if (!evict) {
@@ -207,14 +214,14 @@ async function enforceCap(
 
   const toEvict = active.length - limit + 1;
   console.log(`Evicting ${toEvict} dev-server(s) to make room (cap ${limit}).`);
-  const evicted = await evictOldest(mainWorktree, toEvict);
+  const evicted = await evictOldest(mainWorktree, config.registryDir, toEvict);
   for (const entry of evicted) {
     const ownerPart = entry.owner ? `, owner=${entry.owner}` : "";
     console.log(
       `Evicted slot ${entry.slot} (branch=${entry.branch}${ownerPart}, startedAt=${entry.startedAt}).`,
     );
     for (const name of Object.keys(entry.pids)) {
-      cleanupPidFile(join(entry.worktree, config.localWt, `${name}.pid`));
+      cleanupPidFile(join(entry.worktree, config.runtimeDir, `${name}.pid`));
     }
   }
 }
@@ -233,7 +240,7 @@ async function checkPortsFree(servers: ServerDescriptor[]): Promise<void> {
 
 function checkNoLocalPidConflict(config: DevServerConfig): void {
   for (const server of config.servers) {
-    const pidFile = pidFileFor(config.localWt, server.name);
+    const pidFile = pidFileFor(config.runtimeDir, server.name);
     const existingPid = readPid(pidFile);
     if (existingPid !== undefined && isProcessAlive(existingPid)) {
       console.error(`Error: ${server.name} is already running (PID ${existingPid}).`);
@@ -245,11 +252,11 @@ function checkNoLocalPidConflict(config: DevServerConfig): void {
 
 async function stopLocal(config: DevServerConfig, mainWorktree: string): Promise<void> {
   for (const server of config.servers) {
-    await stopByPidFile(pidFileFor(config.localWt, server.name), server.name, (msg) =>
+    await stopByPidFile(pidFileFor(config.runtimeDir, server.name), server.name, (msg) =>
       console.log(msg),
     );
   }
-  unregisterDevServer(mainWorktree, process.cwd());
+  unregisterDevServer(mainWorktree, config.registryDir, process.cwd());
 }
 
 function defaultPrintSummary(
@@ -257,23 +264,23 @@ function defaultPrintSummary(
   servers: ServerDescriptor[],
   ports: number[],
   pids: number[],
-  localWt: string,
+  runtimeDir: string,
 ): void {
   console.log("\nDev servers started!");
   const ownerSuffix = slot.owner ? `, owner ${slot.owner}` : "";
   console.log(`  Worktree: slot ${slot.slot}${ownerSuffix}`);
   servers.forEach((server, i) => {
     const url = `http://localhost:${ports[i]}/`;
-    const logPath = join(process.cwd(), logFileFor(localWt, server.name));
+    const logPath = join(process.cwd(), logFileFor(runtimeDir, server.name));
     console.log(`  ${server.name}: ${url}  (PID ${pids[i]})`);
     console.log(`    log: ${logPath}`);
   });
   console.log("");
 }
 
-function spawnServer(server: ServerDescriptor, localWt: string): number {
-  const logFile = logFileFor(localWt, server.name);
-  const pidFile = pidFileFor(localWt, server.name);
+function spawnServer(server: ServerDescriptor, runtimeDir: string): number {
+  const logFile = logFileFor(runtimeDir, server.name);
+  const pidFile = pidFileFor(runtimeDir, server.name);
   mkdirSync(dirname(logFile), { recursive: true });
   mkdirSync(dirname(pidFile), { recursive: true });
   const logFd = openSync(logFile, "w");

--- a/packages/worktree-env/src/dev-server.ts
+++ b/packages/worktree-env/src/dev-server.ts
@@ -10,6 +10,7 @@ import {
   type DevServerArgs,
 } from "./cli.js";
 import {
+  evictOldest,
   listDevServers,
   printActiveServers,
   pruneAndPersist,
@@ -109,44 +110,17 @@ export async function runDevServer(config: DevServerConfig): Promise<void> {
     return;
   }
 
-  await start(config, mainWorktree);
+  await start(config, mainWorktree, { evict: Boolean(args.evict) });
 }
 
-async function start(config: DevServerConfig, mainWorktree: string): Promise<void> {
-  const limit = config.devLimit;
-  const active = pruneAndPersist(mainWorktree).servers;
-  if (limit !== undefined && active.length >= limit) {
-    console.error(`Error: dev-server cap reached (${active.length}/${limit}). Active dev-servers:`);
-    printActiveServers(active);
-    console.error("Run `dev:down` in another worktree, or `dev:down --all`.");
-    process.exit(1);
-  }
-
-  const serverPorts: [ServerDescriptor, number][] = config.servers.map((server) => [
-    server,
-    server.port,
-  ]);
-
-  const busyResults = await Promise.all(serverPorts.map(([, port]) => isPortBusy(port)));
-  let anyBusy = false;
-  busyResults.forEach((busy, i) => {
-    if (busy) {
-      const [server, port] = serverPorts[i];
-      console.error(`Error: Port ${port} (${server.name}) is already in use.`);
-      anyBusy = true;
-    }
-  });
-  if (anyBusy) process.exit(1);
-
-  for (const server of config.servers) {
-    const pidFile = pidFileFor(config.localWt, server.name);
-    const existingPid = readPid(pidFile);
-    if (existingPid !== undefined && isProcessAlive(existingPid)) {
-      console.error(`Error: ${server.name} is already running (PID ${existingPid}).`);
-      process.exit(1);
-    }
-    cleanupPidFile(pidFile);
-  }
+async function start(
+  config: DevServerConfig,
+  mainWorktree: string,
+  { evict }: { evict: boolean },
+): Promise<void> {
+  await enforceCap(config, mainWorktree, evict);
+  await checkPortsFree(config.servers);
+  checkNoLocalPidConflict(config);
 
   if (config.ensureInfrastructure) await config.ensureInfrastructure();
 
@@ -194,7 +168,7 @@ async function start(config: DevServerConfig, mainWorktree: string): Promise<voi
         slot,
         servers: config.servers.map((server, i) => ({
           server,
-          port: serverPorts[i][1],
+          port: server.port,
           pid: pids[i],
         })),
       }),
@@ -203,10 +177,66 @@ async function start(config: DevServerConfig, mainWorktree: string): Promise<voi
     defaultPrintSummary(
       slot,
       config.servers,
-      serverPorts.map(([, p]) => p),
+      config.servers.map((s) => s.port),
       pids,
       config.localWt,
     );
+  }
+}
+
+async function enforceCap(
+  config: DevServerConfig,
+  mainWorktree: string,
+  evict: boolean,
+): Promise<void> {
+  const limit = config.devLimit;
+  if (limit === undefined) return;
+  const active = pruneAndPersist(mainWorktree).servers;
+  if (active.length < limit) return;
+
+  if (!evict) {
+    console.error(`Error: dev-server cap reached (${active.length}/${limit}). Active dev-servers:`);
+    printActiveServers(active);
+    console.error("Run `dev:down` in another worktree, or `dev:down --all`.");
+    console.error("Re-run with --evict to evict the oldest.");
+    process.exit(1);
+  }
+
+  const toEvict = active.length - limit + 1;
+  console.log(`Evicting ${toEvict} dev-server(s) to make room (cap ${limit}).`);
+  const evicted = await evictOldest(mainWorktree, toEvict);
+  for (const entry of evicted) {
+    const ownerPart = entry.owner ? `, owner=${entry.owner}` : "";
+    console.log(
+      `Evicted slot ${entry.slot} (branch=${entry.branch}${ownerPart}, startedAt=${entry.startedAt}).`,
+    );
+    for (const name of config.servers.map((s) => s.name)) {
+      cleanupPidFile(join(entry.worktree, config.localWt, `${name}.pid`));
+    }
+  }
+}
+
+async function checkPortsFree(servers: ServerDescriptor[]): Promise<void> {
+  const busy = await Promise.all(servers.map((s) => isPortBusy(s.port)));
+  let anyBusy = false;
+  busy.forEach((b, i) => {
+    if (b) {
+      console.error(`Error: Port ${servers[i].port} (${servers[i].name}) is already in use.`);
+      anyBusy = true;
+    }
+  });
+  if (anyBusy) process.exit(1);
+}
+
+function checkNoLocalPidConflict(config: DevServerConfig): void {
+  for (const server of config.servers) {
+    const pidFile = pidFileFor(config.localWt, server.name);
+    const existingPid = readPid(pidFile);
+    if (existingPid !== undefined && isProcessAlive(existingPid)) {
+      console.error(`Error: ${server.name} is already running (PID ${existingPid}).`);
+      process.exit(1);
+    }
+    cleanupPidFile(pidFile);
   }
 }
 

--- a/packages/worktree-env/src/dev-server.ts
+++ b/packages/worktree-env/src/dev-server.ts
@@ -210,7 +210,7 @@ async function enforceCap(
     console.log(
       `Evicted slot ${entry.slot} (branch=${entry.branch}${ownerPart}, startedAt=${entry.startedAt}).`,
     );
-    for (const name of config.servers.map((s) => s.name)) {
+    for (const name of Object.keys(entry.pids)) {
       cleanupPidFile(join(entry.worktree, config.localWt, `${name}.pid`));
     }
   }

--- a/packages/worktree-env/src/dev-server.ts
+++ b/packages/worktree-env/src/dev-server.ts
@@ -61,43 +61,6 @@ export interface DevServerSummaryContext {
   servers: { server: ServerDescriptor; port: number; pid: number }[];
 }
 
-function isPortBusy(port: number): Promise<boolean> {
-  return new Promise((resolve) => {
-    const socket = createConnection({ port, host: "127.0.0.1" });
-    socket.setTimeout(500);
-    socket.once("connect", () => {
-      socket.destroy();
-      resolve(true);
-    });
-    socket.once("timeout", () => {
-      socket.destroy();
-      resolve(false);
-    });
-    socket.once("error", () => {
-      resolve(false);
-    });
-  });
-}
-
-function spawnServer(server: ServerDescriptor): number {
-  mkdirSync(dirname(server.logFile), { recursive: true });
-  mkdirSync(dirname(server.pidFile), { recursive: true });
-  const logFd = openSync(server.logFile, "w");
-  const child = spawn(server.exec.command, server.exec.args, {
-    detached: true,
-    stdio: ["ignore", logFd, logFd],
-  });
-  if (child.pid === undefined) {
-    closeSync(logFd);
-    console.error(`Error: failed to spawn ${server.name}.`);
-    process.exit(1);
-  }
-  writeFileSync(server.pidFile, String(child.pid));
-  child.unref();
-  closeSync(logFd);
-  return child.pid;
-}
-
 export async function runDevServer(config: DevServerConfig): Promise<void> {
   let args: DevServerArgs;
   try {
@@ -239,6 +202,13 @@ async function start(config: DevServerConfig, mainWorktree: string): Promise<voi
   }
 }
 
+async function stopLocal(config: DevServerConfig, mainWorktree: string): Promise<void> {
+  for (const server of config.servers) {
+    await stopByPidFile(server.pidFile, server.name, (msg) => console.log(msg));
+  }
+  unregisterDevServer(mainWorktree, process.cwd());
+}
+
 function defaultPrintSummary(
   slot: ResolvedSlot,
   servers: ServerDescriptor[],
@@ -257,9 +227,39 @@ function defaultPrintSummary(
   console.log("");
 }
 
-async function stopLocal(config: DevServerConfig, mainWorktree: string): Promise<void> {
-  for (const server of config.servers) {
-    await stopByPidFile(server.pidFile, server.name, (msg) => console.log(msg));
+function spawnServer(server: ServerDescriptor): number {
+  mkdirSync(dirname(server.logFile), { recursive: true });
+  mkdirSync(dirname(server.pidFile), { recursive: true });
+  const logFd = openSync(server.logFile, "w");
+  const child = spawn(server.exec.command, server.exec.args, {
+    detached: true,
+    stdio: ["ignore", logFd, logFd],
+  });
+  if (child.pid === undefined) {
+    closeSync(logFd);
+    console.error(`Error: failed to spawn ${server.name}.`);
+    process.exit(1);
   }
-  unregisterDevServer(mainWorktree, process.cwd());
+  writeFileSync(server.pidFile, String(child.pid));
+  child.unref();
+  closeSync(logFd);
+  return child.pid;
+}
+
+function isPortBusy(port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const socket = createConnection({ port, host: "127.0.0.1" });
+    socket.setTimeout(500);
+    socket.once("connect", () => {
+      socket.destroy();
+      resolve(true);
+    });
+    socket.once("timeout", () => {
+      socket.destroy();
+      resolve(false);
+    });
+    socket.once("error", () => {
+      resolve(false);
+    });
+  });
 }

--- a/packages/worktree-env/src/dev-server.ts
+++ b/packages/worktree-env/src/dev-server.ts
@@ -184,6 +184,9 @@ async function start(
   }
 }
 
+// TOCTOU: the cap check and the subsequent register are not atomic. Two concurrent `dev:up --evict`
+// from different worktrees can both pass the cap check and both register, exceeding the limit by
+// one. Accepted: the race window is narrow and the consequence is bounded (one extra dev-server).
 async function enforceCap(
   config: DevServerConfig,
   mainWorktree: string,

--- a/packages/worktree-env/src/dev-server.ts
+++ b/packages/worktree-env/src/dev-server.ts
@@ -27,6 +27,8 @@ import { detectWorktree } from "./worktree.js";
 export interface DevServerConfig {
   /** Anchor port for the slot range. Used to synthesize the main worktree's slot. */
   basePort: number;
+  /** Per-worktree runtime directory, relative to the worktree root (e.g. `.local-wt`). */
+  localWt: string;
   /** Maximum concurrent dev-servers across all worktrees. Omit for no limit. */
   devLimit?: number;
   /** One entry per process to spawn. Started in array order. */
@@ -39,20 +41,24 @@ export interface DevServerConfig {
 
 /** Describes one process to spawn. */
 export interface ServerDescriptor {
-  /** Short label used in logs and the registry. */
+  /** Short label used in logs and the registry. Derives `<localWt>/<name>.pid` and `<localWt>/logs/<name>.log`. */
   name: string;
   /** Command and arguments passed to `child_process.spawn`. */
   exec: { command: string; args: string[] };
   /** Port the process will listen on. Use `helpers.readPortFromEnvFile` / `readPortFromJsonFile` to read it from a config file. */
   port: number;
-  /** Path (relative to cwd) where the spawned PID is written. */
-  pidFile: string;
-  /** Path (relative to cwd) where stdout+stderr are tee'd. */
-  logFile: string;
   /** Returns `true` once the log content indicates the server is ready. */
   detectSuccess: (logContent: string) => boolean;
   /** Returns a non-empty marker string when the log content indicates a fatal error, or `false` otherwise. */
   detectError?: (logContent: string) => string | false;
+}
+
+function pidFileFor(localWt: string, name: string): string {
+  return join(localWt, `${name}.pid`);
+}
+
+function logFileFor(localWt: string, name: string): string {
+  return join(localWt, "logs", `${name}.log`);
 }
 
 /** Context passed to {@link DevServerConfig.printSummary}. */
@@ -94,7 +100,7 @@ export async function runDevServer(config: DevServerConfig): Promise<void> {
   if (args.stop && args.all) {
     await stopAllRegistered({
       mainWorktree,
-      pidFiles: config.servers.map((s) => s.pidFile),
+      pidFiles: config.servers.map((s) => pidFileFor(config.localWt, s.name)),
     });
     return;
   }
@@ -133,12 +139,13 @@ async function start(config: DevServerConfig, mainWorktree: string): Promise<voi
   if (anyBusy) process.exit(1);
 
   for (const server of config.servers) {
-    const existingPid = readPid(server.pidFile);
+    const pidFile = pidFileFor(config.localWt, server.name);
+    const existingPid = readPid(pidFile);
     if (existingPid !== undefined && isProcessAlive(existingPid)) {
       console.error(`Error: ${server.name} is already running (PID ${existingPid}).`);
       process.exit(1);
     }
-    cleanupPidFile(server.pidFile);
+    cleanupPidFile(pidFile);
   }
 
   if (config.ensureInfrastructure) await config.ensureInfrastructure();
@@ -146,13 +153,13 @@ async function start(config: DevServerConfig, mainWorktree: string): Promise<voi
   const pids: number[] = [];
   for (const server of config.servers) {
     console.log(`Starting ${server.name} dev server...`);
-    pids.push(spawnServer(server));
+    pids.push(spawnServer(server, config.localWt));
   }
 
   try {
     const pollables: PollableServer[] = config.servers.map((s) => ({
       name: s.name,
-      logFile: s.logFile,
+      logFile: logFileFor(config.localWt, s.name),
       detectSuccess: s.detectSuccess,
       detectError: s.detectError,
     }));
@@ -198,13 +205,16 @@ async function start(config: DevServerConfig, mainWorktree: string): Promise<voi
       config.servers,
       serverPorts.map(([, p]) => p),
       pids,
+      config.localWt,
     );
   }
 }
 
 async function stopLocal(config: DevServerConfig, mainWorktree: string): Promise<void> {
   for (const server of config.servers) {
-    await stopByPidFile(server.pidFile, server.name, (msg) => console.log(msg));
+    await stopByPidFile(pidFileFor(config.localWt, server.name), server.name, (msg) =>
+      console.log(msg),
+    );
   }
   unregisterDevServer(mainWorktree, process.cwd());
 }
@@ -214,23 +224,26 @@ function defaultPrintSummary(
   servers: ServerDescriptor[],
   ports: number[],
   pids: number[],
+  localWt: string,
 ): void {
   console.log("\nDev servers started!");
   const ownerSuffix = slot.owner ? `, owner ${slot.owner}` : "";
   console.log(`  Worktree: slot ${slot.slot}${ownerSuffix}`);
   servers.forEach((server, i) => {
     const url = `http://localhost:${ports[i]}/`;
-    const logPath = join(process.cwd(), server.logFile);
+    const logPath = join(process.cwd(), logFileFor(localWt, server.name));
     console.log(`  ${server.name}: ${url}  (PID ${pids[i]})`);
     console.log(`    log: ${logPath}`);
   });
   console.log("");
 }
 
-function spawnServer(server: ServerDescriptor): number {
-  mkdirSync(dirname(server.logFile), { recursive: true });
-  mkdirSync(dirname(server.pidFile), { recursive: true });
-  const logFd = openSync(server.logFile, "w");
+function spawnServer(server: ServerDescriptor, localWt: string): number {
+  const logFile = logFileFor(localWt, server.name);
+  const pidFile = pidFileFor(localWt, server.name);
+  mkdirSync(dirname(logFile), { recursive: true });
+  mkdirSync(dirname(pidFile), { recursive: true });
+  const logFd = openSync(logFile, "w");
   const child = spawn(server.exec.command, server.exec.args, {
     detached: true,
     stdio: ["ignore", logFd, logFd],
@@ -240,7 +253,7 @@ function spawnServer(server: ServerDescriptor): number {
     console.error(`Error: failed to spawn ${server.name}.`);
     process.exit(1);
   }
-  writeFileSync(server.pidFile, String(child.pid));
+  writeFileSync(pidFile, String(child.pid));
   child.unref();
   closeSync(logFd);
   return child.pid;

--- a/packages/worktree-env/src/dev-servers-registry.ts
+++ b/packages/worktree-env/src/dev-servers-registry.ts
@@ -68,6 +68,32 @@ export async function stopAllRegistered(input: StopAllInput): Promise<void> {
   console.log(`Stopped ${data.servers.length} dev-server(s).`);
 }
 
+export interface EvictDeps {
+  isAlive?: IsAliveFn;
+  stop?: (pid: number) => Promise<void>;
+}
+
+export async function evictOldest(
+  mainWorktree: string,
+  count: number,
+  deps: EvictDeps = {},
+): Promise<DevServerEntry[]> {
+  const isAlive = deps.isAlive ?? isProcessAlive;
+  const stop = deps.stop ?? stopProcessGroup;
+  const data = pruneAndPersist(mainWorktree, isAlive);
+  const sorted = [...data.servers].sort((a, b) => a.startedAt.localeCompare(b.startedAt));
+  const victims = sorted.slice(0, count);
+  for (const entry of victims) {
+    for (const pid of Object.values(entry.pids)) {
+      if (isAlive(pid)) await stop(pid);
+    }
+  }
+  const victimWorktrees = new Set(victims.map((v) => v.worktree));
+  const filtered = data.servers.filter((entry) => !victimWorktrees.has(entry.worktree));
+  writeDevServers(mainWorktree, { servers: filtered });
+  return victims;
+}
+
 export function registerDevServer(mainWorktree: string, entry: DevServerEntry): void {
   const data = pruneAndPersist(mainWorktree);
   data.servers.push(entry);

--- a/packages/worktree-env/src/dev-servers-registry.ts
+++ b/packages/worktree-env/src/dev-servers-registry.ts
@@ -3,8 +3,7 @@ import { join, resolve } from "node:path";
 
 import { isProcessAlive, stopProcessGroup } from "./process-control.js";
 
-export const DEV_SERVERS_FILE = ".local/worktrees/dev-servers.json";
-export const WORKTREES_DIR = ".local/worktrees";
+const DEV_SERVERS_FILENAME = "dev-servers.json";
 
 export interface DevServerEntry {
   slot: number;
@@ -21,8 +20,8 @@ export interface DevServersData {
 
 export type IsAliveFn = (pid: number) => boolean;
 
-export function listDevServers(mainWorktree: string): void {
-  const data = pruneAndPersist(mainWorktree);
+export function listDevServers(mainWorktree: string, registryDir: string): void {
+  const data = pruneAndPersist(mainWorktree, registryDir);
   if (data.servers.length === 0) {
     console.log("No dev-servers running.");
     return;
@@ -42,11 +41,12 @@ export function printActiveServers(active: DevServerEntry[]): void {
 
 export interface StopAllInput {
   mainWorktree: string;
-  pidFiles: string[];
+  registryDir: string;
+  runtimeDir: string;
 }
 
 export async function stopAllRegistered(input: StopAllInput): Promise<void> {
-  const data = pruneAndPersist(input.mainWorktree);
+  const data = pruneAndPersist(input.mainWorktree, input.registryDir);
   if (data.servers.length === 0) {
     console.log("No dev-servers running.");
     return;
@@ -59,12 +59,14 @@ export async function stopAllRegistered(input: StopAllInput): Promise<void> {
       console.log(`  ${name} (PID ${pid})`);
       await stopProcessGroup(pid);
     }
-    for (const pidFile of input.pidFiles) {
-      const fp = join(entry.worktree, pidFile);
+    // `runtimeDir` is repo-wide, so each entry's PID files live at the same relative path.
+    // Server names vary per entry, hence reading them from `entry.pids` rather than caller config.
+    for (const name of Object.keys(entry.pids)) {
+      const fp = join(entry.worktree, input.runtimeDir, `${name}.pid`);
       if (existsSync(fp)) unlinkSync(fp);
     }
   }
-  writeDevServers(input.mainWorktree, { servers: [] });
+  writeDevServers(input.mainWorktree, input.registryDir, { servers: [] });
   console.log(`Stopped ${data.servers.length} dev-server(s).`);
 }
 
@@ -75,12 +77,13 @@ export interface EvictDeps {
 
 export async function evictOldest(
   mainWorktree: string,
+  registryDir: string,
   count: number,
   deps: EvictDeps = {},
 ): Promise<DevServerEntry[]> {
   const isAlive = deps.isAlive ?? isProcessAlive;
   const stop = deps.stop ?? stopProcessGroup;
-  const data = pruneAndPersist(mainWorktree, isAlive);
+  const data = pruneDeadServers(readDevServers(mainWorktree, registryDir), isAlive);
   const sorted = [...data.servers].sort((a, b) => a.startedAt.localeCompare(b.startedAt));
   const victims = sorted.slice(0, count);
   for (const entry of victims) {
@@ -90,44 +93,57 @@ export async function evictOldest(
   }
   const victimSlots = new Set(victims.map((v) => v.slot));
   const filtered = data.servers.filter((entry) => !victimSlots.has(entry.slot));
-  writeDevServers(mainWorktree, { servers: filtered });
+  writeDevServers(mainWorktree, registryDir, { servers: filtered });
   return victims;
 }
 
-export function registerDevServer(mainWorktree: string, entry: DevServerEntry): void {
-  const data = pruneAndPersist(mainWorktree);
+export function registerDevServer(
+  mainWorktree: string,
+  registryDir: string,
+  entry: DevServerEntry,
+): void {
+  const data = pruneAndPersist(mainWorktree, registryDir);
   data.servers.push(entry);
-  writeDevServers(mainWorktree, data);
+  writeDevServers(mainWorktree, registryDir, data);
 }
 
-export function unregisterDevServer(mainWorktree: string, worktreePath: string): void {
-  const fp = filePath(mainWorktree);
+export function unregisterDevServer(
+  mainWorktree: string,
+  registryDir: string,
+  worktreePath: string,
+): void {
+  const fp = filePath(mainWorktree, registryDir);
   if (!existsSync(fp)) return;
-  const data = pruneAndPersist(mainWorktree);
+  const data = pruneAndPersist(mainWorktree, registryDir);
   const target = resolve(worktreePath);
   const filtered = data.servers.filter((entry) => resolve(entry.worktree) !== target);
   if (filtered.length === data.servers.length) return;
-  writeDevServers(mainWorktree, { servers: filtered });
+  writeDevServers(mainWorktree, registryDir, { servers: filtered });
 }
 
-export function removeDevServerEntryByWorktree(mainWorktree: string, worktreePath: string): void {
-  const fp = filePath(mainWorktree);
+export function removeDevServerEntryByWorktree(
+  mainWorktree: string,
+  registryDir: string,
+  worktreePath: string,
+): void {
+  const fp = filePath(mainWorktree, registryDir);
   if (!existsSync(fp)) return;
-  const data = readDevServers(mainWorktree);
+  const data = readDevServers(mainWorktree, registryDir);
   const target = resolve(worktreePath);
   const filtered = data.servers.filter((entry) => resolve(entry.worktree) !== target);
   if (filtered.length === data.servers.length) return;
-  writeDevServers(mainWorktree, { servers: filtered });
+  writeDevServers(mainWorktree, registryDir, { servers: filtered });
 }
 
 export function pruneAndPersist(
   mainWorktree: string,
+  registryDir: string,
   isAlive: IsAliveFn = isProcessAlive,
 ): DevServersData {
-  const data = readDevServers(mainWorktree);
+  const data = readDevServers(mainWorktree, registryDir);
   const pruned = pruneDeadServers(data, isAlive);
   if (pruned.servers.length !== data.servers.length) {
-    writeDevServers(mainWorktree, pruned);
+    writeDevServers(mainWorktree, registryDir, pruned);
   }
   return pruned;
 }
@@ -142,20 +158,24 @@ export function pruneDeadServers(
   return { servers: live };
 }
 
-export function readDevServers(mainWorktree: string): DevServersData {
-  const fp = filePath(mainWorktree);
+export function readDevServers(mainWorktree: string, registryDir: string): DevServersData {
+  const fp = filePath(mainWorktree, registryDir);
   if (!existsSync(fp)) return { servers: [] };
   return JSON.parse(readFileSync(fp, "utf-8")) as DevServersData;
 }
 
-export function writeDevServers(mainWorktree: string, data: DevServersData): void {
-  const fp = filePath(mainWorktree);
-  mkdirSync(join(mainWorktree, WORKTREES_DIR), { recursive: true });
+export function writeDevServers(
+  mainWorktree: string,
+  registryDir: string,
+  data: DevServersData,
+): void {
+  const fp = filePath(mainWorktree, registryDir);
+  mkdirSync(join(mainWorktree, registryDir), { recursive: true });
   writeFileSync(fp, `${JSON.stringify(data, undefined, 2)}\n`);
 }
 
-function filePath(mainWorktree: string): string {
-  return join(mainWorktree, DEV_SERVERS_FILE);
+function filePath(mainWorktree: string, registryDir: string): string {
+  return join(mainWorktree, registryDir, DEV_SERVERS_FILENAME);
 }
 
 function formatEntry(entry: DevServerEntry): string {

--- a/packages/worktree-env/src/dev-servers-registry.ts
+++ b/packages/worktree-env/src/dev-servers-registry.ts
@@ -19,86 +19,7 @@ export interface DevServersData {
   servers: DevServerEntry[];
 }
 
-function filePath(mainWorktree: string): string {
-  return join(mainWorktree, DEV_SERVERS_FILE);
-}
-
-export function readDevServers(mainWorktree: string): DevServersData {
-  const fp = filePath(mainWorktree);
-  if (!existsSync(fp)) return { servers: [] };
-  return JSON.parse(readFileSync(fp, "utf-8")) as DevServersData;
-}
-
-export function writeDevServers(mainWorktree: string, data: DevServersData): void {
-  const fp = filePath(mainWorktree);
-  mkdirSync(join(mainWorktree, WORKTREES_DIR), { recursive: true });
-  writeFileSync(fp, `${JSON.stringify(data, undefined, 2)}\n`);
-}
-
 export type IsAliveFn = (pid: number) => boolean;
-
-export function pruneDeadServers(
-  data: DevServersData,
-  isAlive: IsAliveFn = isProcessAlive,
-): DevServersData {
-  const live = data.servers.filter((entry) =>
-    Object.values(entry.pids).some((pid) => isAlive(pid)),
-  );
-  return { servers: live };
-}
-
-export function pruneAndPersist(
-  mainWorktree: string,
-  isAlive: IsAliveFn = isProcessAlive,
-): DevServersData {
-  const data = readDevServers(mainWorktree);
-  const pruned = pruneDeadServers(data, isAlive);
-  if (pruned.servers.length !== data.servers.length) {
-    writeDevServers(mainWorktree, pruned);
-  }
-  return pruned;
-}
-
-export function registerDevServer(mainWorktree: string, entry: DevServerEntry): void {
-  const data = pruneAndPersist(mainWorktree);
-  data.servers.push(entry);
-  writeDevServers(mainWorktree, data);
-}
-
-export function unregisterDevServer(mainWorktree: string, worktreePath: string): void {
-  const fp = filePath(mainWorktree);
-  if (!existsSync(fp)) return;
-  const data = pruneAndPersist(mainWorktree);
-  const target = resolve(worktreePath);
-  const filtered = data.servers.filter((entry) => resolve(entry.worktree) !== target);
-  if (filtered.length === data.servers.length) return;
-  writeDevServers(mainWorktree, { servers: filtered });
-}
-
-export function removeDevServerEntryByWorktree(mainWorktree: string, worktreePath: string): void {
-  const fp = filePath(mainWorktree);
-  if (!existsSync(fp)) return;
-  const data = readDevServers(mainWorktree);
-  const target = resolve(worktreePath);
-  const filtered = data.servers.filter((entry) => resolve(entry.worktree) !== target);
-  if (filtered.length === data.servers.length) return;
-  writeDevServers(mainWorktree, { servers: filtered });
-}
-
-function formatEntry(entry: DevServerEntry): string {
-  const pids = Object.entries(entry.pids)
-    .map(([name, pid]) => `${name}=${pid}`)
-    .join(",");
-  const ownerPart = entry.owner ? `  owner=${entry.owner}` : "";
-  return `  slot ${entry.slot}  branch=${entry.branch}${ownerPart}  pids=${pids}  startedAt=${entry.startedAt}  worktree=${entry.worktree}`;
-}
-
-export function printActiveServers(active: DevServerEntry[]): void {
-  const sorted = [...active].sort((a, b) => a.slot - b.slot);
-  for (const entry of sorted) {
-    process.stderr.write(`${formatEntry(entry)}\n`);
-  }
-}
 
 export function listDevServers(mainWorktree: string): void {
   const data = pruneAndPersist(mainWorktree);
@@ -109,6 +30,13 @@ export function listDevServers(mainWorktree: string): void {
   const sorted = [...data.servers].sort((a, b) => a.slot - b.slot);
   for (const entry of sorted) {
     console.log(formatEntry(entry));
+  }
+}
+
+export function printActiveServers(active: DevServerEntry[]): void {
+  const sorted = [...active].sort((a, b) => a.slot - b.slot);
+  for (const entry of sorted) {
+    process.stderr.write(`${formatEntry(entry)}\n`);
   }
 }
 
@@ -138,4 +66,76 @@ export async function stopAllRegistered(input: StopAllInput): Promise<void> {
   }
   writeDevServers(input.mainWorktree, { servers: [] });
   console.log(`Stopped ${data.servers.length} dev-server(s).`);
+}
+
+export function registerDevServer(mainWorktree: string, entry: DevServerEntry): void {
+  const data = pruneAndPersist(mainWorktree);
+  data.servers.push(entry);
+  writeDevServers(mainWorktree, data);
+}
+
+export function unregisterDevServer(mainWorktree: string, worktreePath: string): void {
+  const fp = filePath(mainWorktree);
+  if (!existsSync(fp)) return;
+  const data = pruneAndPersist(mainWorktree);
+  const target = resolve(worktreePath);
+  const filtered = data.servers.filter((entry) => resolve(entry.worktree) !== target);
+  if (filtered.length === data.servers.length) return;
+  writeDevServers(mainWorktree, { servers: filtered });
+}
+
+export function removeDevServerEntryByWorktree(mainWorktree: string, worktreePath: string): void {
+  const fp = filePath(mainWorktree);
+  if (!existsSync(fp)) return;
+  const data = readDevServers(mainWorktree);
+  const target = resolve(worktreePath);
+  const filtered = data.servers.filter((entry) => resolve(entry.worktree) !== target);
+  if (filtered.length === data.servers.length) return;
+  writeDevServers(mainWorktree, { servers: filtered });
+}
+
+export function pruneAndPersist(
+  mainWorktree: string,
+  isAlive: IsAliveFn = isProcessAlive,
+): DevServersData {
+  const data = readDevServers(mainWorktree);
+  const pruned = pruneDeadServers(data, isAlive);
+  if (pruned.servers.length !== data.servers.length) {
+    writeDevServers(mainWorktree, pruned);
+  }
+  return pruned;
+}
+
+export function pruneDeadServers(
+  data: DevServersData,
+  isAlive: IsAliveFn = isProcessAlive,
+): DevServersData {
+  const live = data.servers.filter((entry) =>
+    Object.values(entry.pids).some((pid) => isAlive(pid)),
+  );
+  return { servers: live };
+}
+
+export function readDevServers(mainWorktree: string): DevServersData {
+  const fp = filePath(mainWorktree);
+  if (!existsSync(fp)) return { servers: [] };
+  return JSON.parse(readFileSync(fp, "utf-8")) as DevServersData;
+}
+
+export function writeDevServers(mainWorktree: string, data: DevServersData): void {
+  const fp = filePath(mainWorktree);
+  mkdirSync(join(mainWorktree, WORKTREES_DIR), { recursive: true });
+  writeFileSync(fp, `${JSON.stringify(data, undefined, 2)}\n`);
+}
+
+function filePath(mainWorktree: string): string {
+  return join(mainWorktree, DEV_SERVERS_FILE);
+}
+
+function formatEntry(entry: DevServerEntry): string {
+  const pids = Object.entries(entry.pids)
+    .map(([name, pid]) => `${name}=${pid}`)
+    .join(",");
+  const ownerPart = entry.owner ? `  owner=${entry.owner}` : "";
+  return `  slot ${entry.slot}  branch=${entry.branch}${ownerPart}  pids=${pids}  startedAt=${entry.startedAt}  worktree=${entry.worktree}`;
 }

--- a/packages/worktree-env/src/dev-servers-registry.ts
+++ b/packages/worktree-env/src/dev-servers-registry.ts
@@ -88,8 +88,8 @@ export async function evictOldest(
       if (isAlive(pid)) await stop(pid);
     }
   }
-  const victimWorktrees = new Set(victims.map((v) => v.worktree));
-  const filtered = data.servers.filter((entry) => !victimWorktrees.has(entry.worktree));
+  const victimSlots = new Set(victims.map((v) => v.slot));
+  const filtered = data.servers.filter((entry) => !victimSlots.has(entry.slot));
   writeDevServers(mainWorktree, { servers: filtered });
   return victims;
 }

--- a/packages/worktree-env/src/errors.ts
+++ b/packages/worktree-env/src/errors.ts
@@ -17,8 +17,3 @@ export class ConfigError extends Error {
     this.exitCode = exitCode;
   }
 }
-
-export function exitWith(code: number, message: string): never {
-  console.error(message);
-  process.exit(code);
-}

--- a/packages/worktree-env/src/helpers.ts
+++ b/packages/worktree-env/src/helpers.ts
@@ -63,15 +63,6 @@ export function readPortFromJsonFile(file: string, jsonPath: string): number {
   return toPort(String(cur), file);
 }
 
-function toPort(raw: string, file: string): number {
-  const port = Number(raw);
-  if (!Number.isFinite(port)) {
-    console.error(`Error: invalid port "${raw}" in ${file}.`);
-    process.exit(1);
-  }
-  return port;
-}
-
 export interface CopyAndPatchCtx {
   currentWorktree: string;
   mainWorktree: string;
@@ -109,4 +100,13 @@ export function copyAndPatchFile(
   mkdirSync(dirname(targetPath), { recursive: true });
   writeFileSync(targetPath, patched);
   ctx.log(`${alreadyExists ? "Overwritten" : "Created"} ${label}.`);
+}
+
+function toPort(raw: string, file: string): number {
+  const port = Number(raw);
+  if (!Number.isFinite(port)) {
+    console.error(`Error: invalid port "${raw}" in ${file}.`);
+    process.exit(1);
+  }
+  return port;
 }

--- a/packages/worktree-env/src/log-polling.ts
+++ b/packages/worktree-env/src/log-polling.ts
@@ -21,7 +21,25 @@ export interface AwaitOptions {
   isAlive?: (pid: number) => boolean;
 }
 
-export async function waitForReady(
+export async function awaitAllReady(
+  servers: PollableServer[],
+  pids: number[],
+  options?: AwaitOptions,
+): Promise<void> {
+  await Promise.all(servers.map((server, i) => waitForReady(server, pids[i], options)));
+}
+
+export function handleStartupFailure(err: StartupError): void {
+  console.error(`\nError: ${err.label} ${err.reason}.`);
+  if (err.logFile && existsSync(err.logFile)) {
+    const lines = readFileSync(err.logFile, "utf-8").split("\n").slice(-LOG_TAIL_LINES);
+    console.error(`\n--- ${err.label} log tail (last ${LOG_TAIL_LINES} lines) ---`);
+    console.error(lines.join("\n"));
+    console.error(`--- end ---\nFull log: ${join(process.cwd(), err.logFile)}`);
+  }
+}
+
+async function waitForReady(
   server: PollableServer,
   pid: number,
   options: AwaitOptions = {},
@@ -53,22 +71,4 @@ export async function waitForReady(
     `did not become ready within ${timeoutMs / 1000}s`,
     server.logFile,
   );
-}
-
-export async function awaitAllReady(
-  servers: PollableServer[],
-  pids: number[],
-  options?: AwaitOptions,
-): Promise<void> {
-  await Promise.all(servers.map((server, i) => waitForReady(server, pids[i], options)));
-}
-
-export function handleStartupFailure(err: StartupError): void {
-  console.error(`\nError: ${err.label} ${err.reason}.`);
-  if (err.logFile && existsSync(err.logFile)) {
-    const lines = readFileSync(err.logFile, "utf-8").split("\n").slice(-LOG_TAIL_LINES);
-    console.error(`\n--- ${err.label} log tail (last ${LOG_TAIL_LINES} lines) ---`);
-    console.error(lines.join("\n"));
-    console.error(`--- end ---\nFull log: ${join(process.cwd(), err.logFile)}`);
-  }
 }

--- a/packages/worktree-env/src/ports.ts
+++ b/packages/worktree-env/src/ports.ts
@@ -1,15 +1,15 @@
-export interface PortSchemeOptions {
-  basePort: number;
-  portStep?: number;
-  maxSlotCount?: number;
-}
-
 export interface PortScheme {
   basePort: number;
   portStep: number;
   maxSlotCount: number;
   minPort: number;
   maxPort: number;
+}
+
+export interface PortSchemeOptions {
+  basePort: number;
+  portStep?: number;
+  maxSlotCount?: number;
 }
 
 export function resolvePortScheme(opts: PortSchemeOptions): PortScheme {

--- a/packages/worktree-env/src/process-control.ts
+++ b/packages/worktree-env/src/process-control.ts
@@ -1,5 +1,32 @@
 import { existsSync, readFileSync, unlinkSync } from "node:fs";
 
+export async function stopByPidFile(
+  pidFile: string,
+  label: string,
+  log: (msg: string) => void = () => {},
+): Promise<void> {
+  const pid = readPid(pidFile);
+  if (pid === undefined || !isProcessAlive(pid)) {
+    cleanupPidFile(pidFile);
+    log(`No ${label} process is running.`);
+    return;
+  }
+  log(`Stopping ${label} (PID ${pid})...`);
+  await stopProcessGroup(pid);
+  cleanupPidFile(pidFile);
+  log(`${label} stopped.`);
+}
+
+export async function stopProcessGroup(pid: number, timeoutMs = 10_000): Promise<void> {
+  killProcessGroup(pid, "SIGTERM");
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, 300));
+    if (!isProcessGroupAlive(pid)) return;
+  }
+  killProcessGroup(pid, "SIGKILL");
+}
+
 export function readPid(pidFile: string): number | undefined {
   if (!existsSync(pidFile)) return undefined;
   const raw = readFileSync(pidFile, "utf-8").trim();
@@ -40,31 +67,4 @@ export function killProcessGroup(pid: number, signal: NodeJS.Signals): void {
 
 export function cleanupPidFile(pidFile: string): void {
   if (existsSync(pidFile)) unlinkSync(pidFile);
-}
-
-export async function stopProcessGroup(pid: number, timeoutMs = 10_000): Promise<void> {
-  killProcessGroup(pid, "SIGTERM");
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    await new Promise((r) => setTimeout(r, 300));
-    if (!isProcessGroupAlive(pid)) return;
-  }
-  killProcessGroup(pid, "SIGKILL");
-}
-
-export async function stopByPidFile(
-  pidFile: string,
-  label: string,
-  log: (msg: string) => void = () => {},
-): Promise<void> {
-  const pid = readPid(pidFile);
-  if (pid === undefined || !isProcessAlive(pid)) {
-    cleanupPidFile(pidFile);
-    log(`No ${label} process is running.`);
-    return;
-  }
-  log(`Stopping ${label} (PID ${pid})...`);
-  await stopProcessGroup(pid);
-  cleanupPidFile(pidFile);
-  log(`${label} stopped.`);
 }

--- a/packages/worktree-env/src/setup-worktree.ts
+++ b/packages/worktree-env/src/setup-worktree.ts
@@ -27,7 +27,7 @@ import {
 import { removeDevServerEntryByWorktree } from "./dev-servers-registry.js";
 import { ConfigError } from "./errors.js";
 import { copyAndPatchFile } from "./helpers.js";
-import { defaultComputePorts, resolvePortScheme, type PortScheme } from "./ports.js";
+import { defaultComputePorts, isValidPort, resolvePortScheme, type PortScheme } from "./ports.js";
 import {
   cleanupPidFile,
   isProcessAlive,
@@ -37,6 +37,7 @@ import {
 } from "./process-control.js";
 import {
   handleSetOwner,
+  markSlotFailed,
   markSlotReady,
   readSlots,
   resolveAndRegisterSlot,
@@ -68,7 +69,7 @@ export interface SetupWorktreeConfig {
   basePort: number;
   /** Distance between consecutive slots. Defaults to `10`. */
   portStep?: number;
-  /** Maximum number of slots. Defaults to `9`. */
+  /** Maximum number of slots. Defaults to `19`. */
   maxSlotCount?: number;
   /** Custom port computation; takes precedence over `portNames`. */
   ports?: (slot: number) => Record<string, number>;
@@ -76,8 +77,17 @@ export interface SetupWorktreeConfig {
   portNames?: string[];
   /** Directories symlinked from the main worktree. */
   sharedDirs: string[];
-  /** Per-worktree runtime directory, relative to the worktree root (e.g. `.local-wt`). */
-  localWt: string;
+  /**
+   * Per-worktree runtime directory, relative to the worktree root (e.g. `.local-wt`).
+   * Holds the setup log, dev-server PID files, and dev-server logs.
+   */
+  runtimeDir: string;
+  /**
+   * Shared registry directory, relative to a worktree root (e.g. `.local/wt-registry`).
+   * Holds `slots.json` and `dev-servers.json`. Must resolve to the same physical directory
+   * across linked worktrees — typically via a symlink listed in `sharedDirs` (e.g. `.local`).
+   */
+  registryDir: string;
   /** Config files copied from the main worktree and patched per slot. */
   configFiles: ConfigFileEntry[];
   /**
@@ -204,7 +214,7 @@ export async function runSetupWorktree(config: SetupWorktreeConfig): Promise<voi
   }
 
   if (isSetOwnerMode(args)) {
-    handleSetOwnerMode(args, ctx);
+    handleSetOwnerMode(args, ctx, config);
     return;
   }
 
@@ -223,6 +233,7 @@ async function runSetup(
   validateSlotAvailability(args.slot, {
     currentWorktree: ctx.currentWorktree,
     mainWorktree: ctx.mainWorktree,
+    registryDir: config.registryDir,
     scheme,
   });
 
@@ -232,16 +243,18 @@ async function runSetup(
     slot: args.slot,
     currentWorktree: setupCtx.currentWorktree,
     mainWorktree: setupCtx.mainWorktree,
+    registryDir: config.registryDir,
     scheme,
     branch,
     requestedOwner: args.owner,
   });
   const ports = portsFn(slot);
 
-  const localWtDir = join(setupCtx.currentWorktree, config.localWt);
-  mkdirSync(localWtDir, { recursive: true });
-  const logPath = join(localWtDir, "wt-setup.log");
-  const logFd = openSync(logPath, "w");
+  const runtimeDir = join(setupCtx.currentWorktree, config.runtimeDir);
+  mkdirSync(runtimeDir, { recursive: true });
+  const logPath = join(runtimeDir, "wt-setup.log");
+  // Opened "a" so the same fd can be inherited by the detached finalize child below.
+  const logFd = openSync(logPath, "a");
   const teeLog = (message: string): void => {
     console.log(message);
     appendFileSync(logFd, `${message}\n`);
@@ -272,38 +285,33 @@ async function runSetup(
   );
 
   teeLog(`WORKTREE_CREATED path=${setupCtx.currentWorktree} branch=${branch} slot=${slot}`);
-  teeLog(`Setup continuing in background. Tail: ${config.localWt}/wt-setup.log`);
+  teeLog(`Setup continuing in background. Tail: ${config.runtimeDir}/wt-setup.log`);
 
-  closeSync(logFd);
-
-  // Hand the detached child a fresh fd appended to the same log file; the parent's fd is closed
-  // just above so we cannot reuse it.
-  const finalizeLogFd = openSync(logPath, "a");
   const child = spawn(process.execPath, [config.scriptPath, "--__finalize", String(slot)], {
     detached: true,
-    stdio: ["ignore", finalizeLogFd, finalizeLogFd],
+    stdio: ["ignore", logFd, logFd],
     cwd: setupCtx.currentWorktree,
   });
   child.unref();
-  closeSync(finalizeLogFd);
+  closeSync(logFd);
 }
 
 async function runFinalize(args: SetupArgs, config: SetupWorktreeConfig): Promise<void> {
   const slot = Number(args.__finalize);
   const ctx = detectWorktree();
-  const logPath = join(ctx.currentWorktree, config.localWt, "wt-setup.log");
+  const logPath = join(ctx.currentWorktree, config.runtimeDir, "wt-setup.log");
   const appendLog = (message: string): void => {
     appendFileSync(logPath, `${message}\n`);
   };
 
-  const registry = readSlots(ctx.mainWorktree);
+  const registry = readSlots(ctx.mainWorktree, config.registryDir);
   const entry = registry.slots[String(slot)];
   if (!entry || resolve(entry.worktree) !== resolve(ctx.currentWorktree)) {
     appendLog(`FAILED: No matching slot ${slot} for worktree ${ctx.currentWorktree}.`);
     process.exit(1);
   }
 
-  if (entry.ready && !args.force) {
+  if (entry.status === "ready" && !args.force) {
     appendLog(`READY: branch ${entry.branch} (slot ${slot}) already finalized; skipping.`);
     return;
   }
@@ -326,29 +334,33 @@ async function runFinalize(args: SetupArgs, config: SetupWorktreeConfig): Promis
 
   try {
     await config.finalizeWorktree(setupContext);
-    markSlotReady(ctx.mainWorktree, slot);
+    markSlotReady(ctx.mainWorktree, config.registryDir, slot);
     appendLog("============================================================");
     appendLog(`READY: branch ${entry.branch} (slot ${slot})`);
     appendLog("============================================================");
   } catch (err) {
     const message = (err as Error).message;
     const stack = (err as Error).stack ?? "";
+    markSlotFailed(ctx.mainWorktree, config.registryDir, slot, message);
     appendLog(`FAILED: ${message}`);
     if (stack) appendLog(stack);
     process.exit(1);
   }
 }
 
-function resolveWaitSlot(args: SetupArgs, basePort: number): number {
+function resolveWaitSlot(args: SetupArgs, config: SetupWorktreeConfig): number {
   if (args.slot !== undefined) {
     const slot = Number(args.slot);
-    if (!Number.isFinite(slot)) {
-      console.error(`Error: --slot expects a port number; got "${args.slot}".`);
+    const scheme = resolvePortScheme(config);
+    if (!isValidPort(slot, scheme)) {
+      console.error(
+        `Error: --slot expects a port in [${scheme.minPort}, ${scheme.maxPort}] stepped by ${scheme.portStep}; got "${args.slot}".`,
+      );
       process.exit(1);
     }
     return slot;
   }
-  return resolveCurrentSlot(basePort).slot;
+  return resolveCurrentSlot(config.basePort, config.registryDir).slot;
 }
 
 function printWorktreeInfo(
@@ -358,17 +370,22 @@ function printWorktreeInfo(
   fallback: { branch: string; owner?: string },
 ): void {
   const ctx = detectWorktree();
-  const registry = readSlots(ctx.mainWorktree);
+  const registry = readSlots(ctx.mainWorktree, config.registryDir);
   const entry = registry.slots[String(slot)];
   const ports = resolvePortsFn(config)(slot);
 
   const branch = entry?.branch ?? fallback.branch;
   const owner = entry?.owner ?? fallback.owner;
-  const ready = entry?.ready ?? ctx.isMainWorktree;
-  const status = ready
-    ? "ready"
-    : `not ready (tail ${join(worktreeForLog, config.localWt, "wt-setup.log")})`;
-  console.log(`Status: ${status}`);
+  // Main worktree has no slot entry by design — treat it as ready when the registry has no row.
+  const slotStatus = entry?.status ?? (ctx.isMainWorktree ? "ready" : "pending");
+  const logHint = ` (tail ${join(worktreeForLog, config.runtimeDir, "wt-setup.log")})`;
+  const display =
+    slotStatus === "ready"
+      ? "ready"
+      : slotStatus === "failed"
+        ? `failed: ${entry?.failure?.message ?? "(no message)"}${logHint}`
+        : `pending${logHint}`;
+  console.log(`Status: ${display}`);
   console.log(
     config.printSummary({
       slot,
@@ -382,49 +399,37 @@ function printWorktreeInfo(
 }
 
 function runInfo(config: SetupWorktreeConfig): void {
-  const resolved = resolveCurrentSlot(config.basePort);
+  const resolved = resolveCurrentSlot(config.basePort, config.registryDir);
   printWorktreeInfo(config, resolved.slot, ".", { branch: resolved.branch, owner: resolved.owner });
 }
 
 async function runWait(args: SetupArgs, config: SetupWorktreeConfig): Promise<void> {
   const ctx = detectWorktree();
-  const slot = resolveWaitSlot(args, config.basePort);
-  const registry = readSlots(ctx.mainWorktree);
-  const entry = registry.slots[String(slot)];
-  if (!entry) {
+  const slot = resolveWaitSlot(args, config);
+  const initial = readSlots(ctx.mainWorktree, config.registryDir).slots[String(slot)];
+  if (!initial) {
     console.error(`Error: No slot ${slot} in registry.`);
     process.exit(1);
   }
 
-  if (entry.ready) {
-    printWorktreeInfo(config, slot, entry.worktree, { branch: entry.branch, owner: entry.owner });
-    return;
-  }
-
-  const logPath = join(entry.worktree, config.localWt, "wt-setup.log");
-  let offset = 0;
   const pollMs = 500;
-  // Stream new content from wt-setup.log until we see READY: or FAILED: at line start.
+  // Poll slots.json — the finalize child writes `status` on success or failure. Tiny file, no
+  // log-tailing race.
   for (;;) {
-    if (existsSync(logPath)) {
-      const content = readFileSync(logPath, "utf-8");
-      if (content.length > offset) {
-        const fresh = content.slice(offset);
-        offset = content.length;
-        for (const line of fresh.split("\n")) {
-          if (line.startsWith("READY:")) {
-            printWorktreeInfo(config, slot, entry.worktree, {
-              branch: entry.branch,
-              owner: entry.owner,
-            });
-            return;
-          }
-          if (line.startsWith("FAILED:")) {
-            console.error(line);
-            process.exit(1);
-          }
-        }
-      }
+    const entry = readSlots(ctx.mainWorktree, config.registryDir).slots[String(slot)];
+    if (!entry) {
+      console.error(`Error: Slot ${slot} disappeared from registry.`);
+      process.exit(1);
+    }
+    if (entry.status === "ready") {
+      printWorktreeInfo(config, slot, entry.worktree, { branch: entry.branch, owner: entry.owner });
+      return;
+    }
+    if (entry.status === "failed") {
+      const logPath = join(entry.worktree, config.runtimeDir, "wt-setup.log");
+      console.error(`FAILED: ${entry.failure?.message ?? "(no message)"}`);
+      console.error(`Full log: ${logPath}`);
+      process.exit(1);
     }
     await new Promise((r) => setTimeout(r, pollMs));
   }
@@ -438,7 +443,7 @@ async function handleRemove(
 ): Promise<void> {
   const verboseLog = makeVerboseLog(run.verbose);
   const removeHere = Boolean(args["remove-here"]);
-  const registry = readSlots(ctx.mainWorktree);
+  const registry = readSlots(ctx.mainWorktree, config.registryDir);
   const target = resolveRemoveTarget(args, ctx, registry, removeHere);
 
   if (!args["no-remote-check"]) {
@@ -452,14 +457,14 @@ async function handleRemove(
       `Warning: Worktree directory ${target.worktreePath} not found. Cleaning up registry only.`,
     );
     delete registry.slots[target.slotPort];
-    writeSlots(ctx.mainWorktree, registry);
+    writeSlots(ctx.mainWorktree, config.registryDir, registry);
     console.log(
       `Removed registry entry for branch "${target.branch}" (slot ${target.slotPort}${ownerSuffix}).`,
     );
     return;
   }
 
-  await stopAllDevServersInLocalWt(target.worktreePath, config.localWt, verboseLog);
+  await stopAllDevServersInRuntimeDir(target.worktreePath, config.runtimeDir, verboseLog);
 
   if (config.teardownInfrastructure) {
     await config.teardownInfrastructure({
@@ -470,8 +475,8 @@ async function handleRemove(
   }
 
   delete registry.slots[target.slotPort];
-  writeSlots(ctx.mainWorktree, registry);
-  removeDevServerEntryByWorktree(ctx.mainWorktree, target.worktreePath);
+  writeSlots(ctx.mainWorktree, config.registryDir, registry);
+  removeDevServerEntryByWorktree(ctx.mainWorktree, config.registryDir, target.worktreePath);
 
   if (removeHere) {
     process.chdir(ctx.mainWorktree);
@@ -487,17 +492,22 @@ async function handleRemove(
   }
 }
 
-function handleSetOwnerMode(args: SetupArgs, ctx: WorktreeContext): void {
+function handleSetOwnerMode(
+  args: SetupArgs,
+  ctx: WorktreeContext,
+  config: SetupWorktreeConfig,
+): void {
   const newOwner = args["set-owner"];
   const { slotPort } = handleSetOwner({
     newOwner,
     currentWorktree: ctx.currentWorktree,
     mainWorktree: ctx.mainWorktree,
+    registryDir: config.registryDir,
     isMainWorktree: ctx.isMainWorktree,
   });
 
   // Propagate to dev-servers.json entries for this worktree.
-  const devServersPath = join(ctx.mainWorktree, ".local/worktrees/dev-servers.json");
+  const devServersPath = join(ctx.mainWorktree, config.registryDir, "dev-servers.json");
   if (existsSync(devServersPath)) {
     const data = JSON.parse(readFileSync(devServersPath, "utf-8")) as {
       servers: { worktree: string; owner?: string }[];
@@ -620,12 +630,12 @@ function resolveRemoveTarget(
   return { slotPort: entry[0], branch, worktreePath, owner: entry[1].owner };
 }
 
-async function stopAllDevServersInLocalWt(
+async function stopAllDevServersInRuntimeDir(
   worktreePath: string,
-  localWt: string,
+  runtimeDir: string,
   log: (msg: string) => void,
 ): Promise<void> {
-  const dir = join(worktreePath, localWt);
+  const dir = join(worktreePath, runtimeDir);
   let entries: string[];
   try {
     entries = readdirSync(dir);

--- a/packages/worktree-env/src/setup-worktree.ts
+++ b/packages/worktree-env/src/setup-worktree.ts
@@ -107,7 +107,7 @@ export interface SetupWorktreeConfig {
   configFiles: ConfigFileEntry[];
   /**
    * Runs after symlinks and config files. Owns per-worktree data setup:
-   * create any required directories (e.g. `.local-data/...`), copy or
+   * create any required directories (e.g. `.local-wt/...`), copy or
    * provision databases / file storage, start infrastructure containers.
    */
   setupWorktreeData: (ctx: SetupContext) => Promise<void> | void;

--- a/packages/worktree-env/src/setup-worktree.ts
+++ b/packages/worktree-env/src/setup-worktree.ts
@@ -14,9 +14,11 @@ import { dirname, join, relative, resolve } from "node:path";
 
 import {
   isFinalizeMode,
+  isInfoMode,
   isRemoveMode,
   isSetOwnerMode,
   isSetupMode,
+  isWaitMode,
   parseSetupArgs,
   printSetupHelp,
   type SetupArgs,
@@ -38,6 +40,7 @@ import {
   markSlotReady,
   readSlots,
   resolveAndRegisterSlot,
+  resolveCurrentSlot,
   validateSlotAvailability,
   writeSlots,
 } from "./slots.js";
@@ -55,6 +58,12 @@ import {
 
 /** Configuration accepted by {@link runSetupWorktree}. */
 export interface SetupWorktreeConfig {
+  /**
+   * Absolute path to the wrapper script that calls `runSetupWorktree`. The package re-spawns this
+   * file as a detached child for the finalize phase, so it must point at a runnable Node entrypoint
+   * — typically `fileURLToPath(import.meta.url)` from your `setup-worktree.mjs`.
+   */
+  scriptPath: string;
   /** Anchor port for the slot range. Slots are derived from this value. */
   basePort: number;
   /** Distance between consecutive slots. Defaults to `10`. */
@@ -147,6 +156,14 @@ export async function runSetupWorktree(config: SetupWorktreeConfig): Promise<voi
     return;
   }
 
+  if (!existsSync(config.scriptPath)) {
+    console.error(
+      `Error: scriptPath does not exist: ${config.scriptPath}. ` +
+        "Pass `fileURLToPath(import.meta.url)` from your wrapper script.",
+    );
+    process.exit(1);
+  }
+
   try {
     validateSetupFlags(args);
   } catch (err) {
@@ -159,6 +176,16 @@ export async function runSetupWorktree(config: SetupWorktreeConfig): Promise<voi
 
   if (isFinalizeMode(args)) {
     await runFinalize(args, config);
+    return;
+  }
+
+  if (isWaitMode(args)) {
+    await runWait(args, config);
+    return;
+  }
+
+  if (isInfoMode(args)) {
+    runInfo(config);
     return;
   }
 
@@ -252,7 +279,7 @@ async function runSetup(
   // Hand the detached child a fresh fd appended to the same log file; the parent's fd is closed
   // just above so we cannot reuse it.
   const finalizeLogFd = openSync(logPath, "a");
-  const child = spawn(process.execPath, [process.argv[1], "--__finalize", String(slot)], {
+  const child = spawn(process.execPath, [config.scriptPath, "--__finalize", String(slot)], {
     detached: true,
     stdio: ["ignore", finalizeLogFd, finalizeLogFd],
     cwd: setupCtx.currentWorktree,
@@ -309,6 +336,97 @@ async function runFinalize(args: SetupArgs, config: SetupWorktreeConfig): Promis
     appendLog(`FAILED: ${message}`);
     if (stack) appendLog(stack);
     process.exit(1);
+  }
+}
+
+function resolveWaitSlot(args: SetupArgs, basePort: number): number {
+  if (args.slot !== undefined) {
+    const slot = Number(args.slot);
+    if (!Number.isFinite(slot)) {
+      console.error(`Error: --slot expects a port number; got "${args.slot}".`);
+      process.exit(1);
+    }
+    return slot;
+  }
+  return resolveCurrentSlot(basePort).slot;
+}
+
+function printWorktreeInfo(
+  config: SetupWorktreeConfig,
+  slot: number,
+  worktreeForLog: string,
+  fallback: { branch: string; owner?: string },
+): void {
+  const ctx = detectWorktree();
+  const registry = readSlots(ctx.mainWorktree);
+  const entry = registry.slots[String(slot)];
+  const ports = resolvePortsFn(config)(slot);
+
+  const branch = entry?.branch ?? fallback.branch;
+  const owner = entry?.owner ?? fallback.owner;
+  const ready = entry?.ready ?? ctx.isMainWorktree;
+  const status = ready
+    ? "ready"
+    : `not ready (tail ${join(worktreeForLog, config.localWt, "wt-setup.log")})`;
+  console.log(`Status: ${status}`);
+  console.log(
+    config.printSummary({
+      slot,
+      branch,
+      owner,
+      ports,
+      currentWorktree: entry?.worktree ?? ctx.currentWorktree,
+      mainWorktree: ctx.mainWorktree,
+    }),
+  );
+}
+
+function runInfo(config: SetupWorktreeConfig): void {
+  const resolved = resolveCurrentSlot(config.basePort);
+  printWorktreeInfo(config, resolved.slot, ".", { branch: resolved.branch, owner: resolved.owner });
+}
+
+async function runWait(args: SetupArgs, config: SetupWorktreeConfig): Promise<void> {
+  const ctx = detectWorktree();
+  const slot = resolveWaitSlot(args, config.basePort);
+  const registry = readSlots(ctx.mainWorktree);
+  const entry = registry.slots[String(slot)];
+  if (!entry) {
+    console.error(`Error: No slot ${slot} in registry.`);
+    process.exit(1);
+  }
+
+  if (entry.ready) {
+    printWorktreeInfo(config, slot, entry.worktree, { branch: entry.branch, owner: entry.owner });
+    return;
+  }
+
+  const logPath = join(entry.worktree, config.localWt, "wt-setup.log");
+  let offset = 0;
+  const pollMs = 500;
+  // Stream new content from wt-setup.log until we see READY: or FAILED: at line start.
+  for (;;) {
+    if (existsSync(logPath)) {
+      const content = readFileSync(logPath, "utf-8");
+      if (content.length > offset) {
+        const fresh = content.slice(offset);
+        offset = content.length;
+        for (const line of fresh.split("\n")) {
+          if (line.startsWith("READY:")) {
+            printWorktreeInfo(config, slot, entry.worktree, {
+              branch: entry.branch,
+              owner: entry.owner,
+            });
+            return;
+          }
+          if (line.startsWith("FAILED:")) {
+            console.error(line);
+            process.exit(1);
+          }
+        }
+      }
+    }
+    await new Promise((r) => setTimeout(r, pollMs));
   }
 }
 

--- a/packages/worktree-env/src/setup-worktree.ts
+++ b/packages/worktree-env/src/setup-worktree.ts
@@ -15,6 +15,13 @@ import { ConfigError } from "./errors.js";
 import { copyAndPatchFile } from "./helpers.js";
 import { defaultComputePorts, resolvePortScheme, type PortScheme } from "./ports.js";
 import {
+  cleanupPidFile,
+  isProcessAlive,
+  isProcessGroupAlive,
+  killProcessGroup,
+  readPid,
+} from "./process-control.js";
+import {
   handleSetOwner,
   readSlots,
   resolveAndRegisterSlot,
@@ -32,60 +39,6 @@ import {
   verifyBranchAbsentFromRemote,
   type WorktreeContext,
 } from "./worktree.js";
-import {
-  cleanupPidFile,
-  isProcessAlive,
-  isProcessGroupAlive,
-  killProcessGroup,
-  readPid,
-} from "./process-control.js";
-
-/** Context passed to setup-time hooks (`setupWorktreeData`, `installAndBuild`, `afterDatabase`). */
-export interface SetupContext {
-  currentWorktree: string;
-  mainWorktree: string;
-  slot: number;
-  branch: string;
-  owner?: string;
-  ports: Record<string, number>;
-  force: boolean;
-  verbose: boolean;
-}
-
-/** Context passed to {@link ConfigFileEntry.patch}. */
-export interface PatchContext {
-  slot: number;
-  ports: Record<string, number>;
-  mainWorktree: string;
-  currentWorktree: string;
-}
-
-/** One config file copied from the main worktree and patched per slot. */
-export interface ConfigFileEntry {
-  /** Path relative to the worktree root. Same path is read from main and written to current. */
-  path: string;
-  /** Returns the patched content given the source content and the slot's ports. */
-  patch: (content: string, ctx: PatchContext) => string;
-  /** When `true`, abort if the source file is missing in the main worktree. Defaults to `false`. */
-  required?: boolean;
-}
-
-/** Context passed to {@link SetupWorktreeConfig.printSummary}. */
-export interface SummaryContext {
-  slot: number;
-  branch: string;
-  owner?: string;
-  ports: Record<string, number>;
-  currentWorktree: string;
-  mainWorktree: string;
-}
-
-/** Context passed to {@link SetupWorktreeConfig.teardownInfrastructure}. */
-export interface TeardownContext {
-  worktree: string;
-  mainWorktree: string;
-  verbose: boolean;
-}
 
 /** Configuration accepted by {@link runSetupWorktree}. */
 export interface SetupWorktreeConfig {
@@ -121,18 +74,51 @@ export interface SetupWorktreeConfig {
   printSummary: (ctx: SummaryContext) => string;
 }
 
-function makeVerboseLog(verbose: boolean): (msg: string) => void {
-  return (msg) => {
-    if (verbose) console.log(msg);
-  };
+/** Context passed to setup-time hooks (`setupWorktreeData`, `installAndBuild`, `afterDatabase`). */
+export interface SetupContext {
+  currentWorktree: string;
+  mainWorktree: string;
+  slot: number;
+  branch: string;
+  owner?: string;
+  ports: Record<string, number>;
+  force: boolean;
+  verbose: boolean;
 }
 
-function resolvePortsFn(config: SetupWorktreeConfig): (slot: number) => Record<string, number> {
-  if (config.ports) return config.ports;
-  if (config.portNames && config.portNames.length > 0) {
-    return defaultComputePorts(config.portNames);
-  }
-  throw new ConfigError("Config error: provide either `ports` (function) or `portNames` (array).");
+/** Context passed to {@link SetupWorktreeConfig.printSummary}. */
+export interface SummaryContext {
+  slot: number;
+  branch: string;
+  owner?: string;
+  ports: Record<string, number>;
+  currentWorktree: string;
+  mainWorktree: string;
+}
+
+/** Context passed to {@link SetupWorktreeConfig.teardownInfrastructure}. */
+export interface TeardownContext {
+  worktree: string;
+  mainWorktree: string;
+  verbose: boolean;
+}
+
+/** One config file copied from the main worktree and patched per slot. */
+export interface ConfigFileEntry {
+  /** Path relative to the worktree root. Same path is read from main and written to current. */
+  path: string;
+  /** Returns the patched content given the source content and the slot's ports. */
+  patch: (content: string, ctx: PatchContext) => string;
+  /** When `true`, abort if the source file is missing in the main worktree. Defaults to `false`. */
+  required?: boolean;
+}
+
+/** Context passed to {@link ConfigFileEntry.patch}. */
+export interface PatchContext {
+  slot: number;
+  ports: Record<string, number>;
+  mainWorktree: string;
+  currentWorktree: string;
 }
 
 export async function runSetupWorktree(config: SetupWorktreeConfig): Promise<void> {
@@ -250,6 +236,96 @@ async function runSetup(
       mainWorktree: setupCtx.mainWorktree,
     }),
   );
+}
+
+async function handleRemove(
+  args: SetupArgs,
+  ctx: WorktreeContext,
+  run: RunCtx,
+  config: SetupWorktreeConfig,
+): Promise<void> {
+  const verboseLog = makeVerboseLog(run.verbose);
+  const removeHere = Boolean(args["remove-here"]);
+  const registry = readSlots(ctx.mainWorktree);
+  const target = resolveRemoveTarget(args, ctx, registry, removeHere);
+
+  if (!args["no-remote-check"]) {
+    verifyBranchAbsentFromRemote(target.branch, run);
+  }
+
+  const ownerSuffix = target.owner ? `, owner ${target.owner}` : "";
+
+  if (!existsSync(target.worktreePath)) {
+    console.warn(
+      `Warning: Worktree directory ${target.worktreePath} not found. Cleaning up registry only.`,
+    );
+    delete registry.slots[target.slotPort];
+    writeSlots(ctx.mainWorktree, registry);
+    console.log(
+      `Removed registry entry for branch "${target.branch}" (slot ${target.slotPort}${ownerSuffix}).`,
+    );
+    return;
+  }
+
+  await stopDevServerByPidFiles(target.worktreePath, config.devServerPidFiles, verboseLog);
+
+  if (config.teardownInfrastructure) {
+    await config.teardownInfrastructure({
+      worktree: target.worktreePath,
+      mainWorktree: ctx.mainWorktree,
+      verbose: run.verbose,
+    });
+  }
+
+  delete registry.slots[target.slotPort];
+  writeSlots(ctx.mainWorktree, registry);
+  removeDevServerEntryByWorktree(ctx.mainWorktree, target.worktreePath);
+
+  if (removeHere) {
+    process.chdir(ctx.mainWorktree);
+  }
+
+  removeWorktree(target.worktreePath, run);
+
+  console.log(
+    `Removed worktree for branch "${target.branch}" (slot ${target.slotPort}${ownerSuffix}).`,
+  );
+  if (removeHere) {
+    console.log(`Now run: cd ${ctx.mainWorktree}`);
+  }
+}
+
+function handleSetOwnerMode(args: SetupArgs, ctx: WorktreeContext): void {
+  const newOwner = args["set-owner"];
+  const { slotPort } = handleSetOwner({
+    newOwner,
+    currentWorktree: ctx.currentWorktree,
+    mainWorktree: ctx.mainWorktree,
+    isMainWorktree: ctx.isMainWorktree,
+  });
+
+  // Propagate to dev-servers.json entries for this worktree.
+  const devServersPath = join(ctx.mainWorktree, ".local/worktrees/dev-servers.json");
+  if (existsSync(devServersPath)) {
+    const data = JSON.parse(readFileSync(devServersPath, "utf-8")) as {
+      servers: { worktree: string; owner?: string }[];
+    };
+    let changed = false;
+    const resolvedCurrent = resolve(ctx.currentWorktree);
+    for (const server of data.servers) {
+      if (resolve(server.worktree) === resolvedCurrent) {
+        if (newOwner !== undefined) server.owner = newOwner;
+        else delete server.owner;
+        changed = true;
+      }
+    }
+    if (changed) {
+      mkdirSync(dirname(devServersPath), { recursive: true });
+      writeFileSync(devServersPath, `${JSON.stringify(data, undefined, 2)}\n`);
+    }
+  }
+
+  console.log(`Owner for slot ${slotPort}: ${newOwner ?? "(none)"}`);
 }
 
 function ensureWorktree(args: SetupArgs, ctx: WorktreeContext, run: RunCtx): WorktreeContext {
@@ -383,92 +459,16 @@ async function stopDevServerByPidFiles(
   }
 }
 
-async function handleRemove(
-  args: SetupArgs,
-  ctx: WorktreeContext,
-  run: RunCtx,
-  config: SetupWorktreeConfig,
-): Promise<void> {
-  const verboseLog = makeVerboseLog(run.verbose);
-  const removeHere = Boolean(args["remove-here"]);
-  const registry = readSlots(ctx.mainWorktree);
-  const target = resolveRemoveTarget(args, ctx, registry, removeHere);
-
-  if (!args["no-remote-check"]) {
-    verifyBranchAbsentFromRemote(target.branch, run);
+function resolvePortsFn(config: SetupWorktreeConfig): (slot: number) => Record<string, number> {
+  if (config.ports) return config.ports;
+  if (config.portNames && config.portNames.length > 0) {
+    return defaultComputePorts(config.portNames);
   }
-
-  const ownerSuffix = target.owner ? `, owner ${target.owner}` : "";
-
-  if (!existsSync(target.worktreePath)) {
-    console.warn(
-      `Warning: Worktree directory ${target.worktreePath} not found. Cleaning up registry only.`,
-    );
-    delete registry.slots[target.slotPort];
-    writeSlots(ctx.mainWorktree, registry);
-    console.log(
-      `Removed registry entry for branch "${target.branch}" (slot ${target.slotPort}${ownerSuffix}).`,
-    );
-    return;
-  }
-
-  await stopDevServerByPidFiles(target.worktreePath, config.devServerPidFiles, verboseLog);
-
-  if (config.teardownInfrastructure) {
-    await config.teardownInfrastructure({
-      worktree: target.worktreePath,
-      mainWorktree: ctx.mainWorktree,
-      verbose: run.verbose,
-    });
-  }
-
-  delete registry.slots[target.slotPort];
-  writeSlots(ctx.mainWorktree, registry);
-  removeDevServerEntryByWorktree(ctx.mainWorktree, target.worktreePath);
-
-  if (removeHere) {
-    process.chdir(ctx.mainWorktree);
-  }
-
-  removeWorktree(target.worktreePath, run);
-
-  console.log(
-    `Removed worktree for branch "${target.branch}" (slot ${target.slotPort}${ownerSuffix}).`,
-  );
-  if (removeHere) {
-    console.log(`Now run: cd ${ctx.mainWorktree}`);
-  }
+  throw new ConfigError("Config error: provide either `ports` (function) or `portNames` (array).");
 }
 
-function handleSetOwnerMode(args: SetupArgs, ctx: WorktreeContext): void {
-  const newOwner = args["set-owner"];
-  const { slotPort } = handleSetOwner({
-    newOwner,
-    currentWorktree: ctx.currentWorktree,
-    mainWorktree: ctx.mainWorktree,
-    isMainWorktree: ctx.isMainWorktree,
-  });
-
-  // Propagate to dev-servers.json entries for this worktree.
-  const devServersPath = join(ctx.mainWorktree, ".local/worktrees/dev-servers.json");
-  if (existsSync(devServersPath)) {
-    const data = JSON.parse(readFileSync(devServersPath, "utf-8")) as {
-      servers: { worktree: string; owner?: string }[];
-    };
-    let changed = false;
-    const resolvedCurrent = resolve(ctx.currentWorktree);
-    for (const server of data.servers) {
-      if (resolve(server.worktree) === resolvedCurrent) {
-        if (newOwner !== undefined) server.owner = newOwner;
-        else delete server.owner;
-        changed = true;
-      }
-    }
-    if (changed) {
-      mkdirSync(dirname(devServersPath), { recursive: true });
-      writeFileSync(devServersPath, `${JSON.stringify(data, undefined, 2)}\n`);
-    }
-  }
-
-  console.log(`Owner for slot ${slotPort}: ${newOwner ?? "(none)"}`);
+function makeVerboseLog(verbose: boolean): (msg: string) => void {
+  return (msg) => {
+    if (verbose) console.log(msg);
+  };
 }

--- a/packages/worktree-env/src/setup-worktree.ts
+++ b/packages/worktree-env/src/setup-worktree.ts
@@ -1,7 +1,19 @@
-import { existsSync, mkdirSync, readFileSync, symlinkSync, writeFileSync } from "node:fs";
+import { spawn } from "node:child_process";
+import {
+  appendFileSync,
+  closeSync,
+  existsSync,
+  mkdirSync,
+  openSync,
+  readdirSync,
+  readFileSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { dirname, join, relative, resolve } from "node:path";
 
 import {
+  isFinalizeMode,
   isRemoveMode,
   isSetOwnerMode,
   isSetupMode,
@@ -23,6 +35,7 @@ import {
 } from "./process-control.js";
 import {
   handleSetOwner,
+  markSlotReady,
   readSlots,
   resolveAndRegisterSlot,
   validateSlotAvailability,
@@ -52,29 +65,26 @@ export interface SetupWorktreeConfig {
   ports?: (slot: number) => Record<string, number>;
   /** Named offsets `[name0, name1, ...]` mapped to `slot+0`, `slot+1`, ... Required if `ports` is omitted. */
   portNames?: string[];
-  /** Directories symlinked from the main worktree. Defaults to `[".local", ".plans"]`. */
-  sharedDirs?: string[];
-  /** PID files written by `dev-server`, used by `--remove` to stop processes before teardown. */
-  devServerPidFiles: string[];
+  /** Directories symlinked from the main worktree. */
+  sharedDirs: string[];
+  /** Per-worktree runtime directory, relative to the worktree root (e.g. `.local-wt`). */
+  localWt: string;
   /** Config files copied from the main worktree and patched per slot. */
   configFiles: ConfigFileEntry[];
   /**
-   * Runs after symlinks and config files. Owns per-worktree data setup:
-   * create any required directories (e.g. `.local-wt/...`), copy or
-   * provision databases / file storage, start infrastructure containers.
+   * MUST be idempotent. After a failure, the user re-runs `setup-worktree --here` from inside
+   * the worktree — this callback will be invoked again with the same context. Re-runs must not
+   * error on pre-existing state (created directories, started containers, ran migrations,
+   * installed deps, etc.).
    */
-  setupWorktreeData: (ctx: SetupContext) => Promise<void> | void;
+  finalizeWorktree: (ctx: SetupContext) => Promise<void> | void;
   /** Tears down infrastructure on `--remove` (e.g. `docker compose down -v`). Best-effort; errors should be swallowed. */
   teardownInfrastructure?: (ctx: TeardownContext) => Promise<void> | void;
-  /** Runs after `setupWorktreeData`. Typically `npm install && npm run build`. */
-  installAndBuild: (ctx: SetupContext) => Promise<void> | void;
-  /** Runs after `installAndBuild`. Typically migrations and seeds. */
-  afterDatabase?: (ctx: SetupContext) => Promise<void> | void;
   /** Builds the post-setup summary printed to stdout. */
   printSummary: (ctx: SummaryContext) => string;
 }
 
-/** Context passed to setup-time hooks (`setupWorktreeData`, `installAndBuild`, `afterDatabase`). */
+/** Context passed to {@link SetupWorktreeConfig.finalizeWorktree}. */
 export interface SetupContext {
   currentWorktree: string;
   mainWorktree: string;
@@ -147,6 +157,11 @@ export async function runSetupWorktree(config: SetupWorktreeConfig): Promise<voi
     throw err;
   }
 
+  if (isFinalizeMode(args)) {
+    await runFinalize(args, config);
+    return;
+  }
+
   if (!isSetupMode(args) && !isRemoveMode(args) && !isSetOwnerMode(args)) {
     printSetupHelp();
     return;
@@ -175,7 +190,6 @@ async function runSetup(
   run: RunCtx,
   config: SetupWorktreeConfig,
 ): Promise<void> {
-  const verboseLog = makeVerboseLog(run.verbose);
   const scheme: PortScheme = resolvePortScheme(config);
   const portsFn = resolvePortsFn(config);
 
@@ -194,8 +208,22 @@ async function runSetup(
     scheme,
     branch,
     requestedOwner: args.owner,
+    ready: false,
   });
   const ports = portsFn(slot);
+
+  const localWtDir = join(setupCtx.currentWorktree, config.localWt);
+  mkdirSync(localWtDir, { recursive: true });
+  const logPath = join(localWtDir, "wt-setup.log");
+  const logFd = openSync(logPath, "w");
+  const teeLog = (message: string): void => {
+    console.log(message);
+    appendFileSync(logFd, `${message}\n`);
+  };
+  const verboseLog = (msg: string): void => {
+    if (run.verbose) teeLog(msg);
+    else appendFileSync(logFd, `${msg}\n`);
+  };
 
   verboseLog(
     `Using slot ${slot} (${Object.entries(ports)
@@ -203,30 +231,10 @@ async function runSetup(
       .join(", ")})`,
   );
 
-  console.log(`WORKTREE_CREATED path=${setupCtx.currentWorktree} branch=${branch} slot=${slot}`);
-
-  const sharedDirs = config.sharedDirs ?? [".local", ".plans"];
-
-  linkSharedDirectories(setupCtx, sharedDirs, verboseLog);
+  linkSharedDirectories(setupCtx, config.sharedDirs, verboseLog);
   generateConfigFiles(setupCtx, config.configFiles, slot, ports, args.force ?? false, verboseLog);
 
-  const force = args.force ?? false;
-  const setupContext: SetupContext = {
-    currentWorktree: setupCtx.currentWorktree,
-    mainWorktree: setupCtx.mainWorktree,
-    slot,
-    branch,
-    owner,
-    ports,
-    force,
-    verbose: run.verbose,
-  };
-
-  await config.setupWorktreeData(setupContext);
-  await config.installAndBuild(setupContext);
-  if (config.afterDatabase) await config.afterDatabase(setupContext);
-
-  console.log(
+  teeLog(
     config.printSummary({
       slot,
       branch,
@@ -236,6 +244,65 @@ async function runSetup(
       mainWorktree: setupCtx.mainWorktree,
     }),
   );
+
+  teeLog(`WORKTREE_CREATED path=${setupCtx.currentWorktree} branch=${branch} slot=${slot}`);
+  teeLog(`Setup continuing in background. Tail: ${config.localWt}/wt-setup.log`);
+
+  closeSync(logFd);
+
+  const finalizeLogFd = openSync(logPath, "a");
+  const child = spawn(process.execPath, [process.argv[1], "--__finalize", String(slot)], {
+    detached: true,
+    stdio: ["ignore", finalizeLogFd, finalizeLogFd],
+    cwd: setupCtx.currentWorktree,
+  });
+  child.unref();
+  closeSync(finalizeLogFd);
+}
+
+async function runFinalize(args: SetupArgs, config: SetupWorktreeConfig): Promise<void> {
+  const slot = Number(args.__finalize);
+  const ctx = detectWorktree();
+  const registry = readSlots(ctx.mainWorktree);
+  const entry = registry.slots[String(slot)];
+  if (!entry || resolve(entry.worktree) !== resolve(ctx.currentWorktree)) {
+    console.error(`Error: No matching slot ${slot} for worktree ${ctx.currentWorktree}.`);
+    process.exit(1);
+  }
+
+  const portsFn = resolvePortsFn(config);
+  const ports = portsFn(slot);
+  const logPath = join(ctx.currentWorktree, config.localWt, "wt-setup.log");
+  const appendLog = (message: string): void => {
+    appendFileSync(logPath, `${message}\n`);
+  };
+
+  appendLog(`--- finalizing slot ${slot} at ${new Date().toISOString()} ---`);
+
+  const setupContext: SetupContext = {
+    currentWorktree: ctx.currentWorktree,
+    mainWorktree: ctx.mainWorktree,
+    slot,
+    branch: entry.branch,
+    owner: entry.owner,
+    ports,
+    force: false,
+    verbose: false,
+  };
+
+  try {
+    await config.finalizeWorktree(setupContext);
+    markSlotReady(ctx.mainWorktree, slot);
+    appendLog("============================================================");
+    appendLog(`READY: branch ${entry.branch} (slot ${slot})`);
+    appendLog("============================================================");
+  } catch (err) {
+    const message = (err as Error).message;
+    const stack = (err as Error).stack ?? "";
+    appendLog(`FAILED: ${message}`);
+    if (stack) appendLog(stack);
+    process.exit(1);
+  }
 }
 
 async function handleRemove(
@@ -267,7 +334,7 @@ async function handleRemove(
     return;
   }
 
-  await stopDevServerByPidFiles(target.worktreePath, config.devServerPidFiles, verboseLog);
+  await stopAllDevServersInLocalWt(target.worktreePath, config.localWt, verboseLog);
 
   if (config.teardownInfrastructure) {
     await config.teardownInfrastructure({
@@ -428,13 +495,21 @@ function resolveRemoveTarget(
   return { slotPort: entry[0], branch, worktreePath, owner: entry[1].owner };
 }
 
-async function stopDevServerByPidFiles(
+async function stopAllDevServersInLocalWt(
   worktreePath: string,
-  pidFiles: string[],
+  localWt: string,
   log: (msg: string) => void,
 ): Promise<void> {
-  for (const pidFileRel of pidFiles) {
-    const pidFile = join(worktreePath, pidFileRel);
+  const dir = join(worktreePath, localWt);
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return;
+  }
+  for (const name of entries) {
+    if (!name.endsWith(".pid")) continue;
+    const pidFile = join(dir, name);
     const pid = readPid(pidFile);
     if (pid === undefined) continue;
     if (!isProcessAlive(pid)) {

--- a/packages/worktree-env/src/setup-worktree.ts
+++ b/packages/worktree-env/src/setup-worktree.ts
@@ -208,7 +208,6 @@ async function runSetup(
     scheme,
     branch,
     requestedOwner: args.owner,
-    ready: false,
   });
   const ports = portsFn(slot);
 
@@ -250,6 +249,8 @@ async function runSetup(
 
   closeSync(logFd);
 
+  // Hand the detached child a fresh fd appended to the same log file; the parent's fd is closed
+  // just above so we cannot reuse it.
   const finalizeLogFd = openSync(logPath, "a");
   const child = spawn(process.execPath, [process.argv[1], "--__finalize", String(slot)], {
     detached: true,
@@ -263,19 +264,25 @@ async function runSetup(
 async function runFinalize(args: SetupArgs, config: SetupWorktreeConfig): Promise<void> {
   const slot = Number(args.__finalize);
   const ctx = detectWorktree();
-  const registry = readSlots(ctx.mainWorktree);
-  const entry = registry.slots[String(slot)];
-  if (!entry || resolve(entry.worktree) !== resolve(ctx.currentWorktree)) {
-    console.error(`Error: No matching slot ${slot} for worktree ${ctx.currentWorktree}.`);
-    process.exit(1);
-  }
-
-  const portsFn = resolvePortsFn(config);
-  const ports = portsFn(slot);
   const logPath = join(ctx.currentWorktree, config.localWt, "wt-setup.log");
   const appendLog = (message: string): void => {
     appendFileSync(logPath, `${message}\n`);
   };
+
+  const registry = readSlots(ctx.mainWorktree);
+  const entry = registry.slots[String(slot)];
+  if (!entry || resolve(entry.worktree) !== resolve(ctx.currentWorktree)) {
+    appendLog(`FAILED: No matching slot ${slot} for worktree ${ctx.currentWorktree}.`);
+    process.exit(1);
+  }
+
+  if (entry.ready && !args.force) {
+    appendLog(`READY: branch ${entry.branch} (slot ${slot}) already finalized; skipping.`);
+    return;
+  }
+
+  const portsFn = resolvePortsFn(config);
+  const ports = portsFn(slot);
 
   appendLog(`--- finalizing slot ${slot} at ${new Date().toISOString()} ---`);
 
@@ -286,7 +293,7 @@ async function runFinalize(args: SetupArgs, config: SetupWorktreeConfig): Promis
     branch: entry.branch,
     owner: entry.owner,
     ports,
-    force: false,
+    force: args.force ?? false,
     verbose: false,
   };
 

--- a/packages/worktree-env/src/slots.ts
+++ b/packages/worktree-env/src/slots.ts
@@ -7,6 +7,13 @@ import { allPorts, isValidPort, type PortScheme } from "./ports.js";
 export const WORKTREES_DIR = ".local/worktrees";
 export const SLOTS_FILE = ".local/worktrees/slots.json";
 
+export interface ResolvedSlot {
+  slot: number;
+  worktree: string;
+  branch: string;
+  owner?: string;
+}
+
 export interface SlotEntry {
   worktree: string;
   branch: string;
@@ -15,13 +22,6 @@ export interface SlotEntry {
 
 export interface SlotsRegistry {
   slots: Record<string, SlotEntry>;
-}
-
-export interface ResolvedSlot {
-  slot: number;
-  worktree: string;
-  branch: string;
-  owner?: string;
 }
 
 export function readSlots(mainWorktree: string): SlotsRegistry {
@@ -34,44 +34,6 @@ export function writeSlots(mainWorktree: string, registry: SlotsRegistry): void 
   const filePath = join(mainWorktree, SLOTS_FILE);
   mkdirSync(join(mainWorktree, WORKTREES_DIR), { recursive: true });
   writeFileSync(filePath, `${JSON.stringify(registry, undefined, 2)}\n`);
-}
-
-export interface PickSlotArgs {
-  slot?: string;
-  currentWorktree: string;
-  mainWorktree: string;
-  scheme: PortScheme;
-}
-
-export function pickSlotPort(args: PickSlotArgs, registry: SlotsRegistry): number {
-  const resolvedCurrent = resolve(args.currentWorktree);
-
-  if (args.slot !== undefined) {
-    const port = Number(args.slot);
-    if (!isValidPort(port, args.scheme)) {
-      console.error(`Error: Slot must be a valid port: ${allPorts(args.scheme).join(", ")}.`);
-      process.exit(1);
-    }
-    const existing = registry.slots[String(port)];
-    if (existing && resolve(existing.worktree) !== resolvedCurrent) {
-      console.error(
-        `Error: Slot ${port} is already taken by ${existing.worktree} (branch: ${existing.branch}).`,
-      );
-      process.exit(1);
-    }
-    return port;
-  }
-
-  const existingEntry = Object.entries(registry.slots).find(
-    ([, v]) => resolve(v.worktree) === resolvedCurrent,
-  );
-  if (existingEntry) return Number(existingEntry[0]);
-
-  for (const port of allPorts(args.scheme)) {
-    if (!registry.slots[String(port)]) return port;
-  }
-  console.error("Error: All slots are taken. Remove a worktree with --remove first.");
-  process.exit(1);
 }
 
 export interface RegisterSlotInput {
@@ -121,38 +83,6 @@ export function validateSlotAvailability(
   }
 }
 
-export function lookupSlotForCwd(): ResolvedSlot | undefined {
-  const cwd = resolve(process.cwd());
-  // Reads slots.json relative to cwd's `.local` symlink (so works in linked worktrees too).
-  const filePath = SLOTS_FILE;
-  if (!existsSync(filePath)) return undefined;
-  const registry = JSON.parse(readFileSync(filePath, "utf-8")) as SlotsRegistry;
-  for (const [port, entry] of Object.entries(registry.slots)) {
-    if (resolve(entry.worktree) === cwd) {
-      return {
-        slot: Number(port),
-        worktree: entry.worktree,
-        branch: entry.branch,
-        owner: entry.owner,
-      };
-    }
-  }
-  return undefined;
-}
-
-export function synthesizeMainSlot(basePort: number): ResolvedSlot | undefined {
-  const gitCommonDir = execFileSync(
-    "git",
-    ["rev-parse", "--path-format=absolute", "--git-common-dir"],
-    { encoding: "utf-8" },
-  ).trim();
-  const mainWorktree = dirname(gitCommonDir);
-  const cwd = resolve(process.cwd());
-  if (resolve(mainWorktree) !== cwd) return undefined;
-  const branch = execFileSync("git", ["branch", "--show-current"], { encoding: "utf-8" }).trim();
-  return { slot: basePort, worktree: cwd, branch };
-}
-
 export function resolveCurrentSlot(basePort: number): ResolvedSlot {
   const slot = lookupSlotForCwd() ?? synthesizeMainSlot(basePort);
   if (!slot) {
@@ -195,4 +125,74 @@ export function handleSetOwner(input: SetOwnerInput): {
   registry.slots[slotPort] = updated;
   writeSlots(input.mainWorktree, registry);
   return { slotPort, owner: input.newOwner };
+}
+
+interface PickSlotArgs {
+  slot?: string;
+  currentWorktree: string;
+  mainWorktree: string;
+  scheme: PortScheme;
+}
+
+function pickSlotPort(args: PickSlotArgs, registry: SlotsRegistry): number {
+  const resolvedCurrent = resolve(args.currentWorktree);
+
+  if (args.slot !== undefined) {
+    const port = Number(args.slot);
+    if (!isValidPort(port, args.scheme)) {
+      console.error(`Error: Slot must be a valid port: ${allPorts(args.scheme).join(", ")}.`);
+      process.exit(1);
+    }
+    const existing = registry.slots[String(port)];
+    if (existing && resolve(existing.worktree) !== resolvedCurrent) {
+      console.error(
+        `Error: Slot ${port} is already taken by ${existing.worktree} (branch: ${existing.branch}).`,
+      );
+      process.exit(1);
+    }
+    return port;
+  }
+
+  const existingEntry = Object.entries(registry.slots).find(
+    ([, v]) => resolve(v.worktree) === resolvedCurrent,
+  );
+  if (existingEntry) return Number(existingEntry[0]);
+
+  for (const port of allPorts(args.scheme)) {
+    if (!registry.slots[String(port)]) return port;
+  }
+  console.error("Error: All slots are taken. Remove a worktree with --remove first.");
+  process.exit(1);
+}
+
+function lookupSlotForCwd(): ResolvedSlot | undefined {
+  const cwd = resolve(process.cwd());
+  // Reads slots.json relative to cwd's `.local` symlink (so works in linked worktrees too).
+  const filePath = SLOTS_FILE;
+  if (!existsSync(filePath)) return undefined;
+  const registry = JSON.parse(readFileSync(filePath, "utf-8")) as SlotsRegistry;
+  for (const [port, entry] of Object.entries(registry.slots)) {
+    if (resolve(entry.worktree) === cwd) {
+      return {
+        slot: Number(port),
+        worktree: entry.worktree,
+        branch: entry.branch,
+        owner: entry.owner,
+      };
+    }
+  }
+  return undefined;
+}
+
+function synthesizeMainSlot(basePort: number): ResolvedSlot | undefined {
+  const gitCommonDir = execFileSync(
+    "git",
+    ["rev-parse", "--path-format=absolute", "--git-common-dir"],
+    { encoding: "utf-8" },
+  ).trim();
+  const mainWorktree = dirname(gitCommonDir);
+  const cwd = resolve(process.cwd());
+  if (resolve(mainWorktree) !== cwd) return undefined;
+  const branch = execFileSync("git", ["branch", "--show-current"], { encoding: "utf-8" }).trim();
+  return { slot: basePort, worktree: cwd, branch };
 }

--- a/packages/worktree-env/src/slots.ts
+++ b/packages/worktree-env/src/slots.ts
@@ -18,6 +18,8 @@ export interface SlotEntry {
   worktree: string;
   branch: string;
   owner?: string;
+  createdAt: string;
+  ready: boolean;
 }
 
 export interface SlotsRegistry {
@@ -43,6 +45,7 @@ export interface RegisterSlotInput {
   scheme: PortScheme;
   branch: string;
   requestedOwner?: string;
+  ready?: boolean;
 }
 
 export function resolveAndRegisterSlot(input: RegisterSlotInput): {
@@ -53,14 +56,26 @@ export function resolveAndRegisterSlot(input: RegisterSlotInput): {
   const port = pickSlotPort(input, registry);
   const existing = registry.slots[String(port)];
   const owner = input.requestedOwner ?? existing?.owner;
+  const createdAt = existing?.createdAt ?? new Date().toISOString();
+  const ready = input.ready ?? existing?.ready ?? false;
   const entry: SlotEntry = {
     worktree: input.currentWorktree,
     branch: input.branch,
+    createdAt,
+    ready,
   };
   if (owner !== undefined) entry.owner = owner;
   registry.slots[String(port)] = entry;
   writeSlots(input.mainWorktree, registry);
   return { port, owner };
+}
+
+export function markSlotReady(mainWorktree: string, slotPort: number): void {
+  const registry = readSlots(mainWorktree);
+  const entry = registry.slots[String(slotPort)];
+  if (!entry) return;
+  entry.ready = true;
+  writeSlots(mainWorktree, registry);
 }
 
 export function validateSlotAvailability(
@@ -120,6 +135,8 @@ export function handleSetOwner(input: SetOwnerInput): {
   const updated: SlotEntry = {
     worktree: slotData.worktree,
     branch: slotData.branch,
+    createdAt: slotData.createdAt,
+    ready: slotData.ready,
   };
   if (input.newOwner !== undefined) updated.owner = input.newOwner;
   registry.slots[slotPort] = updated;

--- a/packages/worktree-env/src/slots.ts
+++ b/packages/worktree-env/src/slots.ts
@@ -4,8 +4,7 @@ import { dirname, join, resolve } from "node:path";
 
 import { allPorts, isValidPort, type PortScheme } from "./ports.js";
 
-export const WORKTREES_DIR = ".local/worktrees";
-export const SLOTS_FILE = ".local/worktrees/slots.json";
+const SLOTS_FILENAME = "slots.json";
 
 export interface ResolvedSlot {
   slot: number;
@@ -14,27 +13,34 @@ export interface ResolvedSlot {
   owner?: string;
 }
 
+export type SlotStatus = "pending" | "ready" | "failed";
+
 export interface SlotEntry {
   worktree: string;
   branch: string;
   owner?: string;
   createdAt: string;
-  ready: boolean;
+  status: SlotStatus;
+  failure?: { at: string; message: string };
 }
 
 export interface SlotsRegistry {
   slots: Record<string, SlotEntry>;
 }
 
-export function readSlots(mainWorktree: string): SlotsRegistry {
-  const filePath = join(mainWorktree, SLOTS_FILE);
+export function readSlots(mainWorktree: string, registryDir: string): SlotsRegistry {
+  const filePath = join(mainWorktree, registryDir, SLOTS_FILENAME);
   if (!existsSync(filePath)) return { slots: {} };
   return JSON.parse(readFileSync(filePath, "utf-8")) as SlotsRegistry;
 }
 
-export function writeSlots(mainWorktree: string, registry: SlotsRegistry): void {
-  const filePath = join(mainWorktree, SLOTS_FILE);
-  mkdirSync(join(mainWorktree, WORKTREES_DIR), { recursive: true });
+export function writeSlots(
+  mainWorktree: string,
+  registryDir: string,
+  registry: SlotsRegistry,
+): void {
+  const filePath = join(mainWorktree, registryDir, SLOTS_FILENAME);
+  mkdirSync(join(mainWorktree, registryDir), { recursive: true });
   writeFileSync(filePath, `${JSON.stringify(registry, undefined, 2)}\n`);
 }
 
@@ -42,47 +48,66 @@ export interface RegisterSlotInput {
   slot?: string;
   currentWorktree: string;
   mainWorktree: string;
+  registryDir: string;
   scheme: PortScheme;
   branch: string;
   requestedOwner?: string;
-  ready?: boolean;
 }
 
 export function resolveAndRegisterSlot(input: RegisterSlotInput): {
   port: number;
   owner: string | undefined;
 } {
-  const registry = readSlots(input.mainWorktree);
+  const registry = readSlots(input.mainWorktree, input.registryDir);
   const port = pickSlotPort(input, registry);
   const existing = registry.slots[String(port)];
   const owner = input.requestedOwner ?? existing?.owner;
   const createdAt = existing?.createdAt ?? new Date().toISOString();
-  // Preserve existing `ready` when caller omits it. `markSlotReady` is the only writer that flips
-  // it to true, so a re-run via `--here` keeps a previously finalized slot ready.
-  const ready = input.ready ?? existing?.ready ?? false;
+  // Re-runs of `--here` keep a previously finalized slot ready; otherwise reset to pending.
+  const status: SlotStatus = existing?.status === "ready" ? "ready" : "pending";
   const entry: SlotEntry = {
     worktree: input.currentWorktree,
     branch: input.branch,
     createdAt,
-    ready,
+    status,
   };
   if (owner !== undefined) entry.owner = owner;
   registry.slots[String(port)] = entry;
-  writeSlots(input.mainWorktree, registry);
+  writeSlots(input.mainWorktree, input.registryDir, registry);
   return { port, owner };
 }
 
-export function markSlotReady(mainWorktree: string, slotPort: number): void {
-  const registry = readSlots(mainWorktree);
+export function markSlotReady(mainWorktree: string, registryDir: string, slotPort: number): void {
+  const registry = readSlots(mainWorktree, registryDir);
   const entry = registry.slots[String(slotPort)];
   if (!entry) return;
-  entry.ready = true;
-  writeSlots(mainWorktree, registry);
+  entry.status = "ready";
+  delete entry.failure;
+  writeSlots(mainWorktree, registryDir, registry);
+}
+
+export function markSlotFailed(
+  mainWorktree: string,
+  registryDir: string,
+  slotPort: number,
+  message: string,
+): void {
+  const registry = readSlots(mainWorktree, registryDir);
+  const entry = registry.slots[String(slotPort)];
+  if (!entry) return;
+  entry.status = "failed";
+  entry.failure = { at: new Date().toISOString(), message };
+  writeSlots(mainWorktree, registryDir, registry);
 }
 
 export function validateSlotAvailability(
   slotArg: string | undefined,
-  ctx: { currentWorktree: string; mainWorktree: string; scheme: PortScheme },
+  ctx: {
+    currentWorktree: string;
+    mainWorktree: string;
+    registryDir: string;
+    scheme: PortScheme;
+  },
 ): void {
   if (slotArg === undefined) return;
   const port = Number(slotArg);
@@ -90,7 +115,7 @@ export function validateSlotAvailability(
     console.error(`Error: Slot must be a valid port: ${allPorts(ctx.scheme).join(", ")}.`);
     process.exit(1);
   }
-  const registry = readSlots(ctx.mainWorktree);
+  const registry = readSlots(ctx.mainWorktree, ctx.registryDir);
   const existing = registry.slots[String(port)];
   if (existing && resolve(existing.worktree) !== resolve(ctx.currentWorktree)) {
     console.error(
@@ -100,8 +125,8 @@ export function validateSlotAvailability(
   }
 }
 
-export function resolveCurrentSlot(basePort: number): ResolvedSlot {
-  const slot = lookupSlotForCwd() ?? synthesizeMainSlot(basePort);
+export function resolveCurrentSlot(basePort: number, registryDir: string): ResolvedSlot {
+  const slot = lookupSlotForCwd(registryDir) ?? synthesizeMainSlot(basePort);
   if (!slot) {
     console.error("Error: No slot found for this worktree. Run setup-worktree first.");
     process.exit(1);
@@ -113,6 +138,7 @@ export interface SetOwnerInput {
   newOwner: string | undefined;
   currentWorktree: string;
   mainWorktree: string;
+  registryDir: string;
   isMainWorktree: boolean;
 }
 
@@ -124,7 +150,7 @@ export function handleSetOwner(input: SetOwnerInput): {
     console.error("Error: --set-owner must be run from a linked worktree.");
     process.exit(1);
   }
-  const registry = readSlots(input.mainWorktree);
+  const registry = readSlots(input.mainWorktree, input.registryDir);
   const resolvedCurrent = resolve(input.currentWorktree);
   const entry = Object.entries(registry.slots).find(
     ([, v]) => resolve(v.worktree) === resolvedCurrent,
@@ -137,12 +163,13 @@ export function handleSetOwner(input: SetOwnerInput): {
   const updated: SlotEntry = {
     worktree: slotData.worktree,
     branch: slotData.branch,
-    createdAt: slotData.createdAt ?? new Date().toISOString(),
-    ready: slotData.ready ?? false,
+    createdAt: slotData.createdAt,
+    status: slotData.status,
   };
+  if (slotData.failure) updated.failure = slotData.failure;
   if (input.newOwner !== undefined) updated.owner = input.newOwner;
   registry.slots[slotPort] = updated;
-  writeSlots(input.mainWorktree, registry);
+  writeSlots(input.mainWorktree, input.registryDir, registry);
   return { slotPort, owner: input.newOwner };
 }
 
@@ -184,10 +211,10 @@ function pickSlotPort(args: PickSlotArgs, registry: SlotsRegistry): number {
   process.exit(1);
 }
 
-function lookupSlotForCwd(): ResolvedSlot | undefined {
+function lookupSlotForCwd(registryDir: string): ResolvedSlot | undefined {
   const cwd = resolve(process.cwd());
-  // Reads slots.json relative to cwd's `.local` symlink (so works in linked worktrees too).
-  const filePath = SLOTS_FILE;
+  // Reads slots.json relative to cwd's shared-dir symlink (so works in linked worktrees too).
+  const filePath = join(registryDir, SLOTS_FILENAME);
   if (!existsSync(filePath)) return undefined;
   const registry = JSON.parse(readFileSync(filePath, "utf-8")) as SlotsRegistry;
   for (const [port, entry] of Object.entries(registry.slots)) {

--- a/packages/worktree-env/src/slots.ts
+++ b/packages/worktree-env/src/slots.ts
@@ -57,6 +57,8 @@ export function resolveAndRegisterSlot(input: RegisterSlotInput): {
   const existing = registry.slots[String(port)];
   const owner = input.requestedOwner ?? existing?.owner;
   const createdAt = existing?.createdAt ?? new Date().toISOString();
+  // Preserve existing `ready` when caller omits it. `markSlotReady` is the only writer that flips
+  // it to true, so a re-run via `--here` keeps a previously finalized slot ready.
   const ready = input.ready ?? existing?.ready ?? false;
   const entry: SlotEntry = {
     worktree: input.currentWorktree,
@@ -135,8 +137,8 @@ export function handleSetOwner(input: SetOwnerInput): {
   const updated: SlotEntry = {
     worktree: slotData.worktree,
     branch: slotData.branch,
-    createdAt: slotData.createdAt,
-    ready: slotData.ready,
+    createdAt: slotData.createdAt ?? new Date().toISOString(),
+    ready: slotData.ready ?? false,
   };
   if (input.newOwner !== undefined) updated.owner = input.newOwner;
   registry.slots[slotPort] = updated;

--- a/packages/worktree-env/src/worktree.ts
+++ b/packages/worktree-env/src/worktree.ts
@@ -11,10 +11,6 @@ export interface RunCtx {
   verbose: boolean;
 }
 
-function stdioFor(ctx: RunCtx): "inherit" | "pipe" {
-  return ctx.verbose ? "inherit" : "pipe";
-}
-
 export function detectWorktree(): WorktreeContext {
   const currentWorktree = execFileSync("git", ["rev-parse", "--show-toplevel"], {
     encoding: "utf-8",
@@ -29,22 +25,21 @@ export function detectWorktree(): WorktreeContext {
   return { currentWorktree, mainWorktree, isMainWorktree };
 }
 
-export function computeWorktreePath(mainWorktree: string, branch: string): string {
-  const repoName = basename(mainWorktree);
-  const sanitized = branch.replaceAll("/", "-");
-  return join(dirname(mainWorktree), `${repoName}-${sanitized}`);
-}
-
-export function branchExists(branch: string): boolean {
-  try {
-    execFileSync("git", ["rev-parse", "--verify", branch], { stdio: "pipe" });
-    return true;
-  } catch {
-    try {
-      execFileSync("git", ["rev-parse", "--verify", `origin/${branch}`], { stdio: "pipe" });
-      return true;
-    } catch {
-      return false;
+export function enforceWorktreeMode(
+  args: { use?: string; create?: string; here?: boolean },
+  ctx: WorktreeContext,
+): void {
+  if (args.use || args.create) {
+    if (!ctx.isMainWorktree) {
+      console.error("Error: --use and --create must be run from the main worktree.");
+      process.exit(1);
+    }
+  } else if (args.here) {
+    if (ctx.isMainWorktree) {
+      console.error(
+        "Error: --here must be run from a linked worktree, not from the main worktree.",
+      );
+      process.exit(1);
     }
   }
 }
@@ -103,25 +98,30 @@ export function getCurrentBranch(worktreePath: string): string {
   }).trim();
 }
 
-export function enforceWorktreeMode(
-  args: { use?: string; create?: string; here?: boolean },
-  ctx: WorktreeContext,
-): void {
-  if (args.use || args.create) {
-    if (!ctx.isMainWorktree) {
-      console.error("Error: --use and --create must be run from the main worktree.");
-      process.exit(1);
-    }
-  } else if (args.here) {
-    if (ctx.isMainWorktree) {
-      console.error(
-        "Error: --here must be run from a linked worktree, not from the main worktree.",
-      );
-      process.exit(1);
+export function removeWorktree(worktreePath: string, run: RunCtx): void {
+  execFileSync("git", ["worktree", "remove", "--force", worktreePath], { stdio: stdioFor(run) });
+}
+
+export function computeWorktreePath(mainWorktree: string, branch: string): string {
+  const repoName = basename(mainWorktree);
+  const sanitized = branch.replaceAll("/", "-");
+  return join(dirname(mainWorktree), `${repoName}-${sanitized}`);
+}
+
+function branchExists(branch: string): boolean {
+  try {
+    execFileSync("git", ["rev-parse", "--verify", branch], { stdio: "pipe" });
+    return true;
+  } catch {
+    try {
+      execFileSync("git", ["rev-parse", "--verify", `origin/${branch}`], { stdio: "pipe" });
+      return true;
+    } catch {
+      return false;
     }
   }
 }
 
-export function removeWorktree(worktreePath: string, run: RunCtx): void {
-  execFileSync("git", ["worktree", "remove", "--force", worktreePath], { stdio: stdioFor(run) });
+function stdioFor(ctx: RunCtx): "inherit" | "pipe" {
+  return ctx.verbose ? "inherit" : "pipe";
 }

--- a/packages/worktree-env/test/cli.test.ts
+++ b/packages/worktree-env/test/cli.test.ts
@@ -39,6 +39,11 @@ describe("validateSetupFlags", () => {
     expect(() => validateSetupFlags(args)).toThrow(/mutually exclusive/);
   });
 
+  it("rejects --__finalize combined with another mode flag", () => {
+    const args = parseSetupArgs(["--__finalize", "8110", "--here"]);
+    expect(() => validateSetupFlags(args)).toThrow(ConfigError);
+  });
+
   it("accepts a valid setup invocation", () => {
     const args = parseSetupArgs(["--use", "a", "--owner", "alice", "--slot", "8110", "--force"]);
     expect(() => validateSetupFlags(args)).not.toThrow();

--- a/packages/worktree-env/test/cli.test.ts
+++ b/packages/worktree-env/test/cli.test.ts
@@ -31,7 +31,7 @@ describe("validateSetupFlags", () => {
 
   it("rejects --slot without a setup mode", () => {
     const args = parseSetupArgs(["--slot", "8110"]);
-    expect(() => validateSetupFlags(args)).toThrow(/--slot and --force/);
+    expect(() => validateSetupFlags(args)).toThrow(/--slot/);
   });
 
   it("rejects --remove + --remove-here", () => {

--- a/packages/worktree-env/test/dev-servers-registry.test.ts
+++ b/packages/worktree-env/test/dev-servers-registry.test.ts
@@ -1,15 +1,29 @@
-import { describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
-import { pruneDeadServers, type DevServerEntry } from "../src/dev-servers-registry.js";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-function entry(slot: number, pids: Record<string, number>): DevServerEntry {
+import {
+  evictOldest,
+  pruneDeadServers,
+  readDevServers,
+  writeDevServers,
+  type DevServerEntry,
+} from "../src/dev-servers-registry.js";
+
+function entry(
+  slot: number,
+  pids: Record<string, number>,
+  startedAt = "2026-05-10T00:00:00.000Z",
+): DevServerEntry {
   return {
     slot,
     worktree: `/tmp/wt-${slot}`,
     branch: `feat/${slot}`,
     owner: "alice",
     pids,
-    startedAt: "2026-05-10T00:00:00.000Z",
+    startedAt,
   };
 }
 
@@ -42,5 +56,58 @@ describe("pruneDeadServers", () => {
     const data = { servers: [entry(8110, { main: 2 })] };
     const round = JSON.parse(JSON.stringify(data));
     expect(pruneDeadServers(round, isAlive)).toEqual(data);
+  });
+});
+
+describe("evictOldest", () => {
+  let mainWorktree: string;
+  const isAlive = () => true;
+  const stop = async () => {};
+
+  beforeEach(() => {
+    mainWorktree = mkdtempSync(join(tmpdir(), "wt-env-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(mainWorktree, { recursive: true, force: true });
+  });
+
+  it("selects the entry with the smallest startedAt", async () => {
+    writeDevServers(mainWorktree, {
+      servers: [
+        entry(8120, { main: 2 }, "2026-05-10T02:00:00.000Z"),
+        entry(8110, { main: 4 }, "2026-05-10T00:00:00.000Z"),
+        entry(8130, { main: 6 }, "2026-05-10T01:00:00.000Z"),
+      ],
+    });
+    const evicted = await evictOldest(mainWorktree, 1, { isAlive, stop });
+    expect(evicted).toHaveLength(1);
+    expect(evicted[0].slot).toBe(8110);
+  });
+
+  it("removes the victim from the registry", async () => {
+    writeDevServers(mainWorktree, {
+      servers: [
+        entry(8120, { main: 2 }, "2026-05-10T02:00:00.000Z"),
+        entry(8110, { main: 4 }, "2026-05-10T00:00:00.000Z"),
+      ],
+    });
+    await evictOldest(mainWorktree, 1, { isAlive, stop });
+    const remaining = readDevServers(mainWorktree).servers.map((e) => e.slot);
+    expect(remaining).toEqual([8120]);
+  });
+
+  it("removes the two oldest when count is 2", async () => {
+    writeDevServers(mainWorktree, {
+      servers: [
+        entry(8120, { main: 2 }, "2026-05-10T02:00:00.000Z"),
+        entry(8110, { main: 4 }, "2026-05-10T00:00:00.000Z"),
+        entry(8130, { main: 6 }, "2026-05-10T01:00:00.000Z"),
+      ],
+    });
+    const evicted = await evictOldest(mainWorktree, 2, { isAlive, stop });
+    expect(evicted.map((e) => e.slot)).toEqual([8110, 8130]);
+    const remaining = readDevServers(mainWorktree).servers.map((e) => e.slot);
+    expect(remaining).toEqual([8120]);
   });
 });

--- a/packages/worktree-env/test/dev-servers-registry.test.ts
+++ b/packages/worktree-env/test/dev-servers-registry.test.ts
@@ -61,6 +61,7 @@ describe("pruneDeadServers", () => {
 
 describe("evictOldest", () => {
   let mainWorktree: string;
+  const registryDir = ".local/wt-registry";
   const isAlive = () => true;
   const stop = async () => {};
 
@@ -73,41 +74,41 @@ describe("evictOldest", () => {
   });
 
   it("selects the entry with the smallest startedAt", async () => {
-    writeDevServers(mainWorktree, {
+    writeDevServers(mainWorktree, registryDir, {
       servers: [
         entry(8120, { main: 2 }, "2026-05-10T02:00:00.000Z"),
         entry(8110, { main: 4 }, "2026-05-10T00:00:00.000Z"),
         entry(8130, { main: 6 }, "2026-05-10T01:00:00.000Z"),
       ],
     });
-    const evicted = await evictOldest(mainWorktree, 1, { isAlive, stop });
+    const evicted = await evictOldest(mainWorktree, registryDir, 1, { isAlive, stop });
     expect(evicted).toHaveLength(1);
     expect(evicted[0].slot).toBe(8110);
   });
 
   it("removes the victim from the registry", async () => {
-    writeDevServers(mainWorktree, {
+    writeDevServers(mainWorktree, registryDir, {
       servers: [
         entry(8120, { main: 2 }, "2026-05-10T02:00:00.000Z"),
         entry(8110, { main: 4 }, "2026-05-10T00:00:00.000Z"),
       ],
     });
-    await evictOldest(mainWorktree, 1, { isAlive, stop });
-    const remaining = readDevServers(mainWorktree).servers.map((e) => e.slot);
+    await evictOldest(mainWorktree, registryDir, 1, { isAlive, stop });
+    const remaining = readDevServers(mainWorktree, registryDir).servers.map((e) => e.slot);
     expect(remaining).toEqual([8120]);
   });
 
   it("removes the two oldest when count is 2", async () => {
-    writeDevServers(mainWorktree, {
+    writeDevServers(mainWorktree, registryDir, {
       servers: [
         entry(8120, { main: 2 }, "2026-05-10T02:00:00.000Z"),
         entry(8110, { main: 4 }, "2026-05-10T00:00:00.000Z"),
         entry(8130, { main: 6 }, "2026-05-10T01:00:00.000Z"),
       ],
     });
-    const evicted = await evictOldest(mainWorktree, 2, { isAlive, stop });
+    const evicted = await evictOldest(mainWorktree, registryDir, 2, { isAlive, stop });
     expect(evicted.map((e) => e.slot)).toEqual([8110, 8130]);
-    const remaining = readDevServers(mainWorktree).servers.map((e) => e.slot);
+    const remaining = readDevServers(mainWorktree, registryDir).servers.map((e) => e.slot);
     expect(remaining).toEqual([8120]);
   });
 });

--- a/skills/worktree-env-guide/SKILL.md
+++ b/skills/worktree-env-guide/SKILL.md
@@ -39,7 +39,7 @@ Example split:
 | -------------- | ---------------------- | -------------------------------- |
 | `.local/`      | Shared (symlinked)     | Slot registry, personal notes    |
 | `.plans/`      | Shared (symlinked)     | Task planning files              |
-| `.local-data/` | Per-worktree           | Databases, caches, backups, logs |
+| `.local-wt/`   | Per-worktree           | Databases, caches, backups, logs |
 
 The setup script creates symlinks for shared directories and creates fresh copies of per-worktree directories. The naming doesn't matter — what matters is that you consciously decide which category each directory falls into.
 
@@ -150,7 +150,7 @@ Running the script with no mode flag shows help.
 - `ports(slot)` or `portNames` — supply either a function returning the port map for a slot, or a list of names that defaults to consecutive ports (`{ name0: slot, name1: slot+1, ... }`).
 - `configFiles: Array<{ path, patch, required? }>` — one entry per gitignored config file. `patch(content, { slot, ports, mainWorktree, currentWorktree })` returns the rewritten content. Use `helpers.patchEnvFile` for `KEY=VALUE` files and `helpers.extractHost` to preserve non-localhost hosts.
 - `devServerPidFiles: string[]` — one entry per PID file your dev-server writes; used by `--remove` to stop the dev server cleanly.
-- `setupWorktreeData(ctx)` — required callback. Runs after symlinks and config files. Owns per-worktree directory creation (e.g. `mkdirSync(".local-data/...")` at the top), database / file-storage provisioning, and infrastructure startup. Must end with a working database (see "Database provisioning" below).
+- `setupWorktreeData(ctx)` — required callback. Runs after symlinks and config files. Owns per-worktree directory creation (e.g. `mkdirSync(".local-wt/...")` at the top), database / file-storage provisioning, and infrastructure startup. Must end with a working database (see "Database provisioning" below).
 - `installAndBuild(ctx)` — required callback. `npm install && npm run build`, `pip install`, `cargo build`, etc.
 - `afterDatabase(ctx)` — optional. Migrations / seeding.
 - `teardownInfrastructure(ctx)` — optional. Called by `--remove`. The standard pattern is `docker compose down -v` if you use Docker.
@@ -346,6 +346,6 @@ The agents need to know:
 - [ ] **Write `dev-server`** using [assets/dev-server.mjs](assets/dev-server.mjs) as a starting point. Same approach.
 - [ ] **Add npm scripts** (or Makefile targets, etc.) for `setup-worktree`, `dev:up`, `dev:down`.
 - [ ] **Set the dev-server cap** by passing `devLimit` to `runDevServer` (default `5`).
-- [ ] **Update `.gitignore`** to ignore your shared and per-worktree directories. Make sure `.local/worktrees/` is covered (slot registry and dev-server registry live there).
+- [ ] **Update `.gitignore`** to ignore your shared and per-worktree directories (e.g. `.local/`, `.local-wt/`). Make sure `.local/worktrees/` is covered (slot registry and dev-server registry live there).
 - [ ] **Write agent documentation** if applicable (see [assets/agent-local-env.md](assets/agent-local-env.md)).
 - [ ] **Update your main instruction file** (`AGENTS.md` / `CLAUDE.md`) with a pointer to the agent documentation and any conventions (branch naming, commit messages) the agent needs to follow.

--- a/skills/worktree-env-guide/SKILL.md
+++ b/skills/worktree-env-guide/SKILL.md
@@ -121,7 +121,7 @@ The package's `runSetupWorktree(config: SetupWorktreeConfig)` performs the lifec
 
 1. Looks up the branch in the slot registry to find the worktree path and slot.
 2. Verifies the branch is absent from the remote (skipped with `--no-remote-check`).
-3. Stops the dev server processes by reading every PID file in `config.devServerPidFiles` and killing the process group.
+3. Stops the dev server processes by scanning `<localWt>/*.pid` files in the target worktree and killing each process group.
 4. Calls optional `config.teardownInfrastructure(ctx)` — this is where Docker / database teardown lives (the kernel itself is Docker-agnostic).
 5. Frees the slot, drops the matching `dev-servers.json` entry, and removes the worktree via `git worktree remove --force`.
 
@@ -148,14 +148,12 @@ Running the script with no mode flag shows help.
 - `basePort` — required. The port that anchors the slot range. `8100` is the recommended default.
 - `portStep` (default `10`), `maxSlotCount` (default `19`).
 - `ports(slot)` or `portNames` — supply either a function returning the port map for a slot, or a list of names that defaults to consecutive ports (`{ name0: slot, name1: slot+1, ... }`).
+- `sharedDirs: string[]` — required. Directories symlinked from the main worktree (e.g. `[".local", ".plans"]`).
+- `localWt: string` — required. Per-worktree runtime directory relative to the worktree root (e.g. `.local-wt`). Holds the setup log, dev-server PID files, and dev-server logs.
 - `configFiles: Array<{ path, patch, required? }>` — one entry per gitignored config file. `patch(content, { slot, ports, mainWorktree, currentWorktree })` returns the rewritten content. Use `helpers.patchEnvFile` for `KEY=VALUE` files and `helpers.extractHost` to preserve non-localhost hosts.
-- `devServerPidFiles: string[]` — one entry per PID file your dev-server writes; used by `--remove` to stop the dev server cleanly.
-- `setupWorktreeData(ctx)` — required callback. Runs after symlinks and config files. Owns per-worktree directory creation (e.g. `mkdirSync(".local-wt/...")` at the top), database / file-storage provisioning, and infrastructure startup. Must end with a working database (see "Database provisioning" below).
-- `installAndBuild(ctx)` — required callback. `npm install && npm run build`, `pip install`, `cargo build`, etc.
-- `afterDatabase(ctx)` — optional. Migrations / seeding.
+- `finalizeWorktree(ctx)` — required callback. Runs in a detached background process after the foreground command returns. Owns infrastructure startup (e.g. `docker compose up -d`), database readiness wait, `npm install` / build, migrations, and seeding. **MUST be idempotent** — `setup-worktree --here` is the documented retry path and re-runs this same callback. Failures are logged to `<localWt>/wt-setup.log` with a `FAILED:` banner.
 - `teardownInfrastructure(ctx)` — optional. Called by `--remove`. The standard pattern is `docker compose down -v` if you use Docker.
-- `printSummary(ctx)` — required. Returns the string to print after setup completes.
-- `sharedDirs` — optional, overrides the default (`[".local", ".plans"]`).
+- `printSummary(ctx)` — required. Returns the string to print after the foreground phase (slot creation + symlinks + config files) completes.
 
 ### Database provisioning
 
@@ -181,7 +179,7 @@ This script starts the dev server in the background, waits for it to be ready, a
 
 A "dev server" can be a single process or several cooperating processes (e.g. an API watcher plus a frontend bundler). `runDevServer(config: DevServerConfig)` handles either case via `config.servers: ServerDescriptor[]` — one entry per process — but conceptually they form one dev server.
 
-Each `ServerDescriptor` is `{ name, exec: { command, args }, port, pidFile, logFile, detectSuccess, detectError? }`. `detectSuccess(logContent) => boolean` decides when the server is ready; `detectError(logContent) => string | false` (optional) returns the matched label of a fatal log pattern, or `false` if none. `port` is the resolved port number — read it from your project's existing config file with `helpers.readPortFromEnvFile(file, varName)` for `KEY=VALUE` `.env`-style files, or `helpers.readPortFromJsonFile(file, jsonPath)` for a dotted JSON path.
+Each `ServerDescriptor` is `{ name, exec: { command, args }, port, detectSuccess, detectError? }`. PID and log paths are derived from `config.localWt` + `name` (`<localWt>/<name>.pid` and `<localWt>/logs/<name>.log`). `detectSuccess(logContent) => boolean` decides when the server is ready; `detectError(logContent) => string | false` (optional) returns the matched label of a fatal log pattern, or `false` if none. `port` is the resolved port number — read it from your project's existing config file with `helpers.readPortFromEnvFile(file, varName)` for `KEY=VALUE` `.env`-style files, or `helpers.readPortFromJsonFile(file, jsonPath)` for a dotted JSON path.
 
 See [assets/dev-server.mjs](assets/dev-server.mjs) for a populated reference config.
 

--- a/skills/worktree-env-guide/SKILL.md
+++ b/skills/worktree-env-guide/SKILL.md
@@ -65,7 +65,7 @@ Each worktree gets a unique "slot" that determines its port(s). A central **slot
 
 The slot is identified by the primary port number itself (e.g., `--slot 8120`).
 
-**Registry format** (stored in a shared directory, e.g. `.local/worktrees/slots.json`):
+**Registry format** (stored in a shared directory, e.g. `.local/wt-registry/slots.json`):
 
 ```json
 {
@@ -82,7 +82,7 @@ The main worktree's port is implicit and never stored in the registry.
 
 Host RAM is shared. Without a cap, parallel dev-servers (especially when an AI bot fans out worktrees) can exhaust memory. The wrapper passes an optional `devLimit` number to `runDevServer`; omit it for no limit. A hardcoded `5` is a sensible default — bump it if your stack is light, lower it if it's heavy.
 
-A second registry, `.local/worktrees/dev-servers.json`, tracks live dev-servers. It lives in the main worktree's shared directory; linked worktrees reach it via the existing `.local` symlink. An entry is **live** if at least one PID in its `pids` map is alive; dead entries are pruned on every read. When `live >= limit`, `dev:up` aborts and lists the active servers (slot, branch, owner, pids, started-at, worktree path). Re-run with `dev:up --evict` to stop the oldest live dev-server across all worktrees and start the new one instead of aborting.
+A second registry, `.local/wt-registry/dev-servers.json`, tracks live dev-servers. It lives in the main worktree's shared directory; linked worktrees reach it via the existing `.local` symlink. An entry is **live** if at least one PID in its `pids` map is alive; dead entries are pruned on every read. When `live >= limit`, `dev:up` aborts and lists the active servers (slot, branch, owner, pids, started-at, worktree path). Re-run with `dev:up --evict` to stop the oldest live dev-server across all worktrees and start the new one instead of aborting.
 
 ### Config files must be gitignored
 
@@ -121,7 +121,7 @@ The package's `runSetupWorktree(config: SetupWorktreeConfig)` performs the lifec
 
 1. Looks up the branch in the slot registry to find the worktree path and slot.
 2. Verifies the branch is absent from the remote (skipped with `--no-remote-check`).
-3. Stops the dev server processes by scanning `<localWt>/*.pid` files in the target worktree and killing each process group.
+3. Stops the dev server processes by scanning `<runtimeDir>/*.pid` files in the target worktree and killing each process group.
 4. Calls optional `config.teardownInfrastructure(ctx)` — this is where Docker / database teardown lives (the kernel itself is Docker-agnostic).
 5. Frees the slot, drops the matching `dev-servers.json` entry, and removes the worktree via `git worktree remove --force`.
 
@@ -152,9 +152,10 @@ Running the script with no mode flag shows help.
 - `portStep` (default `10`), `maxSlotCount` (default `19`).
 - `ports(slot)` or `portNames` — supply either a function returning the port map for a slot, or a list of names that defaults to consecutive ports (`{ name0: slot, name1: slot+1, ... }`).
 - `sharedDirs: string[]` — required. Directories symlinked from the main worktree (e.g. `[".local", ".plans"]`).
-- `localWt: string` — required. Per-worktree runtime directory relative to the worktree root (e.g. `.local-wt`). Holds the setup log, dev-server PID files, and dev-server logs.
+- `runtimeDir: string` — required. Per-worktree runtime directory relative to the worktree root (e.g. `.local-wt`). Holds the setup log, dev-server PID files, and dev-server logs.
+- `registryDir: string` — required. Shared registry directory relative to a worktree root (e.g. `.local/wt-registry`). Holds `slots.json` and `dev-servers.json`. Must resolve to the same physical directory across linked worktrees — typically a subdirectory under a `sharedDirs` entry (e.g. `.local`).
 - `configFiles: Array<{ path, patch, required? }>` — one entry per gitignored config file. `patch(content, { slot, ports, mainWorktree, currentWorktree })` returns the rewritten content. Use `helpers.patchEnvFile` for `KEY=VALUE` files and `helpers.extractHost` to preserve non-localhost hosts.
-- `finalizeWorktree(ctx)` — required callback. Runs in a detached background process after the foreground command returns. Owns infrastructure startup (e.g. `docker compose up -d`), database readiness wait, `npm install` / build, migrations, and seeding. **MUST be idempotent** — `setup-worktree --here` is the documented retry path and re-runs this same callback. Failures are logged to `<localWt>/wt-setup.log` with a `FAILED:` banner.
+- `finalizeWorktree(ctx)` — required callback. Runs in a detached background process after the foreground command returns. Owns infrastructure startup (e.g. `docker compose up -d`), database readiness wait, `npm install` / build, migrations, and seeding. **MUST be idempotent** — `setup-worktree --here` is the documented retry path and re-runs this same callback. Failures are logged to `<runtimeDir>/wt-setup.log` with a `FAILED:` banner.
 - `teardownInfrastructure(ctx)` — optional. Called by `--remove`. The standard pattern is `docker compose down -v` if you use Docker.
 - `printSummary(ctx)` — required. Returns the string to print after the foreground phase (slot creation + symlinks + config files) completes.
 
@@ -182,7 +183,7 @@ This script starts the dev server in the background, waits for it to be ready, a
 
 A "dev server" can be a single process or several cooperating processes (e.g. an API watcher plus a frontend bundler). `runDevServer(config: DevServerConfig)` handles either case via `config.servers: ServerDescriptor[]` — one entry per process — but conceptually they form one dev server.
 
-Each `ServerDescriptor` is `{ name, exec: { command, args }, port, detectSuccess, detectError? }`. PID and log paths are derived from `config.localWt` + `name` (`<localWt>/<name>.pid` and `<localWt>/logs/<name>.log`). `detectSuccess(logContent) => boolean` decides when the server is ready; `detectError(logContent) => string | false` (optional) returns the matched label of a fatal log pattern, or `false` if none. `port` is the resolved port number — read it from your project's existing config file with `helpers.readPortFromEnvFile(file, varName)` for `KEY=VALUE` `.env`-style files, or `helpers.readPortFromJsonFile(file, jsonPath)` for a dotted JSON path.
+Each `ServerDescriptor` is `{ name, exec: { command, args }, port, detectSuccess, detectError? }`. PID and log paths are derived from `config.runtimeDir` + `name` (`<runtimeDir>/<name>.pid` and `<runtimeDir>/logs/<name>.log`). `detectSuccess(logContent) => boolean` decides when the server is ready; `detectError(logContent) => string | false` (optional) returns the matched label of a fatal log pattern, or `false` if none. `port` is the resolved port number — read it from your project's existing config file with `helpers.readPortFromEnvFile(file, varName)` for `KEY=VALUE` `.env`-style files, or `helpers.readPortFromJsonFile(file, jsonPath)` for a dotted JSON path.
 
 See [assets/dev-server.mjs](assets/dev-server.mjs) for a populated reference config.
 
@@ -348,6 +349,6 @@ The agents need to know:
 - [ ] **Write `dev-server`** using [assets/dev-server.mjs](assets/dev-server.mjs) as a starting point. Same approach.
 - [ ] **Add npm scripts** (or Makefile targets, etc.) for `setup-worktree`, `dev:up`, `dev:down`.
 - [ ] **Set the dev-server cap** by passing `devLimit` to `runDevServer` (default `5`).
-- [ ] **Update `.gitignore`** to ignore your shared and per-worktree directories (e.g. `.local/`, `.local-wt/`). Make sure `.local/worktrees/` is covered (slot registry and dev-server registry live there).
+- [ ] **Update `.gitignore`** to ignore your shared and per-worktree directories (e.g. `.local/`, `.local-wt/`). Make sure `.local/wt-registry/` is covered (slot registry and dev-server registry live there).
 - [ ] **Write agent documentation** if applicable (see [assets/agent-local-env.md](assets/agent-local-env.md)).
 - [ ] **Update your main instruction file** (`AGENTS.md` / `CLAUDE.md`) with a pointer to the agent documentation and any conventions (branch naming, commit messages) the agent needs to follow.

--- a/skills/worktree-env-guide/SKILL.md
+++ b/skills/worktree-env-guide/SKILL.md
@@ -139,12 +139,15 @@ The package's `runSetupWorktree(config: SetupWorktreeConfig)` performs the lifec
 | `--no-remote-check` | Skip remote branch verification when removing (use with `--remove` or `--remove-here`) |
 | `--slot PORT` | Use a specific slot instead of auto-assigning |
 | `--force` | Overwrite existing config files and re-provision the database |
+| `--wait` | Block until the background finalize reaches `READY:` (exit 0, prints the worktree summary) or `FAILED:` (exit 1). Uses the current worktree's slot, or `--slot PORT` to target another. Use for CI / agent orchestration |
+| `--info` | Print the summary (ports, branch, readiness) for the current worktree |
 | `--verbose` | Show intermediate output |
 
 Running the script with no mode flag shows help.
 
 **Config fields to populate:**
 
+- `scriptPath: string` — required. Absolute path to your wrapper script. Pass `fileURLToPath(import.meta.url)`. The package re-spawns this script for the detached finalize phase.
 - `basePort` — required. The port that anchors the slot range. `8100` is the recommended default.
 - `portStep` (default `10`), `maxSlotCount` (default `19`).
 - `ports(slot)` or `portNames` — supply either a function returning the port map for a slot, or a list of names that defaults to consecutive ports (`{ name0: slot, name1: slot+1, ... }`).

--- a/skills/worktree-env-guide/SKILL.md
+++ b/skills/worktree-env-guide/SKILL.md
@@ -82,7 +82,7 @@ The main worktree's port is implicit and never stored in the registry.
 
 Host RAM is shared. Without a cap, parallel dev-servers (especially when an AI bot fans out worktrees) can exhaust memory. The wrapper passes an optional `devLimit` number to `runDevServer`; omit it for no limit. A hardcoded `5` is a sensible default — bump it if your stack is light, lower it if it's heavy.
 
-A second registry, `.local/worktrees/dev-servers.json`, tracks live dev-servers. It lives in the main worktree's shared directory; linked worktrees reach it via the existing `.local` symlink. An entry is **live** if at least one PID in its `pids` map is alive; dead entries are pruned on every read. When `live >= limit`, `dev:up` aborts and lists the active servers (slot, branch, owner, pids, started-at, worktree path).
+A second registry, `.local/worktrees/dev-servers.json`, tracks live dev-servers. It lives in the main worktree's shared directory; linked worktrees reach it via the existing `.local` symlink. An entry is **live** if at least one PID in its `pids` map is alive; dead entries are pruned on every read. When `live >= limit`, `dev:up` aborts and lists the active servers (slot, branch, owner, pids, started-at, worktree path). Re-run with `dev:up --evict` to stop the oldest live dev-server across all worktrees and start the new one instead of aborting.
 
 ### Config files must be gitignored
 
@@ -188,7 +188,7 @@ See [assets/dev-server.mjs](assets/dev-server.mjs) for a populated reference con
 **Lifecycle:**
 
 1. Verifies that each server's `port` is not already in use.
-2. Reads `dev-servers.json`, prunes dead entries, and refuses to start when the live count meets `config.devLimit` (omitted = no limit).
+2. Reads `dev-servers.json`, prunes dead entries, and refuses to start when the live count meets `config.devLimit` (omitted = no limit). Pass `--evict` to stop the oldest live dev-server across all worktrees and proceed instead of aborting.
 3. Aborts if a sibling dev-server in this worktree is already running (PID file + alive check).
 4. Calls optional `config.ensureInfrastructure?.()` before any dev server. The standard Docker pattern is `docker compose up -d`; the kernel does no infrastructure I/O of its own.
 5. Iterates `config.servers`, spawning each as a detached process group with stdout/stderr to its log file and PID written to its PID file.
@@ -260,6 +260,7 @@ npm run dev:up     # Later, restart quickly
 ```sh
 npm run dev:list             # List active dev-servers across all worktrees
 npm run dev:down -- --all    # Stop every active dev-server (infrastructure stays up)
+npm run dev:up -- --evict    # If the cap is full, evict the oldest dev-server and start
 ```
 
 ### Creating a worktree without setup

--- a/skills/worktree-env-guide/assets/agent-local-env.md
+++ b/skills/worktree-env-guide/assets/agent-local-env.md
@@ -25,7 +25,7 @@ The script creates the worktree in the correct sibling directory, assigns a port
 
 ### Recovery from a Failed Setup
 
-If `--create` or `--use` fails (or the background finalize step fails — check `<localWt>/wt-setup.log`), the worktree is half-created. Do not delete it. Instead:
+If `--create` or `--use` fails (or the background finalize step fails — check `<runtimeDir>/wt-setup.log`), the worktree is half-created. Do not delete it. Instead:
 
     cd <worktree>
     npm run setup-worktree -- --here
@@ -98,5 +98,5 @@ npm run dev:down                     # 4. stop when done (same directory)
 
 <!-- ADAPT: List your shared and per-worktree directories. -->
 
-- **`.local/`** — Shared across worktrees (symlinked). Lightweight files: personal notes, `worktrees/slots.json` (slot registry; up to 19 linked-worktree slots + the implicit main worktree), `worktrees/dev-servers.json` (live dev-server registry).
+- **`.local/`** — Shared across worktrees (symlinked). Lightweight files: personal notes, `wt/slots.json` (slot registry; up to 19 linked-worktree slots + the implicit main worktree), `wt/dev-servers.json` (live dev-server registry).
 - **`.local-wt/`** — Per-worktree. Runtime data: databases, caches, PID files, `logs/` (dev server logs).

--- a/skills/worktree-env-guide/assets/agent-local-env.md
+++ b/skills/worktree-env-guide/assets/agent-local-env.md
@@ -15,13 +15,22 @@ When the user asks to "set up a new local environment" or "set up a new worktree
 ```sh
 npm run setup-worktree -- --create fix/123    # new branch + worktree (dedup: appends -2, -3… if taken)
 npm run setup-worktree -- --use fix/123       # new worktree on an existing branch
-npm run setup-worktree -- --here              # set up the current worktree
+npm run setup-worktree -- --here              # set up the current worktree (idempotent — also the retry path)
 ```
 
 <!-- ADAPT: Update the setup command if your project uses a different task runner.
      Document any project-specific ports or URLs the developer should know about. -->
 
 The script creates the worktree in the correct sibling directory, assigns a port slot, installs dependencies, builds, generates config files, and provisions the database.
+
+### Recovery from a Failed Setup
+
+If `--create` or `--use` fails (or the background finalize step fails — check `<localWt>/wt-setup.log`), the worktree is half-created. Do not delete it. Instead:
+
+    cd <worktree>
+    npm run setup-worktree -- --here
+
+`--here` is idempotent and will retry the finalize step. Repeat until the log ends with `READY: ...`.
 
 ### Slot Owner
 

--- a/skills/worktree-env-guide/assets/agent-local-env.md
+++ b/skills/worktree-env-guide/assets/agent-local-env.md
@@ -63,10 +63,10 @@ npm run dev:list         # List active dev-servers across all worktrees
 npm run dev:down -- --all # Stop every active dev-server
 ```
 
-<!-- ADAPT: Document where the log/PID files are stored (e.g., .local-data/).
+<!-- ADAPT: Document where the log/PID files are stored (e.g., .local-wt/).
      Mention any project-specific URLs to open after starting. -->
 
-Logs and PID files are stored in `.local-data/logs/` and `.local-data/` (per-worktree).
+Logs and PID files are stored in `.local-wt/logs/` and `.local-wt/` (per-worktree).
 
 The script detects port conflicts: it will refuse to start if a dev server is already running.
 
@@ -90,4 +90,4 @@ npm run dev:down                     # 4. stop when done (same directory)
 <!-- ADAPT: List your shared and per-worktree directories. -->
 
 - **`.local/`** — Shared across worktrees (symlinked). Lightweight files: personal notes, `worktrees/slots.json` (slot registry; up to 19 linked-worktree slots + the implicit main worktree), `worktrees/dev-servers.json` (live dev-server registry).
-- **`.local-data/`** — Per-worktree. Runtime data: databases, caches, PID files, `logs/` (dev server logs).
+- **`.local-wt/`** — Per-worktree. Runtime data: databases, caches, PID files, `logs/` (dev server logs).

--- a/skills/worktree-env-guide/assets/dev-server.mjs
+++ b/skills/worktree-env-guide/assets/dev-server.mjs
@@ -17,8 +17,8 @@ await runDevServer({
       name: "dev",                                          // ADAPT
       exec: { command: "npm", args: ["run", "dev"] },       // ADAPT
       port: helpers.readPortFromEnvFile(".env", "PORT"),    // ADAPT — or helpers.readPortFromJsonFile("config.json", "server.port")
-      pidFile: ".local-data/dev-server.pid",                // ADAPT
-      logFile: ".local-data/logs/dev-server.log",           // ADAPT
+      pidFile: ".local-wt/dev-server.pid",                // ADAPT
+      logFile: ".local-wt/logs/dev-server.log",           // ADAPT
       detectSuccess: (log) => log.includes("Server is ready on port"), // ADAPT
       // ADAPT: return the matched label, or false. Example with fatal markers:
       //   detectError: (log) => ["[ExceptionHandler]", "Node.js v"].find((m) => log.includes(m)) ?? false,
@@ -28,8 +28,8 @@ await runDevServer({
     //   name: "api",
     //   exec: { command: "npm", args: ["run", "watch:api"] },
     //   port: helpers.readPortFromEnvFile(".env", "SERVER_PORT"),
-    //   pidFile: ".local-data/api.pid",
-    //   logFile: ".local-data/logs/api.log",
+    //   pidFile: ".local-wt/api.pid",
+    //   logFile: ".local-wt/logs/api.log",
     //   detectSuccess: (log) => log.includes("API listening on"),
     //   detectError: (log) => log.includes("Node.js v") ? "Node.js v" : false,
     // },
@@ -37,8 +37,8 @@ await runDevServer({
     //   name: "front",
     //   exec: { command: "npm", args: ["run", "watch:front"] },
     //   port: helpers.readPortFromEnvFile(".env", "PORT"),
-    //   pidFile: ".local-data/front.pid",
-    //   logFile: ".local-data/logs/front.log",
+    //   pidFile: ".local-wt/front.pid",
+    //   logFile: ".local-wt/logs/front.log",
     //   detectSuccess: (log) => log.includes("ready in"),
     // },
   ],

--- a/skills/worktree-env-guide/assets/dev-server.mjs
+++ b/skills/worktree-env-guide/assets/dev-server.mjs
@@ -10,7 +10,8 @@ import { runDevServer, helpers } from "@paleo/worktree-env";
 
 await runDevServer({
   basePort: 8100, // ADAPT
-  localWt: ".local-wt", // Per-worktree runtime directory; pid/log paths derive from this + each server's name.
+  runtimeDir: ".local-wt", // Per-worktree runtime directory; pid/log paths derive from this + each server's name.
+  registryDir: ".local/wt-registry", // Shared registry dir (`slots.json`, `dev-servers.json`); reached via the `.local` symlink in linked worktrees.
   devLimit: 5,    // ADAPT — cap on concurrent dev-servers across worktrees; omit for no limit.
 
   servers: [

--- a/skills/worktree-env-guide/assets/dev-server.mjs
+++ b/skills/worktree-env-guide/assets/dev-server.mjs
@@ -10,6 +10,7 @@ import { runDevServer, helpers } from "@paleo/worktree-env";
 
 await runDevServer({
   basePort: 8100, // ADAPT
+  localWt: ".local-wt", // Per-worktree runtime directory; pid/log paths derive from this + each server's name.
   devLimit: 5,    // ADAPT — cap on concurrent dev-servers across worktrees; omit for no limit.
 
   servers: [
@@ -17,8 +18,6 @@ await runDevServer({
       name: "dev",                                          // ADAPT
       exec: { command: "npm", args: ["run", "dev"] },       // ADAPT
       port: helpers.readPortFromEnvFile(".env", "PORT"),    // ADAPT — or helpers.readPortFromJsonFile("config.json", "server.port")
-      pidFile: ".local-wt/dev-server.pid",                // ADAPT
-      logFile: ".local-wt/logs/dev-server.log",           // ADAPT
       detectSuccess: (log) => log.includes("Server is ready on port"), // ADAPT
       // ADAPT: return the matched label, or false. Example with fatal markers:
       //   detectError: (log) => ["[ExceptionHandler]", "Node.js v"].find((m) => log.includes(m)) ?? false,
@@ -28,8 +27,6 @@ await runDevServer({
     //   name: "api",
     //   exec: { command: "npm", args: ["run", "watch:api"] },
     //   port: helpers.readPortFromEnvFile(".env", "SERVER_PORT"),
-    //   pidFile: ".local-wt/api.pid",
-    //   logFile: ".local-wt/logs/api.log",
     //   detectSuccess: (log) => log.includes("API listening on"),
     //   detectError: (log) => log.includes("Node.js v") ? "Node.js v" : false,
     // },
@@ -37,8 +34,6 @@ await runDevServer({
     //   name: "front",
     //   exec: { command: "npm", args: ["run", "watch:front"] },
     //   port: helpers.readPortFromEnvFile(".env", "PORT"),
-    //   pidFile: ".local-wt/front.pid",
-    //   logFile: ".local-wt/logs/front.log",
     //   detectSuccess: (log) => log.includes("ready in"),
     // },
   ],

--- a/skills/worktree-env-guide/assets/setup-worktree.mjs
+++ b/skills/worktree-env-guide/assets/setup-worktree.mjs
@@ -8,25 +8,21 @@
 // =============================================================================
 
 import { execSync } from "node:child_process";
-import { mkdirSync } from "node:fs";
-import { basename, join } from "node:path";
+import { basename } from "node:path";
 import { runSetupWorktree, helpers } from "@paleo/worktree-env";
 
 // ALTERNATIVE: file-based DB (SQLite). Replace the Docker block in
-// `setupWorktreeData` and the `docker-compose.yml` configFile entry with a
+// `finalizeWorktree` and the `docker-compose.yml` configFile entry with a
 // copy from the main worktree:
 //
-//   import { cpSync, existsSync, readdirSync } from "node:fs";
-//   import { join } from "node:path";
-//   setupWorktreeData: ({ currentWorktree, mainWorktree, force }) => {
-//     const localData = join(currentWorktree, ".local-wt/data");
-//     const mainData = join(mainWorktree, ".local-wt/data");
-//     mkdirSync(localData, { recursive: true });
-//     if (readdirSync(localData).length > 0 && !force) return;
-//     if (!existsSync(mainData)) return;
+//   import { cpSync } from "node:fs";
+//   // inside finalizeWorktree, before install/build:
+//   const localData = join(currentWorktree, ".local-wt/data");
+//   const mainData = join(mainWorktree, ".local-wt/data");
+//   mkdirSync(localData, { recursive: true });
+//   if (readdirSync(localData).length === 0 && existsSync(mainData)) {
 //     cpSync(mainData, localData, { recursive: true, force: true });
-//   },
-//   teardownInfrastructure: undefined,
+//   }
 
 await runSetupWorktree({
   // ADAPT: anchor port for the slot range. 8100 is the safe default.
@@ -37,8 +33,12 @@ await runSetupWorktree({
   portNames: ["server", "frontend", "db"],
   // ports: (slot) => ({ server: slot, frontend: slot + 1, db: slot + 2 }),
 
-  // ADAPT: PID files written by the dev-server (must match dev-server.mjs).
-  devServerPidFiles: [".local-wt/dev-server.pid"],
+  // ADAPT: directories symlinked from the main worktree.
+  sharedDirs: [".local", ".plans"],
+
+  // Per-worktree runtime directory. The package writes the setup log,
+  // pid files, and dev-server logs under here.
+  localWt: ".local-wt",
 
   // ADAPT: gitignored config files copied from the main worktree and patched
   // per slot. The source is the same path in the main worktree.
@@ -69,10 +69,13 @@ await runSetupWorktree({
     },
   ],
 
-  // ADAPT: per-worktree data setup. Runs after symlinks and config files.
-  // Create any required directories first, then provision DB / file storage.
-  setupWorktreeData: async ({ currentWorktree }) => {
-    mkdirSync(join(currentWorktree, ".local-wt"), { recursive: true });
+  // ADAPT: Detached finalization step. Runs in the background after the
+  // worktree is created and the foreground command has returned.
+  //
+  // MUST BE IDEMPOTENT — `setup-worktree --here` is the documented retry
+  // path. Guard each block against pre-existing state so re-runs are no-ops.
+  finalizeWorktree: async ({ currentWorktree }) => {
+    // `docker compose up -d` is already idempotent.
     execSync("docker compose up -d", { stdio: "inherit", cwd: currentWorktree });
     const deadline = Date.now() + 30_000;
     while (Date.now() < deadline) {
@@ -81,12 +84,17 @@ await runSetupWorktree({
           stdio: "pipe",
           cwd: currentWorktree,
         });
-        return;
+        break;
       } catch {
         await new Promise((r) => setTimeout(r, 1000));
       }
     }
-    throw new Error("Database did not become ready within 30s.");
+    // `npm install` and `npm run build` are idempotent.
+    execSync("npm install", { stdio: "inherit", cwd: currentWorktree });
+    execSync("npm run build", { stdio: "inherit", cwd: currentWorktree });
+    // Migrations are idempotent; seeds typically guard on existing rows.
+    execSync("npm run migrate", { stdio: "inherit", cwd: currentWorktree });
+    execSync("npm run seed", { stdio: "inherit", cwd: currentWorktree });
   },
 
   // ADAPT: Docker teardown. Called by --remove. Drop on a non-Docker stack.
@@ -96,18 +104,6 @@ await runSetupWorktree({
     } catch {
       // container may not exist
     }
-  },
-
-  // ADAPT
-  installAndBuild: ({ currentWorktree }) => {
-    execSync("npm install", { stdio: "inherit", cwd: currentWorktree });
-    execSync("npm run build", { stdio: "inherit", cwd: currentWorktree });
-  },
-
-  // ADAPT
-  afterDatabase: ({ currentWorktree }) => {
-    execSync("npm run migrate", { stdio: "inherit", cwd: currentWorktree });
-    execSync("npm run seed", { stdio: "inherit", cwd: currentWorktree });
   },
 
   // ADAPT

--- a/skills/worktree-env-guide/assets/setup-worktree.mjs
+++ b/skills/worktree-env-guide/assets/setup-worktree.mjs
@@ -9,6 +9,7 @@
 
 import { execSync } from "node:child_process";
 import { basename } from "node:path";
+import { fileURLToPath } from "node:url";
 import { runSetupWorktree, helpers } from "@paleo/worktree-env";
 
 // ALTERNATIVE: file-based DB (SQLite). Replace the Docker block in
@@ -26,6 +27,10 @@ import { runSetupWorktree, helpers } from "@paleo/worktree-env";
 //   }
 
 await runSetupWorktree({
+  // Required. The package re-spawns this script for the detached finalize phase, so it must know
+  // where it lives. Leave this line as-is — `import.meta.url` always resolves to this file.
+  scriptPath: fileURLToPath(import.meta.url),
+
   // ADAPT: anchor port for the slot range. 8100 is the safe default.
   basePort: 8100,
 

--- a/skills/worktree-env-guide/assets/setup-worktree.mjs
+++ b/skills/worktree-env-guide/assets/setup-worktree.mjs
@@ -19,8 +19,8 @@ import { runSetupWorktree, helpers } from "@paleo/worktree-env";
 //   import { cpSync, existsSync, readdirSync } from "node:fs";
 //   import { join } from "node:path";
 //   setupWorktreeData: ({ currentWorktree, mainWorktree, force }) => {
-//     const localData = join(currentWorktree, ".local-data/data");
-//     const mainData = join(mainWorktree, ".local-data/data");
+//     const localData = join(currentWorktree, ".local-wt/data");
+//     const mainData = join(mainWorktree, ".local-wt/data");
 //     mkdirSync(localData, { recursive: true });
 //     if (readdirSync(localData).length > 0 && !force) return;
 //     if (!existsSync(mainData)) return;
@@ -38,7 +38,7 @@ await runSetupWorktree({
   // ports: (slot) => ({ server: slot, frontend: slot + 1, db: slot + 2 }),
 
   // ADAPT: PID files written by the dev-server (must match dev-server.mjs).
-  devServerPidFiles: [".local-data/dev-server.pid"],
+  devServerPidFiles: [".local-wt/dev-server.pid"],
 
   // ADAPT: gitignored config files copied from the main worktree and patched
   // per slot. The source is the same path in the main worktree.
@@ -72,7 +72,7 @@ await runSetupWorktree({
   // ADAPT: per-worktree data setup. Runs after symlinks and config files.
   // Create any required directories first, then provision DB / file storage.
   setupWorktreeData: async ({ currentWorktree }) => {
-    mkdirSync(join(currentWorktree, ".local-data"), { recursive: true });
+    mkdirSync(join(currentWorktree, ".local-wt"), { recursive: true });
     execSync("docker compose up -d", { stdio: "inherit", cwd: currentWorktree });
     const deadline = Date.now() + 30_000;
     while (Date.now() < deadline) {

--- a/skills/worktree-env-guide/assets/setup-worktree.mjs
+++ b/skills/worktree-env-guide/assets/setup-worktree.mjs
@@ -44,7 +44,12 @@ await runSetupWorktree({
 
   // Per-worktree runtime directory. The package writes the setup log,
   // pid files, and dev-server logs under here.
-  localWt: ".local-wt",
+  runtimeDir: ".local-wt",
+
+  // Shared registry directory holding `slots.json` and `dev-servers.json`.
+  // Must resolve to the same physical directory across linked worktrees —
+  // typically via a symlink listed in `sharedDirs` (e.g. `.local`).
+  registryDir: ".local/wt-registry",
 
   // ADAPT: gitignored config files copied from the main worktree and patched
   // per slot. The source is the same path in the main worktree.

--- a/skills/worktree-env-guide/assets/setup-worktree.mjs
+++ b/skills/worktree-env-guide/assets/setup-worktree.mjs
@@ -15,7 +15,8 @@ import { runSetupWorktree, helpers } from "@paleo/worktree-env";
 // `finalizeWorktree` and the `docker-compose.yml` configFile entry with a
 // copy from the main worktree:
 //
-//   import { cpSync } from "node:fs";
+//   import { cpSync, existsSync, mkdirSync, readdirSync } from "node:fs";
+//   import { join } from "node:path";
 //   // inside finalizeWorktree, before install/build:
 //   const localData = join(currentWorktree, ".local-wt/data");
 //   const mainData = join(mainWorktree, ".local-wt/data");
@@ -78,17 +79,20 @@ await runSetupWorktree({
     // `docker compose up -d` is already idempotent.
     execSync("docker compose up -d", { stdio: "inherit", cwd: currentWorktree });
     const deadline = Date.now() + 30_000;
+    let ready = false;
     while (Date.now() < deadline) {
       try {
         execSync("docker compose exec database pg_isready", {
           stdio: "pipe",
           cwd: currentWorktree,
         });
+        ready = true;
         break;
       } catch {
         await new Promise((r) => setTimeout(r, 1000));
       }
     }
+    if (!ready) throw new Error("Database did not become ready within 30s.");
     // `npm install` and `npm run build` are idempotent.
     execSync("npm install", { stdio: "inherit", cwd: currentWorktree });
     execSync("npm run build", { stdio: "inherit", cwd: currentWorktree });


### PR DESCRIPTION
- Split `runSetupWorktree` into a fast foreground Part 1 and a detached Part 2 that finalizes via a hidden `--__finalize <slot>` subcommand, streaming progress to `<localWt>/wt-setup.log` and ending with a `READY:` or `FAILED:` banner.
- Replace `setupWorktreeData`, `installAndBuild`, and `afterDatabase` with a single idempotent `finalizeWorktree(ctx)` hook; make `sharedDirs` and `localWt` required in `SetupWorktreeConfig`.
- Add `createdAt` and `ready` to `SlotEntry`, preserved across `--here` re-runs; document the `--here` recovery path for failed finalization.
- Drop `pidFile` / `logFile` from `ServerDescriptor` and `devServerPidFiles` from the setup config; derive pid and log paths from `<localWt>/<name>` and scan `<localWt>/*.pid` on `--remove`.
- Add `dev-server --evict` to stop the oldest live dev-server across worktrees when the cap is reached, with a new `evictOldest` registry helper and updated cap error hint.
- Update `worktree-env` README and the `worktree-env-guide` skill (SKILL.md, `setup-worktree.mjs`, `dev-server.mjs`, `agent-local-env.md`) to reflect the new config shape, recovery flow, and `--evict` usage.
