### PR TITLE
feat: move registry dir in runtimeDir

### DIFF
--- a/.changeset/derive-registry-dir.md
+++ b/.changeset/derive-registry-dir.md
@@ -1,5 +1,0 @@
----
-"@paleo/workspace": minor
----
-
-Remove `registryDir`. The registry is now derived as `${runtimeDir}/shared-registry`, auto-symlinked per linked worktree by `workspace setup`. To migrate an existing registry: `workspace migrate-0.16 <old-registryDir>`.

--- a/.changeset/derive-registry-dir.md
+++ b/.changeset/derive-registry-dir.md
@@ -1,0 +1,5 @@
+---
+"@paleo/workspace": minor
+---
+
+Remove `registryDir`. The registry is now derived as `${runtimeDir}/shared-registry`, auto-symlinked per linked worktree by `workspace setup`. To migrate an existing registry: `workspace migrate-0.16 <old-registryDir>`.

--- a/.changeset/init-adds-scripts.md
+++ b/.changeset/init-adds-scripts.md
@@ -1,5 +1,0 @@
----
-"@paleo/openclaw-test": minor
----
-
-`init` now adds the four `package.json` scripts (`env:build`, `env:up`, `env:down`, `e2e`) when missing — existing scripts are never overwritten — and prints the next steps. Simplified README.

--- a/.changeset/init-adds-scripts.md
+++ b/.changeset/init-adds-scripts.md
@@ -1,0 +1,5 @@
+---
+"@paleo/openclaw-test": minor
+---
+
+`init` now adds the four `package.json` scripts (`env:build`, `env:up`, `env:down`, `e2e`) when missing — existing scripts are never overwritten — and prints the next steps. Simplified README.

--- a/openclaw-coder/playbook-test/projects-fixture/template/docs/workspace.md
+++ b/openclaw-coder/playbook-test/projects-fixture/template/docs/workspace.md
@@ -140,8 +140,7 @@ When the user asks to create a PR:
 
 ## Directory Layout
 
-- **`.local/`** — Shared across worktrees (symlinked). It's the right place for any gitignored working files (e.g., personal notes).
-  - `_workspace-registry/slots.json` — Slot registry; main worktree at slot 6500 plus linked-worktree slots 6510 → 6690 (step 10).
-  - `_workspace-registry/dev-servers.json` — Live dev-server registry.
-- **`.local-wt/`** — Per-worktree. Runtime data: `s3/` (file storage), `logs/` (dev server logs, `workspace-setup.log`).
+- **`.local/`** — Shared across worktrees (symlinked). It's the right place for any gitignored working files (e.g. personal notes…).
+- **`.local-wt/`** — Per-worktree. Runtime data: databases, caches, `logs/` (dev server logs).
+  - `shared-registry/` — The workspace registry. Symlinked to the main worktree in linked worktrees.
 - **`.plans/`** — Shared across worktrees (symlinked). Task planning files.

--- a/package-lock.json
+++ b/package-lock.json
@@ -17042,7 +17042,7 @@
     },
     "packages/openclaw-test": {
       "name": "@paleo/openclaw-test",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "~0.98.0",
@@ -22061,7 +22061,7 @@
     },
     "packages/workspace": {
       "name": "@paleo/workspace",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "CC0-1.0",
       "devDependencies": {
         "@types/node": "~24.12.4",

--- a/packages/openclaw-test/CHANGELOG.md
+++ b/packages/openclaw-test/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @paleo/openclaw-test
 
+## 0.11.0
+
+### Minor Changes
+
+- 4107ff1: `init` now adds the four `package.json` scripts (`env:build`, `env:up`, `env:down`, `e2e`) when missing — existing scripts are never overwritten — and prints the next steps. Simplified README.
+
 ## 0.10.0
 
 ### Minor Changes

--- a/packages/openclaw-test/README.md
+++ b/packages/openclaw-test/README.md
@@ -12,18 +12,7 @@ For internals (topology, Dockerfile pair, mocked-CLI shim, channel plugin mechan
 npm i -D @paleo/openclaw-test @paleo/openclaw-channel-mock-core @paleo/openclaw-discord-mock @paleo/openclaw-slack-mock openclaw
 ```
 
-Requires Docker Compose v2.20+ (overlay uses Compose `include:`).
-
-Wire `package.json` scripts:
-
-```json
-"scripts": {
-  "env:build": "openclaw-test env build",
-  "env:up":    "openclaw-test env up",
-  "env:down":  "openclaw-test env down",
-  "e2e":      "openclaw-test run"
-}
-```
+Requires Docker Compose.
 
 ## Init
 
@@ -31,60 +20,58 @@ Wire `package.json` scripts:
 npx @paleo/openclaw-test init <project-dir>
 ```
 
-Drops four files:
+Adds the four `package.json` scripts (`env:build`, `env:up`, `env:down`, `e2e`) if missing, and drops four files:
 
 - `openclaw.json` — gateway config (mode `local`, both channel plugins enabled, main agent placeholder).
-- `.env.local.example` — copy to `.env.local`, fill `ANTHROPIC_API_KEY` + `OPENCLAW_WORKSPACE_DIR`.
-- `docker-compose.yml` — thin overlay that `include:`s the base from `node_modules/`.
-- `Dockerfile` — consumer-owned. Inherits the base via `FROM paleo/openclaw-test-base:${OPENCLAW_TEST_BASE_TAG}`. Add `RUN`/`COPY`/`ENV` for consumer-specific setup (extra system packages, skills install, etc.).
+- `.env.local.example` — copy to `.env.local` and fill in; its comments document every variable.
+- `docker-compose.yml` — thin overlay that `include:`s the base stack from `node_modules/`.
+- `Dockerfile` — consumer-owned; its comments document the common customizations (system tools, mock-CLI symlinks, fixtures, reset scripts).
 
 ## Configure
 
 Edit `openclaw.json`:
 
-- `agents.list[id=main].model` — LiteLLM-style `provider/model` ref. The default boot model; `run --model` overrides it per run by rendering the chosen ref here before the gateway boots (see [Run](#run)).
-- `agents.list[id=main].workspace` — host path to your OpenClaw workspace, bind-mounted into the gateway. Field name is **`workspace`**, not `workspaceDir`.
-- `channels.*` — both `discord-mock` and `slack-mock` blocks point at the same bus.
-- `channels.slack-mock.blockStreaming: true` — set this when running Slack scenarios under auto-thread (`replyToMode: "all"`), otherwise the agent's reply dribbles into the thread token-by-token. Discord-mock works fine without it.
-
-Drop scenarios under `scenarios/<id>.ts`. Project fixtures and their reset logic are consumer concerns — ship a reset script in your consumer image and invoke it from scenarios via `ctx.execInGateway(...)`. See [openclaw-test-architecture.md](https://github.com/paleo/alignfirst/blob/main/docs/openclaw-test-architecture.md) for the exec RPC contract.
-
-Scenarios are loaded by Node 24's built-in TypeScript stripping. Stick to the strip-compatible subset (no `enum`, `namespace`, decorators, ctor parameter properties, `import =`). Shared helpers go under `scenarios/_lib/` — `discoverScenarios()` skips directories.
+- `agents.list[id=main].model` — default `provider/model` ref; `run --model` overrides it per run.
+- `agents.list[id=main].workspace` — host path to your OpenClaw workspace. Field name is **`workspace`**, not `workspaceDir`.
+- `channels.slack-mock.blockStreaming: true` — set this when running Slack scenarios under auto-thread, otherwise the agent's reply dribbles into the thread token-by-token.
 
 ## Env vars (`.env.local`)
 
-Required:
+```sh
+ANTHROPIC_API_KEY=sk-ant-…
+OPENCLAW_WORKSPACE_DIR=/path/to/your/openclaw-workspace
 
-- `ANTHROPIC_API_KEY`
-- `OPENCLAW_WORKSPACE_DIR` — host path mounted at `/home/claw/.openclaw/workspace`.
+# Model catalog: full LiteLLM refs. `run --model` picks by bare id (suffix after the last "/").
+OPENCLAW_TEST_MODELS=anthropic/claude-sonnet-4-6,custom-openrouter/qwen/qwen3.6-plus
+OPENCLAW_DEFAULT_TEST_MODEL=claude-sonnet-4-6
 
-Model selection:
+# Required only when running an OpenRouter model.
+OPENROUTER_API_KEY=
+```
 
-- `OPENCLAW_TEST_MODELS` — comma list of full LiteLLM `provider/model` refs (the only place the `provider/` prefix appears). The catalog `run --model` resolves against.
-- `OPENCLAW_DEFAULT_TEST_MODEL` — default model as a **bare id** (the suffix after the last `/`, e.g. `claude-sonnet-4-6`), used when `--model` is omitted.
+See `.env.local.example` for the optional overrides (paths, raw stream log).
 
-Provider keys (required only when running that provider's model; harmlessly empty otherwise):
+## Scenarios
 
-- `OPENROUTER_API_KEY` — OpenRouter (Qwen 3.6 Plus, OpenAI-compatible endpoint). Custom providers have no env-var convention in OpenClaw, so the key is referenced from `openclaw.json` as `${OPENROUTER_API_KEY}` and expanded by the CLI at render time.
+Drop scenarios under `scenarios/<id>.ts`: each default-exports `async (ctx: ScenarioContext) => void`. They are loaded by Node's built-in TypeScript stripping: no `enum`, `namespace`, decorators, ctor parameter properties. Shared helpers must go under subdirectories (e.g. `scenarios/_lib/`).
 
-Optional (defaults relative to the consumer's project dir):
+Project fixtures and their reset logic are consumer concerns — ship a reset script in your consumer image and invoke it via `ctx.execInGateway(...)`.
 
-- `OPENCLAW_CONFIG_PATH` → `./openclaw.json`
-- `OPENCLAW_TEST_SCENARIOS_DIR` → `./scenarios`
-- `OPENCLAW_TEST_ARTIFACTS_DIR` → `./artifacts`
-- `OPENCLAW_TEST_GATEWAY_LOGS_DIR` → `./.gateway-logs`
-- `OPENCLAW_RAW_STREAM=1` — also write `raw-stream.jsonl` alongside the always-on provider-neutral trajectory log (`trajectory/<sessionId>.jsonl`).
+`ScenarioContext` primitives (authoritative types: `src/context.ts`):
 
-`OPENCLAW_TEST_PROJECT_DIR`, `OPENCLAW_TEST_PACKAGE_DIR`, `CLAW_UID`, `CLAW_GID` are injected by the CLI.
+- `channel`, `conversationId`, `accountId` — per-task isolation; never hard-code a conversation id.
+- `sendInbound(input)` — push an inbound message on the bus.
+- `waitForOutbound(predicate, opts)` — await a matching outbound; fails fast on unmatched outbounds or mock-CLI silence.
+- `poll`, `expectNoOutbound`, `getCursor` — bus consumers.
+- `assertRegex`, `assertEqual`, `assertLength` — structural assertions.
+- `judgeLLM({ message, rubric, label, attachTo? })` — LLM judgement, bound to an action entry.
+- `mockCli(name, handler)` — intercept the gateway's CLI calls (`git`, `claude`, …); unregistered calls fail the scenario.
+- `execInGateway(argv, opts)` — run a command inside the gateway container.
+- `log(...)` — scenario log entry, free-standing or attached to an action.
 
-## Consumer Dockerfile responsibilities
+Prefer structural assertions over `judgeLLM`; reserve the judge for free-form content claims.
 
-The base image ships only Node, the mock-cli shim binary, and the exec watcher. Your consumer `Dockerfile` adds whatever the fixture needs:
-
-- Install runtime tools your scripts/agents shell out to (e.g. `RUN apk add --no-cache git`, `RUN corepack enable && corepack prepare pnpm@latest --activate`).
-- Create the per-command mock-cli symlinks you want intercepted, e.g. `RUN for name in claude gh; do ln -sf mock-cli-shim "/opt/openclaw-test/mocks/bin/$name"; done`.
-- Ship any reset/seed scripts you'll invoke via `ctx.execInGateway(...)` (e.g. `COPY scripts/ /opt/openclaw-test/scripts/`).
-- Declare per-fixture named volumes in your compose overlay (e.g. a `fixture-projects` volume mounted at `/home/claw/projects`).
+Examples: [openclaw-coder/playbook-test/scenarios](https://github.com/paleo/alignfirst/tree/main/openclaw-coder/playbook-test/scenarios).
 
 ## Run
 
@@ -103,75 +90,22 @@ npm run env:up                                                     # (optional) 
 npm run env:down                                                   # tear down a warm stack
 ```
 
-`run` auto-starts `bus` + `gateway` via Docker Compose if they aren't running, and auto-`down`s them after the run completes. If you've explicitly run `env:up` beforehand, `run` leaves the stack up so subsequent runs are fast. Ctrl-C is forwarded to the running container; auto-`down` still runs. If the base image needs (re)building, any already-running bus+gateway are torn down first so the new image is picked up.
+`run` auto-starts bus + gateway and tears them down after the run; an explicit `env:up` beforehand keeps the stack warm across runs.
 
-**Model selection.** `--model <id|id,id,…|all>` picks the agent model(s): a **bare id** (the suffix after the last `/`), a comma list of bare ids (deduped, CLI order preserved), or `all` (alphabetical). Each id resolves to a full ref by suffix-matching `OPENCLAW_TEST_MODELS`, then the CLI renders that ref into `agents.list[id=main].model` of a run-scoped config the gateway boots on (the canonical `openclaw.json` is never mutated). Omitting `--model` uses `OPENCLAW_DEFAULT_TEST_MODEL`. Model is the **outermost** matrix dimension — each model's whole sweep runs before the next, so the gateway reboots only once per model (cheap under `--reuse-stack`), and an explicit `--model` list runs in CLI order (e.g. `qwen3.6-plus,claude-sonnet-4-6` runs qwen first). The model is stamped into the artifact dir name, `report.json`, the cell record, and the summary; the total-cost line breaks down per model. The artifact dir name orders segments `scenario → model → channel`, so listings group a scenario's models side-by-side regardless of run order. Every selected provider needs its API key present.
+Rebuild (`npm run env:build`) after editing `openclaw.json` or the `Dockerfile`, or after bumping any `@paleo/openclaw-*` dependency.
 
-**Per-cell hygiene.** The host owns the matrix loop. Between cells (`scenario × channel × model × iteration`) it issues `docker compose up -d --force-recreate --wait bus gateway`, replacing both containers — the gateway for fresh in-process state, the bus to drop any cross-cell event history. The first cell skips recreation only when `run` itself just brought the stack up (`wereUpBefore === false`). Realistic per-cell recreation overhead: 10–25 s on a healthy box; up to ~40 s under load. `--reuse-stack` opts out entirely (fast, but only safe when you vouch for no cross-cell state leak).
-
-`env:build` first builds the base image (`paleo/openclaw-test-base:<pkg-version>`) from this package's `Dockerfile.base`, then builds the consumer image. Layer cache makes repeat base builds near-free; `env:up` / `run` skip the base build when the tag already exists.
-
-Rebuild required after: bumping any `@paleo/openclaw-*` dependency, edits to `openclaw.json`, or any change to the consumer `Dockerfile`.
-
-Scenarios run **serially** through one gateway. Exit 0 iff every pair passes.
-
-## Scenario primitives
-
-From `@paleo/openclaw-test` (`src/context.ts`):
-
-- `channel`, `conversationId`, `accountId` — per-task isolation. Use `ctx.conversationId` everywhere; never hard-code a value.
-- `sendInbound(input)` → `{ message, entry }`. Push an inbound on the bus; `entry` is the `inboundSent` `ActionEntry` to which assertions/logs can be attached.
-- `poll`, `expectNoOutbound` — bus consumers.
-- `waitForOutbound(predicate, opts)` → `{ match, entry, nextCursor }`. `entry` is the `outboundReceived` `ActionEntry`; pass it as `attachTo` to bind judges and attached logs to that specific outbound. Two fail-fast signals are on by default; pass `false` per option to disable:
-  - `failFastUnmatchedOutbounds` (default `3`) — fail when this many outbounds arrive without satisfying the predicate.
-  - `failFastCliMockGraceMs` (default `10_000`) — fail when this long elapses after the most recent `cliMock` with no matching outbound. Each new `cliMock` resets the timer.
-- `assertRegex`, `assertEqual`, `assertLength` — structural assertions. Silent on success; on failure, the assertion record and a `failure` field land on the **current entry** (most recent agent-action entry).
-- `judgeLLM({ attachTo?, message, rubric, label })` — Anthropic-direct judgement. Pass `attachTo: entry` to bind the result to a specific action; otherwise it attaches to the **current entry**. `inboundSent` (scenario-emitted) never becomes the current entry — only agent-action entries (`outboundReceived`, `cliMock`, `agentToolCall`) do.
-- `mockCli(name, handler)` — intercepts the gateway's calls to `git` / `npm` / `pnpm` / `yarn` / `claude`. Unregistered calls fail the scenario with `failure.source = "cliMock"`.
-- `execInGateway(argv, { cwd?, env?, stdin?, timeoutMs? })` → `{ exitCode, stdout, stderr }`. Runs a command inside the gateway container via the exec watcher. Always resolves on completion (non-zero exits do not throw); throws only on transport failure or hard timeout. Typical use: invoke a consumer-shipped reset script (`/opt/openclaw-test/scripts/reset-fixture.mjs`) at the top of a scenario.
-- `log(message)` or `log({ attachTo, label?, extra? })` — free-standing `scenarioLog` entry, or a `scenarioLog` note attached to an action entry. `extra` holds any JSON-serializable annotation; the entry's own `text` is not echoed.
-- `getCursor`.
-
-Prefer structural assertions over `judgeLLM`; reserve the judge for free-form content claims.
-
-**Rule of thumb**: when in doubt, pass `attachTo` explicitly. Use the entry returned by `waitForOutbound` / `sendInbound`, or snapshot `ctx.currentEntry` synchronously after the relevant `await` resolves and hand that snapshot to the judge call.
-
-## Judge model
-
-Defaults to `anthropic/claude-haiku-4-5`. Override via `OPENCLAW_TEST_JUDGE_MODEL` on the `runner` service (set in your consumer overlay). The ref must be LiteLLM-style; only the `anthropic/` provider is wired up today. The judge is **not** an OpenClaw agent — don't configure it in `openclaw.json`.
-
-## Artifacts
-
-`artifacts/<runStamp>/<scenario>-<modelId>-<channel>[-#<NN>][-<VERDICT>]/`:
-
-- `scenario-log.jsonl` — appended live (one `ReportEntry` per line), survives a runner crash. Re-emits an entry every time a nested field is added; last write wins per `seq`.
-- `report.json` — final `ScenarioReport`. Merges `scenario-log.jsonl` with `agentToolCall` entries parsed from the provider-neutral trajectory log; adds per-scenario `cost` (also sourced from the trajectory log).
-
-`<modelId>` is the selected model's bare id. `-#<NN>` is the iteration index, prefixed with `#` so it can't be mistaken for a trailing digit of the model id (omitted when `--iterations 1`). `<VERDICT>` is `PASS` / `FAIL`, applied by **renaming the directory** after `report.json` is written. A directory with no verdict suffix means the run is pending or crashed before rename.
-
-Each cell also writes `artifacts/<runStamp>/cells/<scenario>-<modelId>-<channel>[-#<NN>].json` (the `CellResult` host-aggregation contract — `schemaVersion: 2`, verdict, model, cost, durations, judge usages). The host loop reads these to produce the summary and total-cost lines independently of the artifact-dir rename. A missing or invalid file counts the cell as a failure with a logged warning.
-
-Authoritative types: `src/report.ts`.
+Scenarios run serially through one gateway. Exit 0 iff every pair passes. Artifacts land under `artifacts/<runStamp>/` — see the [architecture doc](https://github.com/paleo/alignfirst/blob/main/docs/openclaw-test-architecture.md).
 
 ## Channels
 
-Both `discord-mock` and `slack-mock` register on every boot. Pick which to drive per scenario via `--channel discord-mock|slack-mock|all`.
+- `discord-mock` — full Discord-shaped surface; no auto-thread.
+- `slack-mock` — restricted Slack-shaped surface (`react` / `read` / `edit` / `delete` / `reactions` / `search`); bare-channel inbounds auto-thread on the triggering message.
 
-- `discord-mock` — full Discord-shaped surface; `thread-create` posts an optional body atomically.
-- `slack-mock` — restricted Slack-shaped surface (`react` / `read` / `edit` / `delete` / `reactions` / `search`). Bare-channel inbounds auto-thread on the triggering message.
+Assert on `conversation.id` / `threadId`, not envelope formatting.
 
-Inbound metadata claims `Provider` / `Surface` / `OriginatingChannel` = the registered channel id so the SDK routes tool-schema discovery to the right plugin. Assert on `conversation.id` / `threadId`, not envelope formatting.
+## Judge model
 
-## Target format
-
-Canonical destination param is `to`. Accepted shapes:
-
-- `channel:<id>` or bare `<id>` (channel)
-- `dm:<id>`
-- `group:<id>`
-- `thread:<channelId>/<threadId>`
-
-Actions resolve `to → target → channelId`.
+Defaults to `anthropic/claude-haiku-4-5`. Override via `OPENCLAW_TEST_JUDGE_MODEL` on the `runner` service (set in your consumer overlay). The judge is **not** an OpenClaw agent — don't configure it in `openclaw.json`.
 
 ## Attribution
 

--- a/packages/openclaw-test/package.json
+++ b/packages/openclaw-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paleo/openclaw-test",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Dockerised regression-test framework for OpenClaw workspaces: bus, scenario driver, judge, Compose stack.",
   "keywords": [
     "openclaw",

--- a/packages/openclaw-test/src/cli.ts
+++ b/packages/openclaw-test/src/cli.ts
@@ -1,4 +1,4 @@
-import { copyFile, mkdir, readdir } from "node:fs/promises";
+import { copyFile, mkdir, readdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { startBus } from "./bus.js";
@@ -7,6 +7,13 @@ import { main as runnerMain } from "./runner.js";
 
 // `dist/cli.js` ships under `<package>/dist/`; one level up from its dir is the package root.
 const PACKAGE_DIR = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+const INIT_SCRIPTS: Record<string, string> = {
+  "env:build": "openclaw-test env build",
+  "env:up": "openclaw-test env up",
+  "env:down": "openclaw-test env down",
+  e2e: "openclaw-test run",
+};
 
 export async function dispatch(argv: string[]): Promise<void> {
   const [cmd, ...rest] = argv;
@@ -41,6 +48,55 @@ async function initCommand(targetDirRaw: string | undefined): Promise<void> {
     await copyFile(join(templatesDir, name), join(target, name));
     console.log(`copied ${name} -> ${join(target, name)}`);
   }
+  await addScriptsToPackageJson(target);
+  printNextSteps();
+}
+
+async function addScriptsToPackageJson(target: string): Promise<void> {
+  const pkgPath = join(target, "package.json");
+  let raw: string;
+  try {
+    raw = await readFile(pkgPath, "utf8");
+  } catch {
+    console.log(
+      "no package.json found — run `npm init`, then add the scripts manually (see README)",
+    );
+    return;
+  }
+  const pkg = JSON.parse(raw) as PackageJsonScripts;
+  const added = addInitScripts(pkg);
+  if (added.length === 0) {
+    console.log("package.json scripts already present");
+    return;
+  }
+  await writeFile(pkgPath, `${JSON.stringify(pkg, undefined, 2)}\n`);
+  console.log(`added scripts to package.json: ${added.join(", ")}`);
+}
+
+export interface PackageJsonScripts {
+  scripts?: Record<string, string>;
+}
+
+export function addInitScripts(pkg: PackageJsonScripts): string[] {
+  pkg.scripts ??= {};
+  const scripts = pkg.scripts;
+  const added: string[] = [];
+  for (const [name, command] of Object.entries(INIT_SCRIPTS)) {
+    if (scripts[name] !== undefined) continue;
+    scripts[name] = command;
+    added.push(name);
+  }
+  return added;
+}
+
+function printNextSteps(): void {
+  console.log(
+    "\nNext steps:\n" +
+      "  1. npm i -D @paleo/openclaw-test @paleo/openclaw-channel-mock-core" +
+      " @paleo/openclaw-discord-mock @paleo/openclaw-slack-mock openclaw\n" +
+      "  2. cp .env.local.example .env.local   # then fill it in\n" +
+      "  3. npm run env:build",
+  );
 }
 
 function usage(): never {

--- a/packages/openclaw-test/src/cli.ts
+++ b/packages/openclaw-test/src/cli.ts
@@ -63,7 +63,15 @@ async function addScriptsToPackageJson(target: string): Promise<void> {
     );
     return;
   }
-  const pkg = JSON.parse(raw) as PackageJsonScripts;
+  let pkg: PackageJsonScripts;
+  try {
+    pkg = JSON.parse(raw) as PackageJsonScripts;
+  } catch {
+    console.error(
+      `${pkgPath} is not valid JSON — fix it, then add the scripts manually (see README)`,
+    );
+    return;
+  }
   const added = addInitScripts(pkg);
   if (added.length === 0) {
     console.log("package.json scripts already present");

--- a/packages/openclaw-test/test/cli.test.ts
+++ b/packages/openclaw-test/test/cli.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { addInitScripts, type PackageJsonScripts } from "../src/cli.js";
+
+describe("addInitScripts", () => {
+  it("adds the four scripts to a package.json without scripts", () => {
+    const pkg: PackageJsonScripts = {};
+    const added = addInitScripts(pkg);
+    expect(added).toEqual(["env:build", "env:up", "env:down", "e2e"]);
+    expect(pkg.scripts).toEqual({
+      "env:build": "openclaw-test env build",
+      "env:up": "openclaw-test env up",
+      "env:down": "openclaw-test env down",
+      e2e: "openclaw-test run",
+    });
+  });
+
+  it("never overwrites an existing script", () => {
+    const pkg: PackageJsonScripts = { scripts: { e2e: "custom command" } };
+    const added = addInitScripts(pkg);
+    expect(added).toEqual(["env:build", "env:up", "env:down"]);
+    expect(pkg.scripts?.e2e).toBe("custom command");
+  });
+
+  it("returns an empty list when every script is already present", () => {
+    const pkg: PackageJsonScripts = {};
+    addInitScripts(pkg);
+    expect(addInitScripts(pkg)).toEqual([]);
+  });
+});

--- a/packages/workspace/CHANGELOG.md
+++ b/packages/workspace/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @paleo/workspace
 
+## 0.17.0
+
+### Minor Changes
+
+- b027838: Remove `registryDir`. The registry is now derived as `${runtimeDir}/shared-registry`, auto-symlinked per linked worktree by `workspace setup`. To migrate an existing registry: `workspace migrate-0.16 <old-registryDir>`.
+
 ## 0.16.0
 
 ### Minor Changes

--- a/packages/workspace/README.md
+++ b/packages/workspace/README.md
@@ -51,7 +51,6 @@ await runWorkspace({
   portNames: ["server", "frontend", "db"],
   sharedDirs: [".local", ".plans"],
   runtimeDir: ".local-wt",
-  registryDir: ".local/_workspace-registry",
   configFiles: [
     {
       path: ".env",
@@ -89,7 +88,6 @@ import { runDevServer, helpers } from "@paleo/workspace";
 await runDevServer({
   basePort: 8100,
   runtimeDir: ".local-wt",
-  registryDir: ".local/_workspace-registry",
   devLimit: 5,
   servers: [
     {

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paleo/workspace",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Run multiple git-worktree dev environments side by side.",
   "keywords": [
     "workspace",

--- a/packages/workspace/src/cli.ts
+++ b/packages/workspace/src/cli.ts
@@ -17,6 +17,7 @@ export type WorkspaceCommand =
   | { kind: "wait"; slot?: string }
   | { kind: "set-owner"; name: string }
   | { kind: "finalize"; slot: string; force: boolean }
+  | { kind: "migrate"; oldRegistryDir: string }
   | { kind: "help" };
 
 export interface ParsedWorkspaceArgs {
@@ -54,6 +55,8 @@ function parseSubcommand(subcommand: string, tokens: string[]): ParsedWorkspaceA
       return parseSetOwner(tokens);
     case "__finalize":
       return parseFinalize(tokens);
+    case "migrate-0.16":
+      return parseMigrate(tokens);
     default:
       throw new ConfigError(`Unknown command "${subcommand}". Run \`workspace --help\`.`);
   }
@@ -168,6 +171,17 @@ function parseFinalize(tokens: string[]): ParsedWorkspaceArgs {
   });
   const slot = takeRequiredPositional(positionals, "__finalize", "slot");
   return { command: { kind: "finalize", slot, force: values.force ?? false }, verbose: false };
+}
+
+function parseMigrate(tokens: string[]): ParsedWorkspaceArgs {
+  const { values, positionals } = parseArgs({
+    args: tokens,
+    options: { verbose: { type: "boolean", short: "v" } },
+    allowPositionals: true,
+    strict: true,
+  });
+  const oldRegistryDir = takeRequiredPositional(positionals, "migrate-0.16", "old-registry-dir");
+  return { command: { kind: "migrate", oldRegistryDir }, verbose: values.verbose ?? false };
 }
 
 function takeOptionalPositional(positionals: string[], command: string): string | undefined {

--- a/packages/workspace/src/dev-server.ts
+++ b/packages/workspace/src/dev-server.ts
@@ -102,36 +102,40 @@ export async function runDevServer(config: DevServerConfig): Promise<void> {
     return;
   }
 
-  warnLegacyRegistryDir(config.runtimeDir, (config as { registryDir?: string }).registryDir);
+  warnLegacyRegistryDir(config);
+  const registryDir = registryDirFor(config.runtimeDir);
 
   const { mainWorktree } = detectWorktree();
 
   switch (command.kind) {
     case "list":
-      listDevServers(mainWorktree, registryDirFor(config.runtimeDir));
+      listDevServers(mainWorktree, registryDir);
       return;
     case "down":
       if (command.all) {
         await stopAllRegistered({
           mainWorktree,
-          registryDir: registryDirFor(config.runtimeDir),
+          registryDir,
           callbackServers: callbackServersOf(config),
         });
       } else {
-        await stopLocal(config, mainWorktree);
+        await stopLocal(config, mainWorktree, registryDir);
       }
       return;
     case "up":
-      await start(config, mainWorktree, { evict: command.evict, restart: command.restart });
+      await start(config, mainWorktree, registryDir, {
+        evict: command.evict,
+        restart: command.restart,
+      });
       return;
     case "restart":
-      await start(config, mainWorktree, { evict: command.evict, restart: true });
+      await start(config, mainWorktree, registryDir, { evict: command.evict, restart: true });
       return;
     case "status":
-      printStatus(config, mainWorktree);
+      printStatus(config, mainWorktree, registryDir);
       return;
     case "foreground":
-      await runForeground(config, mainWorktree, {
+      await runForeground(config, mainWorktree, registryDir, {
         evict: command.evict,
         restart: command.restart,
       });
@@ -139,14 +143,14 @@ export async function runDevServer(config: DevServerConfig): Promise<void> {
   }
 }
 
-function printStatus(config: DevServerConfig, mainWorktree: string): void {
-  const entry = findOwnEntry(mainWorktree, registryDirFor(config.runtimeDir), process.cwd());
+function printStatus(config: DevServerConfig, mainWorktree: string, registryDir: string): void {
+  const entry = findOwnEntry(mainWorktree, registryDir, process.cwd());
   if (!entry || !Object.values(entry.pids).some(isProcessAlive)) {
     console.log("Dev-server status: DOWN.");
     return;
   }
   console.log("Dev-server status: UP.");
-  const slot = resolveCurrentSlot(config.basePort, registryDirFor(config.runtimeDir));
+  const slot = resolveCurrentSlot(config.basePort, registryDir);
   printStartSummary(config, slot, entry.pids);
 }
 
@@ -167,15 +171,16 @@ interface StartOptions {
 async function start(
   config: DevServerConfig,
   mainWorktree: string,
+  registryDir: string,
   options: StartOptions,
 ): Promise<void> {
   const ctx: ServerContext = { cwd: process.cwd() };
-  if (await runStartChecks(config, mainWorktree, ctx, options)) return;
+  if (await runStartChecks(config, mainWorktree, registryDir, ctx, options)) return;
 
   const state: StartState = { spawnPids: {}, startedCallbacks: [] };
   await spawnWithRollback(config, ctx, state);
 
-  const slot = registerStartedServer(config, mainWorktree, state.spawnPids);
+  const slot = registerStartedServer(config, mainWorktree, registryDir, state.spawnPids);
   printStartSummary(config, slot, state.spawnPids);
 }
 
@@ -187,11 +192,12 @@ async function start(
 async function runForeground(
   config: DevServerConfig,
   mainWorktree: string,
+  registryDir: string,
   options: StartOptions,
 ): Promise<void> {
   const ctx: ServerContext = { cwd: process.cwd() };
   if (!options.restart) {
-    const running = findOwnLiveEntry(config, mainWorktree, ctx.cwd);
+    const running = findOwnLiveEntry(mainWorktree, registryDir, ctx.cwd);
     if (running) return attachForeground(config, running);
   }
 
@@ -203,7 +209,7 @@ async function runForeground(
     if (shuttingDown) return;
     shuttingDown = true;
     if (started) {
-      void shutdownForeground(config, mainWorktree);
+      void shutdownForeground(config, mainWorktree, registryDir);
     } else {
       void rollbackStart(state.spawnPids, state.startedCallbacks, ctx).then(() =>
         process.exit(130),
@@ -213,7 +219,7 @@ async function runForeground(
   process.on("SIGINT", onSignal);
   process.on("SIGTERM", onSignal);
 
-  if (await runStartChecks(config, mainWorktree, ctx, options)) process.exit(0);
+  if (await runStartChecks(config, mainWorktree, registryDir, ctx, options)) process.exit(0);
 
   // Stream logs from the first byte so the whole startup (e.g. a slow build) is visible live.
   const streamLogs = (): void => tailLogs(config, state.spawnPids, { fromStart: true });
@@ -223,7 +229,7 @@ async function runForeground(
     await new Promise<never>(() => {});
   }
 
-  const slot = registerStartedServer(config, mainWorktree, state.spawnPids);
+  const slot = registerStartedServer(config, mainWorktree, registryDir, state.spawnPids);
   started = true;
   printStartSummary(config, slot, state.spawnPids);
   watchForExternalStop(Object.values(state.spawnPids), () => {
@@ -236,11 +242,11 @@ async function runForeground(
 }
 
 function findOwnLiveEntry(
-  config: DevServerConfig,
   mainWorktree: string,
+  registryDir: string,
   cwd: string,
 ): DevServerEntry | undefined {
-  const entry = findOwnEntry(mainWorktree, registryDirFor(config.runtimeDir), cwd);
+  const entry = findOwnEntry(mainWorktree, registryDir, cwd);
   if (!entry) return;
   return Object.values(entry.pids).some(isProcessAlive) ? entry : undefined;
 }
@@ -278,9 +284,13 @@ async function attachForeground(config: DevServerConfig, entry: DevServerEntry):
   await new Promise<never>(() => {});
 }
 
-async function shutdownForeground(config: DevServerConfig, mainWorktree: string): Promise<void> {
+async function shutdownForeground(
+  config: DevServerConfig,
+  mainWorktree: string,
+  registryDir: string,
+): Promise<void> {
   console.log("\nStopping dev servers...");
-  await stopLocal(config, mainWorktree);
+  await stopLocal(config, mainWorktree, registryDir);
   console.log("Stopped.");
   process.exit(0);
 }
@@ -288,13 +298,14 @@ async function shutdownForeground(config: DevServerConfig, mainWorktree: string)
 async function runStartChecks(
   config: DevServerConfig,
   mainWorktree: string,
+  registryDir: string,
   ctx: ServerContext,
   { evict, restart }: StartOptions,
 ): Promise<boolean> {
-  checkWorktreeReady(config, mainWorktree, ctx.cwd);
-  if (await handleAlreadyRunning(config, mainWorktree, ctx, restart)) return true;
-  await enforceCap(config, mainWorktree, evict);
-  checkNoLocalRegistryConflict(config, mainWorktree, ctx.cwd);
+  checkWorktreeReady(config, mainWorktree, registryDir, ctx.cwd);
+  if (await handleAlreadyRunning(config, mainWorktree, registryDir, ctx, restart)) return true;
+  await enforceCap(config, mainWorktree, registryDir, evict);
+  checkNoLocalRegistryConflict(mainWorktree, registryDir, ctx.cwd);
   await checkPortsFree(config.servers, ctx.cwd);
   return false;
 }
@@ -370,9 +381,10 @@ async function spawnAndAwait(
 function registerStartedServer(
   config: DevServerConfig,
   mainWorktree: string,
+  registryDir: string,
   spawnPids: Record<string, number>,
 ): ResolvedSlot {
-  const slot = resolveCurrentSlot(config.basePort, registryDirFor(config.runtimeDir));
+  const slot = resolveCurrentSlot(config.basePort, registryDir);
   const devEntry: DevServerEntry = {
     slot: slot.slot,
     worktree: slot.worktree,
@@ -381,7 +393,7 @@ function registerStartedServer(
     startedAt: new Date().toISOString(),
   };
   if (slot.main) devEntry.main = true;
-  registerDevServer(mainWorktree, registryDirFor(config.runtimeDir), devEntry);
+  registerDevServer(mainWorktree, registryDir, devEntry);
   return slot;
 }
 
@@ -538,9 +550,14 @@ export function buildWorktreeReadyMessage(input: {
   };
 }
 
-function checkWorktreeReady(config: DevServerConfig, mainWorktree: string, cwd: string): void {
-  const slot = resolveCurrentSlot(config.basePort, registryDirFor(config.runtimeDir));
-  const entry = readSlots(mainWorktree, registryDirFor(config.runtimeDir)).slots[String(slot.slot)];
+function checkWorktreeReady(
+  config: DevServerConfig,
+  mainWorktree: string,
+  registryDir: string,
+  cwd: string,
+): void {
+  const slot = resolveCurrentSlot(config.basePort, registryDir);
+  const entry = readSlots(mainWorktree, registryDir).slots[String(slot.slot)];
   const result = buildWorktreeReadyMessage({
     slotPort: slot.slot,
     worktreePath: cwd,
@@ -561,17 +578,18 @@ function checkWorktreeReady(config: DevServerConfig, mainWorktree: string, cwd: 
 async function handleAlreadyRunning(
   config: DevServerConfig,
   mainWorktree: string,
+  registryDir: string,
   ctx: ServerContext,
   restart: boolean,
 ): Promise<boolean> {
-  const entry = findOwnEntry(mainWorktree, registryDirFor(config.runtimeDir), ctx.cwd);
+  const entry = findOwnEntry(mainWorktree, registryDir, ctx.cwd);
   if (!entry) return false;
   const livePids = Object.entries(entry.pids).filter(([, pid]) => isProcessAlive(pid));
   if (livePids.length === 0) return false;
 
   if (restart) {
     console.log("Restarting dev-server in this worktree...");
-    await stopLocal(config, mainWorktree);
+    await stopLocal(config, mainWorktree, registryDir);
     return false;
   }
 
@@ -589,11 +607,12 @@ async function handleAlreadyRunning(
 async function enforceCap(
   config: DevServerConfig,
   mainWorktree: string,
+  registryDir: string,
   evict: boolean,
 ): Promise<void> {
   const limit = config.devLimit;
   if (limit === undefined) return;
-  const active = pruneAndPersist(mainWorktree, registryDirFor(config.runtimeDir)).servers;
+  const active = pruneAndPersist(mainWorktree, registryDir).servers;
   if (active.length < limit) return;
 
   if (!evict) {
@@ -608,7 +627,7 @@ async function enforceCap(
   console.log(`Evicting ${toEvict} dev-server(s) to make room (cap ${limit}).`);
   const evicted = await evictOldest({
     mainWorktree,
-    registryDir: registryDirFor(config.runtimeDir),
+    registryDir,
     callbackServers: callbackServersOf(config),
     count: toEvict,
   });
@@ -665,11 +684,11 @@ async function checkPortsFree(servers: ServerDescriptor[], cwd: string): Promise
 }
 
 function checkNoLocalRegistryConflict(
-  config: DevServerConfig,
   mainWorktree: string,
+  registryDir: string,
   cwd: string,
 ): void {
-  const entry = findOwnEntry(mainWorktree, registryDirFor(config.runtimeDir), cwd);
+  const entry = findOwnEntry(mainWorktree, registryDir, cwd);
   if (!entry) return;
   for (const [name, pid] of Object.entries(entry.pids)) {
     if (isProcessAlive(pid)) {
@@ -678,12 +697,16 @@ function checkNoLocalRegistryConflict(
     }
   }
   // Stale entry — drop it so registration overwrites cleanly.
-  removeDevServerEntryByWorktree(mainWorktree, registryDirFor(config.runtimeDir), cwd);
+  removeDevServerEntryByWorktree(mainWorktree, registryDir, cwd);
 }
 
-async function stopLocal(config: DevServerConfig, mainWorktree: string): Promise<void> {
+async function stopLocal(
+  config: DevServerConfig,
+  mainWorktree: string,
+  registryDir: string,
+): Promise<void> {
   const ctx: ServerContext = { cwd: process.cwd() };
-  const entry = findOwnEntry(mainWorktree, registryDirFor(config.runtimeDir), ctx.cwd);
+  const entry = findOwnEntry(mainWorktree, registryDir, ctx.cwd);
   if (!entry) {
     console.log("No dev-server running in this worktree.");
     await sweepStalePorts(config.servers, ctx.cwd);
@@ -703,7 +726,7 @@ async function stopLocal(config: DevServerConfig, mainWorktree: string): Promise
       console.error(`  Failed to stop ${server.name}: ${(err as Error).message}`);
     }
   }
-  unregisterDevServer(mainWorktree, registryDirFor(config.runtimeDir), ctx.cwd);
+  unregisterDevServer(mainWorktree, registryDir, ctx.cwd);
   await sweepStalePorts(config.servers, ctx.cwd);
 }
 

--- a/packages/workspace/src/dev-server.ts
+++ b/packages/workspace/src/dev-server.ts
@@ -45,7 +45,14 @@ import type {
   ServerDescriptor,
   SpawnServer,
 } from "./server-descriptor.js";
-import { readSlots, resolveCurrentSlot, type ResolvedSlot, type SlotEntry } from "./slots.js";
+import {
+  readSlots,
+  registryDirFor,
+  resolveCurrentSlot,
+  type ResolvedSlot,
+  type SlotEntry,
+  warnLegacyRegistryDir,
+} from "./slots.js";
 import { detectWorktree, getWorktreeBranch } from "./worktree.js";
 
 export type { CallbackServer, ServerContext, ServerDescriptor, SpawnServer };
@@ -56,12 +63,6 @@ export interface DevServerConfig {
   basePort: number;
   /** Per-worktree runtime directory, relative to the worktree root (e.g. `.local-wt`). */
   runtimeDir: string;
-  /**
-   * Shared registry directory, relative to a worktree root (e.g. `.local/_workspace-registry`).
-   * Holds `slots.json` and `dev-servers.json`. Must resolve to the same physical directory
-   * across linked worktrees — typically via a symlink (e.g. `.local`).
-   */
-  registryDir: string;
   /** Maximum concurrent dev-servers across all worktrees. Omit for no limit. */
   devLimit?: number;
   /** One entry per server to start. Started in array order; stopped in reverse order. */
@@ -101,17 +102,19 @@ export async function runDevServer(config: DevServerConfig): Promise<void> {
     return;
   }
 
+  warnLegacyRegistryDir(config.runtimeDir, (config as { registryDir?: string }).registryDir);
+
   const { mainWorktree } = detectWorktree();
 
   switch (command.kind) {
     case "list":
-      listDevServers(mainWorktree, config.registryDir);
+      listDevServers(mainWorktree, registryDirFor(config.runtimeDir));
       return;
     case "down":
       if (command.all) {
         await stopAllRegistered({
           mainWorktree,
-          registryDir: config.registryDir,
+          registryDir: registryDirFor(config.runtimeDir),
           callbackServers: callbackServersOf(config),
         });
       } else {
@@ -137,13 +140,13 @@ export async function runDevServer(config: DevServerConfig): Promise<void> {
 }
 
 function printStatus(config: DevServerConfig, mainWorktree: string): void {
-  const entry = findOwnEntry(mainWorktree, config.registryDir, process.cwd());
+  const entry = findOwnEntry(mainWorktree, registryDirFor(config.runtimeDir), process.cwd());
   if (!entry || !Object.values(entry.pids).some(isProcessAlive)) {
     console.log("Dev-server status: DOWN.");
     return;
   }
   console.log("Dev-server status: UP.");
-  const slot = resolveCurrentSlot(config.basePort, config.registryDir);
+  const slot = resolveCurrentSlot(config.basePort, registryDirFor(config.runtimeDir));
   printStartSummary(config, slot, entry.pids);
 }
 
@@ -237,7 +240,7 @@ function findOwnLiveEntry(
   mainWorktree: string,
   cwd: string,
 ): DevServerEntry | undefined {
-  const entry = findOwnEntry(mainWorktree, config.registryDir, cwd);
+  const entry = findOwnEntry(mainWorktree, registryDirFor(config.runtimeDir), cwd);
   if (!entry) return;
   return Object.values(entry.pids).some(isProcessAlive) ? entry : undefined;
 }
@@ -369,7 +372,7 @@ function registerStartedServer(
   mainWorktree: string,
   spawnPids: Record<string, number>,
 ): ResolvedSlot {
-  const slot = resolveCurrentSlot(config.basePort, config.registryDir);
+  const slot = resolveCurrentSlot(config.basePort, registryDirFor(config.runtimeDir));
   const devEntry: DevServerEntry = {
     slot: slot.slot,
     worktree: slot.worktree,
@@ -378,7 +381,7 @@ function registerStartedServer(
     startedAt: new Date().toISOString(),
   };
   if (slot.main) devEntry.main = true;
-  registerDevServer(mainWorktree, config.registryDir, devEntry);
+  registerDevServer(mainWorktree, registryDirFor(config.runtimeDir), devEntry);
   return slot;
 }
 
@@ -536,8 +539,8 @@ export function buildWorktreeReadyMessage(input: {
 }
 
 function checkWorktreeReady(config: DevServerConfig, mainWorktree: string, cwd: string): void {
-  const slot = resolveCurrentSlot(config.basePort, config.registryDir);
-  const entry = readSlots(mainWorktree, config.registryDir).slots[String(slot.slot)];
+  const slot = resolveCurrentSlot(config.basePort, registryDirFor(config.runtimeDir));
+  const entry = readSlots(mainWorktree, registryDirFor(config.runtimeDir)).slots[String(slot.slot)];
   const result = buildWorktreeReadyMessage({
     slotPort: slot.slot,
     worktreePath: cwd,
@@ -561,7 +564,7 @@ async function handleAlreadyRunning(
   ctx: ServerContext,
   restart: boolean,
 ): Promise<boolean> {
-  const entry = findOwnEntry(mainWorktree, config.registryDir, ctx.cwd);
+  const entry = findOwnEntry(mainWorktree, registryDirFor(config.runtimeDir), ctx.cwd);
   if (!entry) return false;
   const livePids = Object.entries(entry.pids).filter(([, pid]) => isProcessAlive(pid));
   if (livePids.length === 0) return false;
@@ -590,7 +593,7 @@ async function enforceCap(
 ): Promise<void> {
   const limit = config.devLimit;
   if (limit === undefined) return;
-  const active = pruneAndPersist(mainWorktree, config.registryDir).servers;
+  const active = pruneAndPersist(mainWorktree, registryDirFor(config.runtimeDir)).servers;
   if (active.length < limit) return;
 
   if (!evict) {
@@ -605,7 +608,7 @@ async function enforceCap(
   console.log(`Evicting ${toEvict} dev-server(s) to make room (cap ${limit}).`);
   const evicted = await evictOldest({
     mainWorktree,
-    registryDir: config.registryDir,
+    registryDir: registryDirFor(config.runtimeDir),
     callbackServers: callbackServersOf(config),
     count: toEvict,
   });
@@ -666,7 +669,7 @@ function checkNoLocalRegistryConflict(
   mainWorktree: string,
   cwd: string,
 ): void {
-  const entry = findOwnEntry(mainWorktree, config.registryDir, cwd);
+  const entry = findOwnEntry(mainWorktree, registryDirFor(config.runtimeDir), cwd);
   if (!entry) return;
   for (const [name, pid] of Object.entries(entry.pids)) {
     if (isProcessAlive(pid)) {
@@ -675,12 +678,12 @@ function checkNoLocalRegistryConflict(
     }
   }
   // Stale entry — drop it so registration overwrites cleanly.
-  removeDevServerEntryByWorktree(mainWorktree, config.registryDir, cwd);
+  removeDevServerEntryByWorktree(mainWorktree, registryDirFor(config.runtimeDir), cwd);
 }
 
 async function stopLocal(config: DevServerConfig, mainWorktree: string): Promise<void> {
   const ctx: ServerContext = { cwd: process.cwd() };
-  const entry = findOwnEntry(mainWorktree, config.registryDir, ctx.cwd);
+  const entry = findOwnEntry(mainWorktree, registryDirFor(config.runtimeDir), ctx.cwd);
   if (!entry) {
     console.log("No dev-server running in this worktree.");
     await sweepStalePorts(config.servers, ctx.cwd);
@@ -700,7 +703,7 @@ async function stopLocal(config: DevServerConfig, mainWorktree: string): Promise
       console.error(`  Failed to stop ${server.name}: ${(err as Error).message}`);
     }
   }
-  unregisterDevServer(mainWorktree, config.registryDir, ctx.cwd);
+  unregisterDevServer(mainWorktree, registryDirFor(config.runtimeDir), ctx.cwd);
   await sweepStalePorts(config.servers, ctx.cwd);
 }
 

--- a/packages/workspace/src/dev-servers-registry.ts
+++ b/packages/workspace/src/dev-servers-registry.ts
@@ -214,6 +214,19 @@ export function writeDevServers(
   writeFileSync(fp, `${JSON.stringify(data, undefined, 2)}\n`);
 }
 
+/** Union by resolved `worktree`; `override` wins on conflict. Base-first then override-only order. */
+export function mergeDevServers(base: DevServersData, override: DevServersData): DevServersData {
+  const overrideByWorktree = new Map(override.servers.map((e) => [resolve(e.worktree), e]));
+  const merged: DevServerEntry[] = base.servers.map(
+    (entry) => overrideByWorktree.get(resolve(entry.worktree)) ?? entry,
+  );
+  const baseWorktrees = new Set(base.servers.map((e) => resolve(e.worktree)));
+  for (const entry of override.servers) {
+    if (!baseWorktrees.has(resolve(entry.worktree))) merged.push(entry);
+  }
+  return { servers: merged };
+}
+
 function filePath(mainWorktree: string, registryDir: string): string {
   return join(mainWorktree, registryDir, DEV_SERVERS_FILENAME);
 }

--- a/packages/workspace/src/slots.ts
+++ b/packages/workspace/src/slots.ts
@@ -13,16 +13,14 @@ export function registryDirFor(runtimeDir: string): string {
   return join(runtimeDir, REGISTRY_SUBDIR);
 }
 
-export function warnLegacyRegistryDir(
-  runtimeDir: string,
-  legacyRegistryDir: string | undefined,
-): void {
-  if (legacyRegistryDir === undefined) return;
+/** `registryDir` is gone from the config types but may linger in a consumer's config file. */
+export function warnLegacyRegistryDir(config: { runtimeDir: string; registryDir?: string }): void {
+  if (config.registryDir === undefined) return;
   console.warn(
     "Warning: `registryDir` is obsolete and ignored. The registry now lives at " +
-      `\`${registryDirFor(runtimeDir)}\`. Remove \`registryDir\` from your config. ` +
-      `If you have an existing registry at "${legacyRegistryDir}", run ` +
-      `\`workspace migrate-0.16 ${legacyRegistryDir}\` once to merge it.`,
+      `\`${registryDirFor(config.runtimeDir)}\`. Remove \`registryDir\` from your config. ` +
+      `If you have an existing registry at "${config.registryDir}", run ` +
+      `\`workspace migrate-0.16 ${config.registryDir}\` once to merge it.`,
   );
 }
 

--- a/packages/workspace/src/slots.ts
+++ b/packages/workspace/src/slots.ts
@@ -5,7 +5,26 @@ import { dirname, join, resolve } from "node:path";
 import { allPorts, isValidPort, type PortScheme } from "./ports.js";
 import { getWorktreeBranch } from "./worktree.js";
 
+export const REGISTRY_SUBDIR = "shared-registry";
+
 const SLOTS_FILENAME = "slots.json";
+
+export function registryDirFor(runtimeDir: string): string {
+  return join(runtimeDir, REGISTRY_SUBDIR);
+}
+
+export function warnLegacyRegistryDir(
+  runtimeDir: string,
+  legacyRegistryDir: string | undefined,
+): void {
+  if (legacyRegistryDir === undefined) return;
+  console.warn(
+    "Warning: `registryDir` is obsolete and ignored. The registry now lives at " +
+      `\`${registryDirFor(runtimeDir)}\`. Remove \`registryDir\` from your config. ` +
+      `If you have an existing registry at "${legacyRegistryDir}", run ` +
+      `\`workspace migrate-0.16 ${legacyRegistryDir}\` once to merge it.`,
+  );
+}
 
 export interface ResolvedSlot {
   slot: number;
@@ -45,6 +64,11 @@ export function writeSlots(
   const filePath = join(mainWorktree, registryDir, SLOTS_FILENAME);
   mkdirSync(join(mainWorktree, registryDir), { recursive: true });
   writeFileSync(filePath, `${JSON.stringify(registry, undefined, 2)}\n`);
+}
+
+/** Union of slots keyed by port; `override` wins on conflict. */
+export function mergeSlots(base: SlotsRegistry, override: SlotsRegistry): SlotsRegistry {
+  return { slots: { ...base.slots, ...override.slots } };
 }
 
 export interface RegisterSlotInput {

--- a/packages/workspace/src/workspace.ts
+++ b/packages/workspace/src/workspace.ts
@@ -11,7 +11,7 @@ import {
   symlinkSync,
   writeFileSync,
 } from "node:fs";
-import { dirname, join, relative, resolve } from "node:path";
+import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 
 import { parseWorkspaceArgs, printWorkspaceHelp, type WorkspaceCommand } from "./cli.js";
 import {
@@ -242,10 +242,11 @@ export async function runWorkspace(config: WorkspaceConfig): Promise<void> {
     return;
   }
 
-  warnLegacyRegistryDir(config.runtimeDir, (config as { registryDir?: string }).registryDir);
+  warnLegacyRegistryDir(config);
+  const registryDir = registryDirFor(config.runtimeDir);
 
   if (command.kind === "migrate") {
-    handleMigrate(command, config);
+    handleMigrate(command, config, registryDir);
     return;
   }
 
@@ -259,16 +260,16 @@ export async function runWorkspace(config: WorkspaceConfig): Promise<void> {
 
   switch (command.kind) {
     case "finalize":
-      await runFinalize(command, config);
+      await runFinalize(command, config, registryDir);
       return;
     case "wait":
-      await runWait(command, config);
+      await runWait(command, config, registryDir);
       return;
     case "status":
-      runStatus(command, config);
+      runStatus(command, config, registryDir);
       return;
     case "list":
-      runList(config);
+      runList(registryDir);
       return;
   }
 
@@ -278,14 +279,14 @@ export async function runWorkspace(config: WorkspaceConfig): Promise<void> {
 
   switch (command.kind) {
     case "remove":
-      await handleRemove(command, ctx, run, config);
+      await handleRemove(command, ctx, run, config, registryDir);
       return;
     case "set-owner":
-      handleSetOwnerMode(command, ctx, config);
+      handleSetOwnerMode(command, ctx, registryDir);
       return;
     case "setup": {
-      const { slot } = await runSetup(command, ctx, run, config);
-      if (command.wait) await waitForSlot(slot, config, { printSummary: false });
+      const { slot } = await runSetup(command, ctx, run, config, registryDir);
+      if (command.wait) await waitForSlot(slot, config, registryDir, { printSummary: false });
       return;
     }
   }
@@ -298,6 +299,7 @@ async function runSetup(
   ctx: WorktreeContext,
   run: RunCtx,
   config: WorkspaceConfig,
+  registryDir: string,
 ): Promise<{ slot: number }> {
   const scheme: PortScheme = resolvePortScheme(config);
   const portsFn = resolvePortsFn(config);
@@ -305,12 +307,12 @@ async function runSetup(
   validateSlotAvailability(command.slot, {
     currentWorktree: ctx.currentWorktree,
     mainWorktree: ctx.mainWorktree,
-    registryDir: registryDirFor(config.runtimeDir),
+    registryDir,
     scheme,
   });
 
   const setupCtx = ensureWorktree(command, ctx, run, config.worktreeDirName);
-  refuseIfFinalizePending(setupCtx, registryDirFor(config.runtimeDir), command.force);
+  refuseIfFinalizePending(setupCtx, registryDir, command.force);
   const branch = getWorktreeBranch(setupCtx.currentWorktree) ?? "(detached)";
   const {
     port: slot,
@@ -320,7 +322,7 @@ async function runSetup(
     slot: command.slot,
     currentWorktree: setupCtx.currentWorktree,
     mainWorktree: setupCtx.mainWorktree,
-    registryDir: registryDirFor(config.runtimeDir),
+    registryDir,
     scheme,
     requestedOwner: command.owner,
     isMainWorktree: setupCtx.isMainWorktree,
@@ -414,7 +416,11 @@ function refuseIfFinalizePending(ctx: WorktreeContext, registryDir: string, forc
 
 type FinalizeCommand = Extract<WorkspaceCommand, { kind: "finalize" }>;
 
-async function runFinalize(command: FinalizeCommand, config: WorkspaceConfig): Promise<void> {
+async function runFinalize(
+  command: FinalizeCommand,
+  config: WorkspaceConfig,
+  registryDir: string,
+): Promise<void> {
   const slot = Number(command.slot);
   const ctx = detectWorktree();
   const logPath = setupLogPath(ctx.currentWorktree, config.runtimeDir);
@@ -422,7 +428,7 @@ async function runFinalize(command: FinalizeCommand, config: WorkspaceConfig): P
     appendFileSync(logPath, `${message}\n`);
   };
 
-  const registry = readSlots(ctx.mainWorktree, registryDirFor(config.runtimeDir));
+  const registry = readSlots(ctx.mainWorktree, registryDir);
   const entry = registry.slots[String(slot)];
   if (!entry || resolve(entry.worktree) !== resolve(ctx.currentWorktree)) {
     appendLog(`FAILED: No matching slot ${slot} for worktree ${ctx.currentWorktree}.`);
@@ -455,21 +461,25 @@ async function runFinalize(command: FinalizeCommand, config: WorkspaceConfig): P
 
   try {
     await config.finalizeWorktree(setupContext);
-    markSlotReady(ctx.mainWorktree, registryDirFor(config.runtimeDir), slot);
+    markSlotReady(ctx.mainWorktree, registryDir, slot);
     appendLog("============================================================");
     appendLog(`READY: branch ${branch} (slot ${slot})`);
     appendLog("============================================================");
   } catch (err) {
     const message = (err as Error).message;
     const stack = (err as Error).stack ?? "";
-    markSlotFailed(ctx.mainWorktree, registryDirFor(config.runtimeDir), slot, message);
+    markSlotFailed(ctx.mainWorktree, registryDir, slot, message);
     appendLog(`FAILED: ${message}`);
     if (stack) appendLog(stack);
     process.exit(1);
   }
 }
 
-function resolveTargetSlot(slotArg: string | undefined, config: WorkspaceConfig): number {
+function resolveTargetSlot(
+  slotArg: string | undefined,
+  config: WorkspaceConfig,
+  registryDir: string,
+): number {
   if (slotArg !== undefined) {
     const slot = Number(slotArg);
     const scheme = resolvePortScheme(config);
@@ -481,17 +491,18 @@ function resolveTargetSlot(slotArg: string | undefined, config: WorkspaceConfig)
     }
     return slot;
   }
-  return resolveCurrentSlot(config.basePort, registryDirFor(config.runtimeDir)).slot;
+  return resolveCurrentSlot(config.basePort, registryDir).slot;
 }
 
 function printWorktreeInfo(
   config: WorkspaceConfig,
+  registryDir: string,
   slot: number,
   worktreeForLog: string,
   fallback: { owner?: string },
 ): void {
   const ctx = detectWorktree();
-  const registry = readSlots(ctx.mainWorktree, registryDirFor(config.runtimeDir));
+  const registry = readSlots(ctx.mainWorktree, registryDir);
   const entry: SlotEntry | undefined = registry.slots[String(slot)];
   const ports = resolvePortsFn(config)(slot);
 
@@ -523,16 +534,17 @@ function printWorktreeInfo(
     const elapsed = formatDuration(now - Date.parse(entry.createdAt));
     console.log(`Pending since ${elapsed} ago (tail ${setupLogPath})`);
   }
-  printDevServerBlock(config, ctx.mainWorktree, targetWorktree, now);
+  printDevServerBlock(config, registryDir, ctx.mainWorktree, targetWorktree, now);
 }
 
 function printDevServerBlock(
   config: WorkspaceConfig,
+  registryDir: string,
   mainWorktree: string,
   targetWorktree: string,
   now: number,
 ): void {
-  const entry = findOwnEntry(mainWorktree, registryDirFor(config.runtimeDir), targetWorktree);
+  const entry = findOwnEntry(mainWorktree, registryDir, targetWorktree);
   const liveEntries = entry
     ? Object.entries(entry.pids)
         .filter(([, pid]) => isProcessAlive(pid))
@@ -552,38 +564,34 @@ function printDevServerBlock(
 
 type StatusCommand = Extract<WorkspaceCommand, { kind: "status" }>;
 
-function runStatus(command: StatusCommand, config: WorkspaceConfig): void {
+function runStatus(command: StatusCommand, config: WorkspaceConfig, registryDir: string): void {
   if (command.slot !== undefined) {
-    const slot = resolveTargetSlot(command.slot, config);
+    const slot = resolveTargetSlot(command.slot, config, registryDir);
     const ctx = detectWorktree();
-    const entry = readSlots(ctx.mainWorktree, registryDirFor(config.runtimeDir)).slots[
-      String(slot)
-    ];
+    const entry = readSlots(ctx.mainWorktree, registryDir).slots[String(slot)];
     if (!entry) {
       console.error(`Error: No slot ${slot} in registry.`);
       process.exit(1);
     }
-    printWorktreeInfo(config, slot, entry.worktree, { owner: entry.owner });
+    printWorktreeInfo(config, registryDir, slot, entry.worktree, { owner: entry.owner });
     return;
   }
-  const resolved = resolveCurrentSlot(config.basePort, registryDirFor(config.runtimeDir));
-  printWorktreeInfo(config, resolved.slot, resolved.worktree, {
+  const resolved = resolveCurrentSlot(config.basePort, registryDir);
+  printWorktreeInfo(config, registryDir, resolved.slot, resolved.worktree, {
     owner: resolved.owner,
   });
 }
 
-function runList(config: WorkspaceConfig): void {
+function runList(registryDir: string): void {
   const ctx = detectWorktree();
-  const entries = Object.entries(
-    readSlots(ctx.mainWorktree, registryDirFor(config.runtimeDir)).slots,
-  ).sort(([a], [b]) => Number(a) - Number(b));
+  const entries = Object.entries(readSlots(ctx.mainWorktree, registryDir).slots).sort(
+    ([a], [b]) => Number(a) - Number(b),
+  );
   if (entries.length === 0) {
     console.log("No workspaces registered.");
     return;
   }
-  const liveSet = liveWorktrees(
-    readDevServers(ctx.mainWorktree, registryDirFor(config.runtimeDir)),
-  );
+  const liveSet = liveWorktrees(readDevServers(ctx.mainWorktree, registryDir));
   const rows = entries.map(([port, e]) => ({
     slot: port,
     type: e.main ? "main" : "linked",
@@ -621,22 +629,25 @@ function runList(config: WorkspaceConfig): void {
 
 type WaitCommand = Extract<WorkspaceCommand, { kind: "wait" }>;
 
-async function runWait(command: WaitCommand, config: WorkspaceConfig): Promise<void> {
+async function runWait(
+  command: WaitCommand,
+  config: WorkspaceConfig,
+  registryDir: string,
+): Promise<void> {
   // standalone `workspace wait` (no prior setup in this invocation) → print the full summary on success.
-  const slot = resolveTargetSlot(command.slot, config);
-  await waitForSlot(slot, config);
+  const slot = resolveTargetSlot(command.slot, config, registryDir);
+  await waitForSlot(slot, config, registryDir);
 }
 
 async function waitForSlot(
   slot: number,
   config: WorkspaceConfig,
+  registryDir: string,
   options: { printSummary?: boolean } = {},
 ): Promise<void> {
   const printSummary = options.printSummary ?? true;
   const ctx = detectWorktree();
-  const initial = readSlots(ctx.mainWorktree, registryDirFor(config.runtimeDir)).slots[
-    String(slot)
-  ];
+  const initial = readSlots(ctx.mainWorktree, registryDir).slots[String(slot)];
   if (!initial) {
     console.error(`Error: No slot ${slot} in registry.`);
     process.exit(1);
@@ -646,9 +657,7 @@ async function waitForSlot(
   // Poll slots.json — the finalize child writes `status` on success or failure. Tiny file, no
   // log-tailing race.
   for (;;) {
-    const entry = readSlots(ctx.mainWorktree, registryDirFor(config.runtimeDir)).slots[
-      String(slot)
-    ];
+    const entry = readSlots(ctx.mainWorktree, registryDir).slots[String(slot)];
     if (!entry) {
       console.error(`Error: Slot ${slot} disappeared from registry.`);
       process.exit(1);
@@ -656,7 +665,7 @@ async function waitForSlot(
     if (entry.status === "ready") {
       console.log("\n… ready");
       if (printSummary) {
-        printWorktreeInfo(config, slot, entry.worktree, {
+        printWorktreeInfo(config, registryDir, slot, entry.worktree, {
           owner: entry.owner,
         });
       }
@@ -679,10 +688,11 @@ async function handleRemove(
   ctx: WorktreeContext,
   run: RunCtx,
   config: WorkspaceConfig,
+  registryDir: string,
 ): Promise<void> {
   const verboseLog = makeVerboseLog(run.verbose);
   const removeHere = command.branch === undefined;
-  const registry = readSlots(ctx.mainWorktree, registryDirFor(config.runtimeDir));
+  const registry = readSlots(ctx.mainWorktree, registryDir);
   const target = resolveRemoveTarget(command, ctx, registry);
 
   // Refuse to remove while the detached finalize is still writing to slots.json / workspace-setup.log:
@@ -706,18 +716,14 @@ async function handleRemove(
       `Warning: Worktree directory ${target.worktreePath} not found. Cleaning up registry only.`,
     );
     delete registry.slots[target.slotPort];
-    writeSlots(ctx.mainWorktree, registryDirFor(config.runtimeDir), registry);
+    writeSlots(ctx.mainWorktree, registryDir, registry);
     console.log(
       `Removed registry entry for branch "${target.branch}" (slot ${target.slotPort}${ownerSuffix}).`,
     );
     return;
   }
 
-  const targetEntry = findOwnEntry(
-    ctx.mainWorktree,
-    registryDirFor(config.runtimeDir),
-    target.worktreePath,
-  );
+  const targetEntry = findOwnEntry(ctx.mainWorktree, registryDir, target.worktreePath);
   if (targetEntry) {
     stopTargetDevServer(config.devServerScript, target.worktreePath, verboseLog);
   } else {
@@ -733,12 +739,8 @@ async function handleRemove(
   }
 
   delete registry.slots[target.slotPort];
-  writeSlots(ctx.mainWorktree, registryDirFor(config.runtimeDir), registry);
-  removeDevServerEntryByWorktree(
-    ctx.mainWorktree,
-    registryDirFor(config.runtimeDir),
-    target.worktreePath,
-  );
+  writeSlots(ctx.mainWorktree, registryDir, registry);
+  removeDevServerEntryByWorktree(ctx.mainWorktree, registryDir, target.worktreePath);
 
   if (removeHere) {
     process.chdir(ctx.mainWorktree);
@@ -760,23 +762,19 @@ type SetOwnerCommand = Extract<WorkspaceCommand, { kind: "set-owner" }>;
 function handleSetOwnerMode(
   command: SetOwnerCommand,
   ctx: WorktreeContext,
-  config: WorkspaceConfig,
+  registryDir: string,
 ): void {
   const newOwner = command.name;
   const { slotPort } = handleSetOwner({
     newOwner,
     currentWorktree: ctx.currentWorktree,
     mainWorktree: ctx.mainWorktree,
-    registryDir: registryDirFor(config.runtimeDir),
+    registryDir,
     isMainWorktree: ctx.isMainWorktree,
   });
 
   // Propagate to dev-servers.json entries for this worktree.
-  const devServersPath = join(
-    ctx.mainWorktree,
-    registryDirFor(config.runtimeDir),
-    "dev-servers.json",
-  );
+  const devServersPath = join(ctx.mainWorktree, registryDir, "dev-servers.json");
   if (existsSync(devServersPath)) {
     const data = JSON.parse(readFileSync(devServersPath, "utf-8")) as {
       servers: { worktree: string; owner?: string }[];
@@ -802,9 +800,8 @@ function handleSetOwnerMode(
 type MigrateCommand = Extract<WorkspaceCommand, { kind: "migrate" }>;
 
 /** Transitional (0.16 only): merge a pre-0.16 registry into `${runtimeDir}/shared-registry`. */
-function handleMigrate(command: MigrateCommand, config: WorkspaceConfig): void {
+function handleMigrate(command: MigrateCommand, config: WorkspaceConfig, newRel: string): void {
   const ctx = detectWorktree();
-  const newRel = registryDirFor(config.runtimeDir);
   const oldRel = command.oldRegistryDir;
   const oldAbs = join(ctx.mainWorktree, oldRel);
 
@@ -813,10 +810,7 @@ function handleMigrate(command: MigrateCommand, config: WorkspaceConfig): void {
     relinkWorktrees(readSlots(ctx.mainWorktree, newRel), ctx.mainWorktree, config.runtimeDir);
     return;
   }
-  if (!existsSync(oldAbs)) {
-    console.error(`Error: nothing to migrate at ${oldAbs}.`);
-    process.exit(1);
-  }
+  refuseUnlessOldRegistry(oldAbs, ctx.mainWorktree);
 
   const mergedSlots = mergeSlots(
     readSlots(ctx.mainWorktree, oldRel),
@@ -835,6 +829,25 @@ function handleMigrate(command: MigrateCommand, config: WorkspaceConfig): void {
     `Migrated ${oldRel} → ${newRel}: ${Object.keys(mergedSlots.slots).length} slot(s), ` +
       `${mergedDevServers.servers.length} dev-server(s); ${relinked} symlink(s) recreated.`,
   );
+}
+
+/** `oldAbs` is recursively deleted after the merge — refuse anything that isn't clearly a registry. */
+function refuseUnlessOldRegistry(oldAbs: string, mainWorktree: string): void {
+  const fromMain = relative(mainWorktree, resolve(oldAbs));
+  if (fromMain.startsWith("..") || isAbsolute(fromMain)) {
+    console.error(`Error: the old registry must be inside the main worktree; got ${oldAbs}.`);
+    process.exit(1);
+  }
+  if (!existsSync(oldAbs)) {
+    console.error(`Error: nothing to migrate at ${oldAbs}.`);
+    process.exit(1);
+  }
+  if (!existsSync(join(oldAbs, "slots.json")) && !existsSync(join(oldAbs, "dev-servers.json"))) {
+    console.error(
+      `Error: ${oldAbs} does not look like a registry (no slots.json or dev-servers.json).`,
+    );
+    process.exit(1);
+  }
 }
 
 function relinkWorktrees(slots: SlotsRegistry, mainWorktree: string, runtimeDir: string): number {
@@ -904,12 +917,15 @@ function linkSharedRegistry(
   const runtimeRoot = join(ctx.currentWorktree, runtimeDir);
   mkdirSync(runtimeRoot, { recursive: true });
   const link = join(runtimeRoot, REGISTRY_SUBDIR);
-  if (existsSync(link)) {
-    if (!lstatSync(link).isSymbolicLink()) {
+  // lstat, not existsSync: existsSync follows symlinks, so a broken one would read as absent and
+  // make symlinkSync throw EEXIST. A broken symlink is recreated even without `force`.
+  const linkStat = lstatSync(link, { throwIfNoEntry: false });
+  if (linkStat) {
+    if (!linkStat.isSymbolicLink()) {
       log("Skipped shared-registry symlink (a real directory exists here).");
       return;
     }
-    if (!opts?.force) {
+    if (!opts?.force && existsSync(link)) {
       log("Skipped shared-registry symlink (already exists).");
       return;
     }

--- a/packages/workspace/src/workspace.ts
+++ b/packages/workspace/src/workspace.ts
@@ -3,9 +3,11 @@ import {
   appendFileSync,
   closeSync,
   existsSync,
+  lstatSync,
   mkdirSync,
   openSync,
   readFileSync,
+  rmSync,
   symlinkSync,
   writeFileSync,
 } from "node:fs";
@@ -15,8 +17,10 @@ import { parseWorkspaceArgs, printWorkspaceHelp, type WorkspaceCommand } from ".
 import {
   findOwnEntry,
   liveWorktrees,
+  mergeDevServers,
   readDevServers,
   removeDevServerEntryByWorktree,
+  writeDevServers,
 } from "./dev-servers-registry.js";
 import { ConfigError } from "./errors.js";
 import {
@@ -31,12 +35,17 @@ import {
   handleSetOwner,
   markSlotFailed,
   markSlotReady,
+  mergeSlots,
   readSlots,
+  REGISTRY_SUBDIR,
+  registryDirFor,
   resolveAndRegisterSlot,
   resolveCurrentSlot,
   type SlotEntry,
+  type SlotsRegistry,
   type SlotStatus,
   validateSlotAvailability,
+  warnLegacyRegistryDir,
   writeSlots,
 } from "./slots.js";
 import {
@@ -84,12 +93,6 @@ export interface WorkspaceConfig {
    * Holds the setup log and dev-server logs.
    */
   runtimeDir: string;
-  /**
-   * Shared registry directory, relative to a worktree root (e.g. `.local/_workspace-registry`).
-   * Holds `slots.json` and `dev-servers.json`. Must resolve to the same physical directory
-   * across linked worktrees — typically via a symlink listed in `sharedDirs` (e.g. `.local`).
-   */
-  registryDir: string;
   /** Config files copied from the main worktree and patched per slot. */
   configFiles: ConfigFileEntry[];
   /**
@@ -239,6 +242,13 @@ export async function runWorkspace(config: WorkspaceConfig): Promise<void> {
     return;
   }
 
+  warnLegacyRegistryDir(config.runtimeDir, (config as { registryDir?: string }).registryDir);
+
+  if (command.kind === "migrate") {
+    handleMigrate(command, config);
+    return;
+  }
+
   if (!existsSync(config.scriptPath)) {
     console.error(
       `Error: scriptPath does not exist: ${config.scriptPath}. ` +
@@ -295,12 +305,12 @@ async function runSetup(
   validateSlotAvailability(command.slot, {
     currentWorktree: ctx.currentWorktree,
     mainWorktree: ctx.mainWorktree,
-    registryDir: config.registryDir,
+    registryDir: registryDirFor(config.runtimeDir),
     scheme,
   });
 
   const setupCtx = ensureWorktree(command, ctx, run, config.worktreeDirName);
-  refuseIfFinalizePending(setupCtx, config.registryDir, command.force);
+  refuseIfFinalizePending(setupCtx, registryDirFor(config.runtimeDir), command.force);
   const branch = getWorktreeBranch(setupCtx.currentWorktree) ?? "(detached)";
   const {
     port: slot,
@@ -310,7 +320,7 @@ async function runSetup(
     slot: command.slot,
     currentWorktree: setupCtx.currentWorktree,
     mainWorktree: setupCtx.mainWorktree,
-    registryDir: config.registryDir,
+    registryDir: registryDirFor(config.runtimeDir),
     scheme,
     requestedOwner: command.owner,
     isMainWorktree: setupCtx.isMainWorktree,
@@ -351,6 +361,7 @@ async function runSetup(
   }
 
   linkSharedDirectories(setupCtx, config.sharedDirs, verboseLog);
+  linkSharedRegistry(setupCtx, config.runtimeDir, verboseLog);
   generateConfigFiles(setupCtx, config.configFiles, slot, ports, command.force, verboseLog);
 
   teeLog(
@@ -411,7 +422,7 @@ async function runFinalize(command: FinalizeCommand, config: WorkspaceConfig): P
     appendFileSync(logPath, `${message}\n`);
   };
 
-  const registry = readSlots(ctx.mainWorktree, config.registryDir);
+  const registry = readSlots(ctx.mainWorktree, registryDirFor(config.runtimeDir));
   const entry = registry.slots[String(slot)];
   if (!entry || resolve(entry.worktree) !== resolve(ctx.currentWorktree)) {
     appendLog(`FAILED: No matching slot ${slot} for worktree ${ctx.currentWorktree}.`);
@@ -444,14 +455,14 @@ async function runFinalize(command: FinalizeCommand, config: WorkspaceConfig): P
 
   try {
     await config.finalizeWorktree(setupContext);
-    markSlotReady(ctx.mainWorktree, config.registryDir, slot);
+    markSlotReady(ctx.mainWorktree, registryDirFor(config.runtimeDir), slot);
     appendLog("============================================================");
     appendLog(`READY: branch ${branch} (slot ${slot})`);
     appendLog("============================================================");
   } catch (err) {
     const message = (err as Error).message;
     const stack = (err as Error).stack ?? "";
-    markSlotFailed(ctx.mainWorktree, config.registryDir, slot, message);
+    markSlotFailed(ctx.mainWorktree, registryDirFor(config.runtimeDir), slot, message);
     appendLog(`FAILED: ${message}`);
     if (stack) appendLog(stack);
     process.exit(1);
@@ -470,7 +481,7 @@ function resolveTargetSlot(slotArg: string | undefined, config: WorkspaceConfig)
     }
     return slot;
   }
-  return resolveCurrentSlot(config.basePort, config.registryDir).slot;
+  return resolveCurrentSlot(config.basePort, registryDirFor(config.runtimeDir)).slot;
 }
 
 function printWorktreeInfo(
@@ -480,7 +491,7 @@ function printWorktreeInfo(
   fallback: { owner?: string },
 ): void {
   const ctx = detectWorktree();
-  const registry = readSlots(ctx.mainWorktree, config.registryDir);
+  const registry = readSlots(ctx.mainWorktree, registryDirFor(config.runtimeDir));
   const entry: SlotEntry | undefined = registry.slots[String(slot)];
   const ports = resolvePortsFn(config)(slot);
 
@@ -521,7 +532,7 @@ function printDevServerBlock(
   targetWorktree: string,
   now: number,
 ): void {
-  const entry = findOwnEntry(mainWorktree, config.registryDir, targetWorktree);
+  const entry = findOwnEntry(mainWorktree, registryDirFor(config.runtimeDir), targetWorktree);
   const liveEntries = entry
     ? Object.entries(entry.pids)
         .filter(([, pid]) => isProcessAlive(pid))
@@ -545,7 +556,9 @@ function runStatus(command: StatusCommand, config: WorkspaceConfig): void {
   if (command.slot !== undefined) {
     const slot = resolveTargetSlot(command.slot, config);
     const ctx = detectWorktree();
-    const entry = readSlots(ctx.mainWorktree, config.registryDir).slots[String(slot)];
+    const entry = readSlots(ctx.mainWorktree, registryDirFor(config.runtimeDir)).slots[
+      String(slot)
+    ];
     if (!entry) {
       console.error(`Error: No slot ${slot} in registry.`);
       process.exit(1);
@@ -553,7 +566,7 @@ function runStatus(command: StatusCommand, config: WorkspaceConfig): void {
     printWorktreeInfo(config, slot, entry.worktree, { owner: entry.owner });
     return;
   }
-  const resolved = resolveCurrentSlot(config.basePort, config.registryDir);
+  const resolved = resolveCurrentSlot(config.basePort, registryDirFor(config.runtimeDir));
   printWorktreeInfo(config, resolved.slot, resolved.worktree, {
     owner: resolved.owner,
   });
@@ -561,14 +574,16 @@ function runStatus(command: StatusCommand, config: WorkspaceConfig): void {
 
 function runList(config: WorkspaceConfig): void {
   const ctx = detectWorktree();
-  const entries = Object.entries(readSlots(ctx.mainWorktree, config.registryDir).slots).sort(
-    ([a], [b]) => Number(a) - Number(b),
-  );
+  const entries = Object.entries(
+    readSlots(ctx.mainWorktree, registryDirFor(config.runtimeDir)).slots,
+  ).sort(([a], [b]) => Number(a) - Number(b));
   if (entries.length === 0) {
     console.log("No workspaces registered.");
     return;
   }
-  const liveSet = liveWorktrees(readDevServers(ctx.mainWorktree, config.registryDir));
+  const liveSet = liveWorktrees(
+    readDevServers(ctx.mainWorktree, registryDirFor(config.runtimeDir)),
+  );
   const rows = entries.map(([port, e]) => ({
     slot: port,
     type: e.main ? "main" : "linked",
@@ -619,7 +634,9 @@ async function waitForSlot(
 ): Promise<void> {
   const printSummary = options.printSummary ?? true;
   const ctx = detectWorktree();
-  const initial = readSlots(ctx.mainWorktree, config.registryDir).slots[String(slot)];
+  const initial = readSlots(ctx.mainWorktree, registryDirFor(config.runtimeDir)).slots[
+    String(slot)
+  ];
   if (!initial) {
     console.error(`Error: No slot ${slot} in registry.`);
     process.exit(1);
@@ -629,7 +646,9 @@ async function waitForSlot(
   // Poll slots.json — the finalize child writes `status` on success or failure. Tiny file, no
   // log-tailing race.
   for (;;) {
-    const entry = readSlots(ctx.mainWorktree, config.registryDir).slots[String(slot)];
+    const entry = readSlots(ctx.mainWorktree, registryDirFor(config.runtimeDir)).slots[
+      String(slot)
+    ];
     if (!entry) {
       console.error(`Error: Slot ${slot} disappeared from registry.`);
       process.exit(1);
@@ -663,7 +682,7 @@ async function handleRemove(
 ): Promise<void> {
   const verboseLog = makeVerboseLog(run.verbose);
   const removeHere = command.branch === undefined;
-  const registry = readSlots(ctx.mainWorktree, config.registryDir);
+  const registry = readSlots(ctx.mainWorktree, registryDirFor(config.runtimeDir));
   const target = resolveRemoveTarget(command, ctx, registry);
 
   // Refuse to remove while the detached finalize is still writing to slots.json / workspace-setup.log:
@@ -687,14 +706,18 @@ async function handleRemove(
       `Warning: Worktree directory ${target.worktreePath} not found. Cleaning up registry only.`,
     );
     delete registry.slots[target.slotPort];
-    writeSlots(ctx.mainWorktree, config.registryDir, registry);
+    writeSlots(ctx.mainWorktree, registryDirFor(config.runtimeDir), registry);
     console.log(
       `Removed registry entry for branch "${target.branch}" (slot ${target.slotPort}${ownerSuffix}).`,
     );
     return;
   }
 
-  const targetEntry = findOwnEntry(ctx.mainWorktree, config.registryDir, target.worktreePath);
+  const targetEntry = findOwnEntry(
+    ctx.mainWorktree,
+    registryDirFor(config.runtimeDir),
+    target.worktreePath,
+  );
   if (targetEntry) {
     stopTargetDevServer(config.devServerScript, target.worktreePath, verboseLog);
   } else {
@@ -710,8 +733,12 @@ async function handleRemove(
   }
 
   delete registry.slots[target.slotPort];
-  writeSlots(ctx.mainWorktree, config.registryDir, registry);
-  removeDevServerEntryByWorktree(ctx.mainWorktree, config.registryDir, target.worktreePath);
+  writeSlots(ctx.mainWorktree, registryDirFor(config.runtimeDir), registry);
+  removeDevServerEntryByWorktree(
+    ctx.mainWorktree,
+    registryDirFor(config.runtimeDir),
+    target.worktreePath,
+  );
 
   if (removeHere) {
     process.chdir(ctx.mainWorktree);
@@ -740,12 +767,16 @@ function handleSetOwnerMode(
     newOwner,
     currentWorktree: ctx.currentWorktree,
     mainWorktree: ctx.mainWorktree,
-    registryDir: config.registryDir,
+    registryDir: registryDirFor(config.runtimeDir),
     isMainWorktree: ctx.isMainWorktree,
   });
 
   // Propagate to dev-servers.json entries for this worktree.
-  const devServersPath = join(ctx.mainWorktree, config.registryDir, "dev-servers.json");
+  const devServersPath = join(
+    ctx.mainWorktree,
+    registryDirFor(config.runtimeDir),
+    "dev-servers.json",
+  );
   if (existsSync(devServersPath)) {
     const data = JSON.parse(readFileSync(devServersPath, "utf-8")) as {
       servers: { worktree: string; owner?: string }[];
@@ -766,6 +797,63 @@ function handleSetOwnerMode(
   }
 
   console.log(`Owner for slot ${slotPort}: ${newOwner ?? "(none)"}`);
+}
+
+type MigrateCommand = Extract<WorkspaceCommand, { kind: "migrate" }>;
+
+/** Transitional (0.16 only): merge a pre-0.16 registry into `${runtimeDir}/shared-registry`. */
+function handleMigrate(command: MigrateCommand, config: WorkspaceConfig): void {
+  const ctx = detectWorktree();
+  const newRel = registryDirFor(config.runtimeDir);
+  const oldRel = command.oldRegistryDir;
+  const oldAbs = join(ctx.mainWorktree, oldRel);
+
+  if (resolve(oldAbs) === resolve(join(ctx.mainWorktree, newRel))) {
+    console.log(`Registry already at ${newRel}; relinking worktrees.`);
+    relinkWorktrees(readSlots(ctx.mainWorktree, newRel), ctx.mainWorktree, config.runtimeDir);
+    return;
+  }
+  if (!existsSync(oldAbs)) {
+    console.error(`Error: nothing to migrate at ${oldAbs}.`);
+    process.exit(1);
+  }
+
+  const mergedSlots = mergeSlots(
+    readSlots(ctx.mainWorktree, oldRel),
+    readSlots(ctx.mainWorktree, newRel),
+  );
+  writeSlots(ctx.mainWorktree, newRel, mergedSlots);
+  const mergedDevServers = mergeDevServers(
+    readDevServers(ctx.mainWorktree, oldRel),
+    readDevServers(ctx.mainWorktree, newRel),
+  );
+  writeDevServers(ctx.mainWorktree, newRel, mergedDevServers);
+  rmSync(oldAbs, { recursive: true, force: true });
+
+  const relinked = relinkWorktrees(mergedSlots, ctx.mainWorktree, config.runtimeDir);
+  console.log(
+    `Migrated ${oldRel} → ${newRel}: ${Object.keys(mergedSlots.slots).length} slot(s), ` +
+      `${mergedDevServers.servers.length} dev-server(s); ${relinked} symlink(s) recreated.`,
+  );
+}
+
+function relinkWorktrees(slots: SlotsRegistry, mainWorktree: string, runtimeDir: string): number {
+  let count = 0;
+  for (const entry of Object.values(slots.slots)) {
+    if (entry.main) continue;
+    if (!existsSync(entry.worktree)) {
+      console.warn(`Warning: worktree ${entry.worktree} not found; skipping symlink.`);
+      continue;
+    }
+    linkSharedRegistry(
+      { currentWorktree: entry.worktree, mainWorktree, isMainWorktree: false },
+      runtimeDir,
+      console.log,
+      { force: true },
+    );
+    ++count;
+  }
+  return count;
 }
 
 function ensureWorktree(
@@ -797,6 +885,38 @@ function linkSharedDirectories(
       log(`Created ${dirName} symlink → main worktree.`);
     }
   }
+}
+
+/**
+ * Symlinks the linked worktree's `${runtimeDir}/shared-registry` to the main worktree's, so the
+ * cwd-relative registry read in `resolveCurrentSlot` reaches main. `runtimeDir` is per-worktree and
+ * not in `sharedDirs`, so this is distinct from {@link linkSharedDirectories}.
+ */
+function linkSharedRegistry(
+  ctx: WorktreeContext,
+  runtimeDir: string,
+  log: (msg: string) => void,
+  opts?: { force?: boolean },
+): void {
+  if (ctx.isMainWorktree) return;
+  const mainDir = join(ctx.mainWorktree, runtimeDir, REGISTRY_SUBDIR);
+  mkdirSync(mainDir, { recursive: true });
+  const runtimeRoot = join(ctx.currentWorktree, runtimeDir);
+  mkdirSync(runtimeRoot, { recursive: true });
+  const link = join(runtimeRoot, REGISTRY_SUBDIR);
+  if (existsSync(link)) {
+    if (!lstatSync(link).isSymbolicLink()) {
+      log("Skipped shared-registry symlink (a real directory exists here).");
+      return;
+    }
+    if (!opts?.force) {
+      log("Skipped shared-registry symlink (already exists).");
+      return;
+    }
+    rmSync(link);
+  }
+  symlinkSync(relative(runtimeRoot, mainDir), link);
+  log("Created shared-registry symlink → main worktree.");
 }
 
 function generateConfigFiles(

--- a/packages/workspace/test/cli.test.ts
+++ b/packages/workspace/test/cli.test.ts
@@ -91,6 +91,15 @@ describe("parseWorkspaceArgs", () => {
     expect(parseWorkspaceArgs(["wait"]).command).toEqual({ kind: "wait", slot: undefined });
   });
 
+  it("parses `migrate-0.16 <old-registry-dir>`", () => {
+    const { command } = parseWorkspaceArgs(["migrate-0.16", ".local/_workspace-registry"]);
+    expect(command).toEqual({ kind: "migrate", oldRegistryDir: ".local/_workspace-registry" });
+  });
+
+  it("rejects `migrate-0.16` without a positional", () => {
+    expect(() => parseWorkspaceArgs(["migrate-0.16"])).toThrow(ConfigError);
+  });
+
   it("rejects an unknown subcommand", () => {
     expect(() => parseWorkspaceArgs(["frobnicate"])).toThrow(ConfigError);
   });

--- a/packages/workspace/test/dev-servers-registry.test.ts
+++ b/packages/workspace/test/dev-servers-registry.test.ts
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   evictOldest,
   liveWorktrees,
+  mergeDevServers,
   pruneDeadServers,
   readDevServers,
   writeDevServers,
@@ -77,6 +78,21 @@ describe("liveWorktrees", () => {
   it("returns an empty set when every entry is dead", () => {
     const data = { servers: [entry(8110, { main: 1 })] };
     expect(liveWorktrees(data, isAlive).size).toBe(0);
+  });
+});
+
+describe("mergeDevServers", () => {
+  it("unions by worktree, override wins, order preserved (base-first then override-only)", () => {
+    const base = {
+      servers: [entry(8110, { main: 1 }), entry(8120, { main: 2 })],
+    };
+    const override = {
+      servers: [{ ...entry(8120, { main: 99 }), owner: "bob" }, entry(8130, { main: 3 })],
+    };
+    const merged = mergeDevServers(base, override);
+    expect(merged.servers.map((e) => e.slot)).toEqual([8110, 8120, 8130]);
+    expect(merged.servers[1].pids).toEqual({ main: 99 });
+    expect(merged.servers[1].owner).toBe("bob");
   });
 });
 

--- a/packages/workspace/test/slots.test.ts
+++ b/packages/workspace/test/slots.test.ts
@@ -1,0 +1,31 @@
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { mergeSlots, registryDirFor, type SlotEntry, type SlotsRegistry } from "../src/slots.js";
+
+function slot(worktree: string, status: SlotEntry["status"] = "ready"): SlotEntry {
+  return { worktree, createdAt: "2026-05-10T00:00:00.000Z", status };
+}
+
+describe("registryDirFor", () => {
+  it("appends the shared-registry subdir to runtimeDir", () => {
+    expect(registryDirFor(".local-wt")).toBe(join(".local-wt", "shared-registry"));
+  });
+});
+
+describe("mergeSlots", () => {
+  it("lets the override win on a conflicting slot port", () => {
+    const base: SlotsRegistry = { slots: { "8110": slot("/tmp/old") } };
+    const override: SlotsRegistry = { slots: { "8110": slot("/tmp/new") } };
+    expect(mergeSlots(base, override).slots["8110"].worktree).toBe("/tmp/new");
+  });
+
+  it("preserves base-only keys", () => {
+    const base: SlotsRegistry = { slots: { "8110": slot("/tmp/a"), "8120": slot("/tmp/b") } };
+    const override: SlotsRegistry = { slots: { "8120": slot("/tmp/b2") } };
+    const merged = mergeSlots(base, override);
+    expect(merged.slots["8110"].worktree).toBe("/tmp/a");
+    expect(merged.slots["8120"].worktree).toBe("/tmp/b2");
+  });
+});

--- a/skills/workspace-guide/SKILL.md
+++ b/skills/workspace-guide/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Requires git. Template scripts are in Node.js but the approach wo
 license: CC0 1.0
 metadata:
   author: Paleo
-  version: "0.10.1"
+  version: "0.10.2"
   repository: https://github.com/paleo/skills
 ---
 
@@ -65,7 +65,7 @@ Each worktree gets a unique "slot" that determines its port(s). A central **slot
 
 The slot is identified by the primary port number itself (e.g., `--slot 8120`).
 
-**Registry format** (stored in a shared directory, e.g. `.local/_workspace-registry/slots.json`):
+**Registry format** (stored under the main worktree's `runtimeDir`, e.g. `.local-wt/shared-registry/slots.json`):
 
 ```json
 {
@@ -82,7 +82,7 @@ The main worktree is registered at `basePort` (the first slot); linked worktrees
 
 Host RAM is shared. Without a cap, parallel dev-servers (especially when an AI bot fans out worktrees) can exhaust memory. The wrapper passes an optional `devLimit` number to `runDevServer`; omit it for no limit. A hardcoded `5` is a sensible default — bump it if your stack is light, lower it if it's heavy.
 
-A second registry, `.local/_workspace-registry/dev-servers.json`, tracks live dev-servers. It lives in the main worktree's shared directory; linked worktrees reach it via the existing `.local` symlink. An entry is **live** if at least one PID in its `pids` map is alive; dead entries are pruned on every read. When `live >= limit`, `dev` / `dev up` aborts and lists the active servers (slot, branch, owner, pids, started-at, worktree path). Re-run with `--evict` to stop the oldest live dev-server across all worktrees and start the new one instead of aborting.
+A second registry, `.local-wt/shared-registry/dev-servers.json`, tracks live dev-servers. It lives under the main worktree's `runtimeDir`; linked worktrees reach it via a `shared-registry` symlink created by `workspace setup`. An entry is **live** if at least one PID in its `pids` map is alive; dead entries are pruned on every read. When `live >= limit`, `dev` / `dev up` aborts and lists the active servers (slot, branch, owner, pids, started-at, worktree path). Re-run with `--evict` to stop the oldest live dev-server across all worktrees and start the new one instead of aborting.
 
 ### Config files must be gitignored
 
@@ -110,7 +110,7 @@ The package's `runWorkspace(config: WorkspaceConfig)` performs the lifecycle bel
 1. **Creates the worktree.** Path computed automatically (`../<reponame>-<slug>`). The default slug strips a recognizable ticket suffix from the last branch segment (`feat/ABC-123-extra` → `feat-ABC-123`), caps at 22 chars, and trims trailing dashes. Override via `config.worktreeDirName` (see below). With `-c`, branch-name dedup (appends `-2`, `-3`...) when the name is taken; the directory is independently deduped if a directory of the same name already exists on disk.
 2. **Detects worktrees.** Finds the main worktree via `git rev-parse --git-common-dir` (parent of `.git`).
 3. **Assigns a slot.** Auto-assigns the first available port, or accepts `--slot PORT`. Records `{ worktree, branch, owner? }` in the slot registry. `owner` is undefined by default; `--owner NAME` sets it; on re-setup without `--owner`, the existing owner is preserved.
-4. **Symlinks shared directories** from `config.sharedDirs` (default `[".local", ".plans"]`) to the main worktree using relative paths.
+4. **Symlinks shared directories** from `config.sharedDirs` (default `[".local", ".plans"]`) to the main worktree using relative paths. On a linked worktree it also creates the `shared-registry` symlink, pointing the worktree's `${runtimeDir}/shared-registry` at the main worktree's.
 5. **Generates config files** by iterating `config.configFiles`. Each entry is `{ path, source?, patch(content, ctx), optional? }`; the source (the main worktree's `path` by default) is read and run through `patch`. `optional: true` downgrades a missing source from an error to a skip+warning.
 6. **Runs `await config.finalizeWorktree(ctx)`** in a detached background process. This callback owns infrastructure startup, dependency install / build, database provisioning, migrations, and seeding (see "Database provisioning" below). It MUST be idempotent — `workspace setup` re-runs it as the documented retry path.
 7. **Prints a summary** by calling `config.printSummary(ctx)` and `console.log`-ing the returned string.
@@ -135,6 +135,7 @@ The package's `runWorkspace(config: WorkspaceConfig)` performs the lifecycle bel
 | `workspace status` | Print the summary (ports, branch, readiness) for the current worktree. Status shows elapsed time since `createdAt` / `failure.at` for `pending` / `failed` slots (e.g. `pending, started 4m 12s ago`); a `Dev-server:` block reports whether the dev-server is running, with PIDs and log paths |
 | `workspace wait` | Block until the background finalize reaches `READY:` (exit 0, prints the worktree summary) or `FAILED:` (exit 1). Uses the current worktree's slot, or `--slot PORT` to target another. Use for CI / agent orchestration |
 | `workspace set-owner <name>` | Update the owner of the current linked worktree's slot — no rebuild |
+| `workspace migrate-0.16 <old-registryDir>` | Transitional (0.16 only): merge a pre-0.16 registry into `${runtimeDir}/shared-registry` and relink worktrees. Removed in the next release |
 
 Per-subcommand flags: `setup` accepts `-c`/`--new-branch`, `--owner <name>`, `-s`/`--slot <port>`, `--force`, `--wait`; `remove` accepts `--no-remote-check`; `status`/`wait` accept `-s`/`--slot <port>`; `-v`/`--verbose` is global. `workspace --help` prints help and exits 0; bare `workspace` (or an unknown command) prints a warning then help and exits 1.
 
@@ -146,8 +147,7 @@ Per-subcommand flags: `setup` accepts `-c`/`--new-branch`, `--owner <name>`, `-s
 - `portStep` (default `10`), `maxSlotCount` (default `19`).
 - `ports(slot)` or `portNames` — supply either a function returning the port map for a slot, or a list of names that defaults to consecutive ports (`{ name0: slot, name1: slot+1, ... }`).
 - `sharedDirs: string[]` — required. Directories symlinked from the main worktree (e.g. `[".local", ".plans"]`).
-- `runtimeDir: string` — required. Per-worktree runtime directory relative to the worktree root (e.g. `.local-wt`). Holds the setup log and dev-server logs.
-- `registryDir: string` — required. Shared registry directory relative to a worktree root (e.g. `.local/_workspace-registry`). Holds `slots.json` and `dev-servers.json`. Must resolve to the same physical directory across linked worktrees — typically a subdirectory under a `sharedDirs` entry (e.g. `.local`).
+- `runtimeDir: string` — required. Per-worktree runtime directory relative to the worktree root (e.g. `.local-wt`). Holds the setup log and dev-server logs. The registry lives at `${runtimeDir}/shared-registry` (`slots.json`, `dev-servers.json`), symlinked to the main worktree per linked worktree by `workspace setup`.
 - `configFiles: Array<{ path, source?, patch, optional? }>` — one entry per gitignored config file. `patch(content, { slot, ports, mainWorktree, currentWorktree })` returns the rewritten content. Use `helpers.patchEnvFile` for `KEY=VALUE` files and `helpers.extractHost` to preserve non-localhost hosts. `source` overrides where the initial content comes from (default: `path` read from the main worktree): `{ path }` (relative to the main worktree, e.g. a committed example), `{ content }` (verbatim), or a callback `(ctx) => { path } | { content }` receiving the same `PatchContext`. `optional: true` skips the entry (warning) when a `{ path }` source is missing instead of aborting.
 - `finalizeWorktree(ctx)` — required callback. Runs in a detached background process after the foreground command returns. Owns infrastructure startup (e.g. `docker compose up -d`), database readiness wait, `npm install` / build, migrations, and seeding. **MUST be idempotent** — `workspace setup` is the documented retry path and re-runs this same callback. **Run `npm install` first** so any later failure leaves a worktree with usable `node_modules/`; otherwise the `workspace setup` retry can't import `@paleo/workspace`. Failures are logged to `<runtimeDir>/logs/workspace-setup.log` with a `FAILED:` banner.
 - `purgeInfrastructure(ctx)` — optional. Called by `workspace remove` after the dev-server stop. The standard pattern is `docker compose down -v` if you use Docker — destructive teardown that wipes volumes, complementing the soft `docker compose down` in the callback `stop()`.
@@ -371,6 +371,6 @@ The agents need to know:
 - [ ] **Write `dev-server`** using [assets/dev-server.mjs](assets/dev-server.mjs) as a starting point. Same approach.
 - [ ] **Add npm scripts** (or Makefile targets, etc.): `workspace` and a single `dev` (don't reuse the app's own dev script name).
 - [ ] **Set the dev-server cap** by passing `devLimit` to `runDevServer` (default `5`).
-- [ ] **Update `.gitignore`** to ignore your shared and per-worktree directories (e.g. `.local/`, `.local-wt/`). Make sure `.local/_workspace-registry/` is covered (slot registry and dev-server registry live there).
+- [ ] **Update `.gitignore`** to ignore your shared and per-worktree directories (e.g. `.local/`, `.local-wt/`). The registry now lives under `runtimeDir` (`.local-wt/shared-registry/`), already covered.
 - [ ] **Write agent documentation** if applicable (see [assets/workspace.md](assets/workspace.md)).
 - [ ] **Update your main instruction file** (`AGENTS.md` / `CLAUDE.md`) with a pointer to the agent documentation and any conventions (branch naming, commit messages) the agent needs to follow.

--- a/skills/workspace-guide/SKILL.md
+++ b/skills/workspace-guide/SKILL.md
@@ -371,6 +371,6 @@ The agents need to know:
 - [ ] **Write `dev-server`** using [assets/dev-server.mjs](assets/dev-server.mjs) as a starting point. Same approach.
 - [ ] **Add npm scripts** (or Makefile targets, etc.): `workspace` and a single `dev` (don't reuse the app's own dev script name).
 - [ ] **Set the dev-server cap** by passing `devLimit` to `runDevServer` (default `5`).
-- [ ] **Update `.gitignore`** to ignore your shared and per-worktree directories (e.g. `.local/`, `.local-wt/`). The registry now lives under `runtimeDir` (`.local-wt/shared-registry/`), already covered.
+- [ ] **Update `.gitignore`** to ignore your shared and per-worktree directory (e.g. `.local-wt/`).
 - [ ] **Write agent documentation** if applicable (see [assets/workspace.md](assets/workspace.md)).
 - [ ] **Update your main instruction file** (`AGENTS.md` / `CLAUDE.md`) with a pointer to the agent documentation and any conventions (branch naming, commit messages) the agent needs to follow.

--- a/skills/workspace-guide/assets/dev-server.mjs
+++ b/skills/workspace-guide/assets/dev-server.mjs
@@ -16,8 +16,7 @@ import { runDevServer, helpers } from "@paleo/workspace";
 
 await runDevServer({
   basePort: 8100, // ADAPT
-  runtimeDir: ".local-wt", // Per-worktree runtime directory; dev-server log paths derive from this + each server's name.
-  registryDir: ".local/_workspace-registry", // Shared registry dir (`slots.json`, `dev-servers.json`); reached via the `.local` symlink in linked worktrees.
+  runtimeDir: ".local-wt", // Per-worktree runtime directory; dev-server log paths derive from this + each server's name. The registry lives at `${runtimeDir}/shared-registry`.
   devLimit: 5,    // ADAPT — cap on concurrent dev-servers across worktrees; omit for no limit.
 
   servers: [

--- a/skills/workspace-guide/assets/dev-server.mjs
+++ b/skills/workspace-guide/assets/dev-server.mjs
@@ -12,11 +12,11 @@
 // (e.g. `dev:app`) for the app's own dev command.
 // =============================================================================
 
-import { runDevServer, helpers } from "@paleo/workspace";
+import { helpers, runDevServer } from "@paleo/workspace";
 
 await runDevServer({
   basePort: 8100, // ADAPT
-  runtimeDir: ".local-wt", // Per-worktree runtime directory; dev-server log paths derive from this + each server's name. The registry lives at `${runtimeDir}/shared-registry`.
+  runtimeDir: ".local-wt", // Per-worktree runtime directory. The symlinked registry lives at `${runtimeDir}/shared-registry`.
   devLimit: 5,    // ADAPT — cap on concurrent dev-servers across worktrees; omit for no limit.
 
   servers: [

--- a/skills/workspace-guide/assets/workspace.md
+++ b/skills/workspace-guide/assets/workspace.md
@@ -136,6 +136,5 @@ npm run dev -- down                     # 4. stop when done (same directory)
 
 - **`.local/`** — Shared across worktrees (symlinked). It's the right place for any gitignored working files (e.g. personal notes…).
 - **`.local-wt/`** — Per-worktree. Runtime data: databases, caches, `logs/` (dev server logs).
-  - `shared-registry/slots.json` — Slot registry; main worktree at `basePort` plus linked-worktree slots. (Symlinked to the main worktree in linked worktrees.)
-  - `shared-registry/dev-servers.json` — Live dev-server registry.
+  - `shared-registry/` — The workspace registry. Symlinked to the main worktree in linked worktrees.
 - **`.plans/`** — Shared across worktrees (symlinked). Task planning files.

--- a/skills/workspace-guide/assets/workspace.md
+++ b/skills/workspace-guide/assets/workspace.md
@@ -135,7 +135,7 @@ npm run dev -- down                     # 4. stop when done (same directory)
 <!-- ADAPT: List your shared and per-worktree directories. -->
 
 - **`.local/`** — Shared across worktrees (symlinked). It's the right place for any gitignored working files (e.g. personal notes…).
-  - `_workspace-registry/slots.json` — Slot registry; main worktree at `basePort` plus linked-worktree slots.
-  - `_workspace-registry/dev-servers.json` — Live dev-server registry.
 - **`.local-wt/`** — Per-worktree. Runtime data: databases, caches, `logs/` (dev server logs).
+  - `shared-registry/slots.json` — Slot registry; main worktree at `basePort` plus linked-worktree slots. (Symlinked to the main worktree in linked worktrees.)
+  - `shared-registry/dev-servers.json` — Live dev-server registry.
 - **`.plans/`** — Shared across worktrees (symlinked). Task planning files.

--- a/skills/workspace-guide/assets/workspace.mjs
+++ b/skills/workspace-guide/assets/workspace.mjs
@@ -51,11 +51,6 @@ await runWorkspace({
   // and dev-server logs under here.
   runtimeDir: ".local-wt",
 
-  // Shared registry directory holding `slots.json` and `dev-servers.json`.
-  // Must resolve to the same physical directory across linked worktrees —
-  // typically via a symlink listed in `sharedDirs` (e.g. `.local`).
-  registryDir: ".local/_workspace-registry",
-
   // ADAPT: gitignored config files copied from the main worktree and patched
   // per slot. The source is the same path in the main worktree.
   configFiles: [


### PR DESCRIPTION
- `@paleo/workspace`: removed the `registryDir` config option; the registry now lives at `${runtimeDir}/shared-registry`, symlinked into each linked worktree by `workspace setup`. A transitional `workspace migrate-0.16 <old-registryDir>` command merges a pre-0.16 registry into the new location. A leftover `registryDir` in a config triggers a one-time warning.
- `@paleo/openclaw-test`: `init` now adds the four test scripts to the target `package.json`; README condensed.
