### PR TITLE
feat: drop remote check, guard dirty remove, add setup --from

### DIFF
--- a/.changeset/remove-guards-setup-from.md
+++ b/.changeset/remove-guards-setup-from.md
@@ -1,0 +1,5 @@
+---
+"@paleo/workspace": minor
+---
+
+`workspace remove` no longer checks the remote (`--no-remote-check` is gone — the local branch is always kept) and now refuses on uncommitted changes unless `--force`. `workspace setup <branch> [-c]` runs from any worktree; with `-c`, the new branch starts at the current worktree's HEAD, or at any commit-ish via the new `--from <ref>` option.

--- a/.changeset/remove-guards-setup-from.md
+++ b/.changeset/remove-guards-setup-from.md
@@ -1,5 +1,0 @@
----
-"@paleo/workspace": minor
----
-
-`workspace remove` no longer checks the remote (`--no-remote-check` is gone — the local branch is always kept) and now refuses on uncommitted changes unless `--force`. `workspace setup <branch> [-c]` runs from any worktree; with `-c`, the new branch starts at the current worktree's HEAD, or at any commit-ish via the new `--from <ref>` option.

--- a/docs/workspace-architecture.md
+++ b/docs/workspace-architecture.md
@@ -56,7 +56,7 @@ Consequences for callback authors:
 
 ## The `workspace remove` re-exec
 
-`workspace remove` shells out to `node <devServerScript> down` with `cwd: <target worktree>` rather than stopping the dev-server in-process. This is structural: the `workspace` script doesn't import the dev-server config, so it cannot dispatch callbacks itself. Delegating to the target's own `dev-server.mjs` is how the kernel reaches the callbacks defined on the target's branch. Only after that does `remove` run `purgeInfrastructure` (e.g. `docker compose down -v`), free the slot, and `git worktree remove --force`.
+`workspace remove` shells out to `node <devServerScript> down` with `cwd: <target worktree>` rather than stopping the dev-server in-process. This is structural: the `workspace` script doesn't import the dev-server config, so it cannot dispatch callbacks itself. Delegating to the target's own `dev-server.mjs` is how the kernel reaches the callbacks defined on the target's branch. Only after that does `remove` run `purgeInfrastructure` (e.g. `docker compose down -v`), free the slot, and `git worktree remove --force`. Before any of these teardown steps, `remove` refuses when the worktree has uncommitted changes, unless `--force` is passed.
 
 ## Concurrency-cap TOCTOU race
 

--- a/openclaw-coder/playbook-test/projects-fixture/template/docs/workspace.md
+++ b/openclaw-coder/playbook-test/projects-fixture/template/docs/workspace.md
@@ -144,5 +144,5 @@ When the user asks to create a PR:
 
 - **`.local/`** — Shared across worktrees (symlinked). It's the right place for any gitignored working files (e.g. personal notes…).
 - **`.local-wt/`** — Per-worktree. Runtime data: databases, caches, `logs/` (dev server logs).
-  - `shared-registry/` — The workspace registry. Symlinked to the main worktree in linked worktrees.
+  - `workspace-registry/` — The workspace registry. Symlinked to the main worktree in linked worktrees.
 - **`.plans/`** — Shared across worktrees (symlinked). Task planning files.

--- a/openclaw-coder/playbook-test/projects-fixture/template/docs/workspace.md
+++ b/openclaw-coder/playbook-test/projects-fixture/template/docs/workspace.md
@@ -17,9 +17,12 @@ When the user asks to "set up a new workspace" or "set up a new worktree":
 
 ```sh
 pnpm workspace setup ABC-123/fix -c    # new branch + worktree (dedup: appends -2, -3… if taken)
+pnpm workspace setup ABC-456/fix -c --from origin/ABC-123/fix   # new branch based on another branch
 pnpm workspace setup ABC-123/fix       # worktree on an existing branch
 pnpm workspace setup                   # set up the current worktree (idempotent — also the retry path)
 ```
+
+With `-c`, the new branch starts at the current worktree's HEAD (like `git switch -c`); `--from <ref>` accepts any commit-ish as the base.
 
 The foreground command creates the worktree, assigns a port slot, and generates config files. The remaining steps (`pnpm install`, build, Docker PostgreSQL, migrations, seed) run **detached in the background** and stream progress to `.local-wt/logs/workspace-setup.log`, ending with a `READY:` or `FAILED:` banner.
 
@@ -56,8 +59,8 @@ pnpm workspace list  # print all registered worktrees (slot, type, status, branc
 ### Take over an existing workspace
 
 ```sh
-pnpm workspace info               # print the current worktree's summary (type, ports, branch, readiness)
-pnpm workspace info --slot 6510   # same, for another worktree
+pnpm workspace status               # print the current worktree's summary (type, ports, branch, readiness)
+pnpm workspace status --slot 6510   # same, for another worktree
 ```
 
 ### Slot Owner
@@ -74,12 +77,11 @@ pnpm workspace set-owner bob        # update later, no rebuild
 ```sh
 pnpm workspace remove ABC-123/fix    # remove by branch name
 pnpm workspace remove                # remove the current worktree (from inside it)
-pnpm workspace remove ABC-123/fix --no-remote-check # skip remote branch check
 ```
 
-Stops the dev servers (if running), tears down the Docker container and volumes, frees the slot, and removes the worktree.
+Stops the dev servers (if running), tears down the Docker container and volumes, frees the slot, and removes the worktree. The local branch is always kept.
 
-By default, it verifies the branch has been removed from the remote first. Use `--no-remote-check` to skip that. When run from inside the worktree, the script prints the main worktree path. You'll have to run `cd <main-worktree>` afterward.
+Removal refuses when the worktree has uncommitted changes; pass `--force` to discard them. When run from inside the worktree, the script prints the main worktree path. You'll have to run `cd <main-worktree>` afterward.
 
 **NEVER** delete a branch unless the user explicitly requests it.
 

--- a/openclaw-coder/playbook-test/projects-fixture/template/package.json
+++ b/openclaw-coder/playbook-test/projects-fixture/template/package.json
@@ -16,6 +16,6 @@
   },
   "devDependencies": {
     "@paleo/docmap": "^0.5.1",
-    "@paleo/workspace": "^0.14.2"
+    "@paleo/workspace": "^0.18.0"
   }
 }

--- a/openclaw-coder/playbook-test/projects-fixture/template/package.json
+++ b/openclaw-coder/playbook-test/projects-fixture/template/package.json
@@ -16,6 +16,6 @@
   },
   "devDependencies": {
     "@paleo/docmap": "^0.5.1",
-    "@paleo/workspace": "^0.18.0"
+    "@paleo/workspace": "^0.19.0"
   }
 }

--- a/openclaw-coder/playbook-test/projects-fixture/template/pnpm-lock.yaml
+++ b/openclaw-coder/playbook-test/projects-fixture/template/pnpm-lock.yaml
@@ -16,8 +16,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       '@paleo/workspace':
-        specifier: ^0.18.0
-        version: 0.18.0
+        specifier: ^0.19.0
+        version: 0.19.0
 
 packages:
 
@@ -26,8 +26,8 @@ packages:
     engines: {node: '>=22.11.0'}
     hasBin: true
 
-  '@paleo/workspace@0.18.0':
-    resolution: {integrity: sha512-li5MpPIyTFrT2ygawY71koN/b8TPdU8Kxy8ZMK496WEZhS3E0SkhRv2ZiOlC++/HjFvEyvl7nLtz8+fTvMI5qA==}
+  '@paleo/workspace@0.19.0':
+    resolution: {integrity: sha512-nOk0HWW7XtfAF1yqV4TXxfOCA5+786Y8hToTdQN/aJvsUlqkMnpL6EeavSD51aEMb9Tjab6sIiR+YFcU030dSQ==}
     engines: {node: '>=22.11.0'}
 
   accepts@2.0.0:
@@ -292,7 +292,7 @@ snapshots:
 
   '@paleo/docmap@0.5.1': {}
 
-  '@paleo/workspace@0.18.0': {}
+  '@paleo/workspace@0.19.0': {}
 
   accepts@2.0.0:
     dependencies:

--- a/openclaw-coder/playbook-test/projects-fixture/template/pnpm-lock.yaml
+++ b/openclaw-coder/playbook-test/projects-fixture/template/pnpm-lock.yaml
@@ -16,8 +16,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       '@paleo/workspace':
-        specifier: ^0.14.2
-        version: 0.14.2
+        specifier: ^0.18.0
+        version: 0.18.0
 
 packages:
 
@@ -26,8 +26,8 @@ packages:
     engines: {node: '>=22.11.0'}
     hasBin: true
 
-  '@paleo/workspace@0.14.2':
-    resolution: {integrity: sha512-XVLDEiamZmuKvimp07thz9P9RLG+WAGwWbZQG30YX+o4DwgbJoaIguZ0VmU1u00qd3r6Tqq+JyJ4iQvDiH9Ncw==}
+  '@paleo/workspace@0.18.0':
+    resolution: {integrity: sha512-li5MpPIyTFrT2ygawY71koN/b8TPdU8Kxy8ZMK496WEZhS3E0SkhRv2ZiOlC++/HjFvEyvl7nLtz8+fTvMI5qA==}
     engines: {node: '>=22.11.0'}
 
   accepts@2.0.0:
@@ -292,7 +292,7 @@ snapshots:
 
   '@paleo/docmap@0.5.1': {}
 
-  '@paleo/workspace@0.14.2': {}
+  '@paleo/workspace@0.18.0': {}
 
   accepts@2.0.0:
     dependencies:

--- a/openclaw-coder/playbook-test/projects-fixture/template/scripts/workspace/dev-server.mjs
+++ b/openclaw-coder/playbook-test/projects-fixture/template/scripts/workspace/dev-server.mjs
@@ -10,7 +10,6 @@ const appScript = resolve(here, "..", "..", "app.mjs");
 await runDevServer({
   basePort: 6500,
   runtimeDir: ".local-wt",
-  registryDir: ".local/_workspace-registry",
 
   servers: [
     {

--- a/openclaw-coder/playbook-test/projects-fixture/template/scripts/workspace/workspace.mjs
+++ b/openclaw-coder/playbook-test/projects-fixture/template/scripts/workspace/workspace.mjs
@@ -15,7 +15,6 @@ await runWorkspace({
 
   sharedDirs: [".local", ".plans"],
   runtimeDir: ".local-wt",
-  registryDir: ".local/_workspace-registry",
 
   configFiles: [],
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -22061,7 +22061,7 @@
     },
     "packages/workspace": {
       "name": "@paleo/workspace",
-      "version": "0.17.0",
+      "version": "0.18.0",
       "license": "CC0-1.0",
       "devDependencies": {
         "@types/node": "~24.12.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22061,7 +22061,7 @@
     },
     "packages/workspace": {
       "name": "@paleo/workspace",
-      "version": "0.18.0",
+      "version": "0.19.0",
       "license": "CC0-1.0",
       "devDependencies": {
         "@types/node": "~24.12.4",

--- a/packages/workspace/CHANGELOG.md
+++ b/packages/workspace/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @paleo/workspace
 
+## 0.18.0
+
+### Minor Changes
+
+- 966b65d: `workspace remove` no longer checks the remote (`--no-remote-check` is gone — the local branch is always kept) and now refuses on uncommitted changes unless `--force`. `workspace setup <branch> [-c]` runs from any worktree; with `-c`, the new branch starts at the current worktree's HEAD, or at any commit-ish via the new `--from <ref>` option.
+
 ## 0.17.0
 
 ### Minor Changes

--- a/packages/workspace/CHANGELOG.md
+++ b/packages/workspace/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @paleo/workspace
 
+## 0.19.0
+
+### Minor Changes
+
+- Rename the registry directory: `${runtimeDir}/shared-registry` → `${runtimeDir}/workspace-registry`. `workspace migrate-0.16 <old-registryDir>` now merges into the new location and accepts any old registry path — including a 0.17/0.18 `${runtimeDir}/shared-registry` — and relinks worktrees.
+
 ## 0.18.0
 
 ### Minor Changes

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paleo/workspace",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Run multiple git-worktree dev environments side by side.",
   "keywords": [
     "workspace",

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paleo/workspace",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "Run multiple git-worktree dev environments side by side.",
   "keywords": [
     "workspace",

--- a/packages/workspace/src/cli.ts
+++ b/packages/workspace/src/cli.ts
@@ -6,12 +6,13 @@ export type WorkspaceCommand =
       kind: "setup";
       branch?: string;
       newBranch: boolean;
+      from?: string;
       owner?: string;
       slot?: string;
       force: boolean;
       wait: boolean;
     }
-  | { kind: "remove"; branch?: string; noRemoteCheck: boolean }
+  | { kind: "remove"; branch?: string; force: boolean }
   | { kind: "list" }
   | { kind: "status"; slot?: string }
   | { kind: "wait"; slot?: string }
@@ -67,6 +68,7 @@ function parseSetup(tokens: string[]): ParsedWorkspaceArgs {
     args: tokens,
     options: {
       "new-branch": { type: "boolean", short: "c" },
+      from: { type: "string" },
       owner: { type: "string" },
       slot: { type: "string", short: "s" },
       force: { type: "boolean" },
@@ -81,11 +83,15 @@ function parseSetup(tokens: string[]): ParsedWorkspaceArgs {
   if (newBranch && branch === undefined) {
     throw new ConfigError("`workspace setup <branch> -c` requires a branch name.");
   }
+  if (values.from !== undefined && !newBranch) {
+    throw new ConfigError("`--from` requires `-c`/`--new-branch`.");
+  }
   return {
     command: {
       kind: "setup",
       branch,
       newBranch,
+      from: values.from,
       owner: values.owner,
       slot: values.slot,
       force: values.force ?? false,
@@ -99,7 +105,7 @@ function parseRemove(tokens: string[]): ParsedWorkspaceArgs {
   const { values, positionals } = parseArgs({
     args: tokens,
     options: {
-      "no-remote-check": { type: "boolean" },
+      force: { type: "boolean" },
       verbose: { type: "boolean", short: "v" },
     },
     allowPositionals: true,
@@ -107,7 +113,7 @@ function parseRemove(tokens: string[]): ParsedWorkspaceArgs {
   });
   const branch = takeOptionalPositional(positionals, "remove");
   return {
-    command: { kind: "remove", branch, noRemoteCheck: values["no-remote-check"] ?? false },
+    command: { kind: "remove", branch, force: values.force ?? false },
     verbose: values.verbose ?? false,
   };
 }
@@ -212,13 +218,15 @@ export function printWorkspaceHelp(): void {
       "Manage workspaces: a git worktree plus its own dev setup (ports, config, database, dev server).",
       "",
       "Commands:",
-      "  setup [<branch>] [-c|--new-branch] [--owner <name>] [-s|--slot <port>] [--force] [--wait]",
+      "  setup [<branch>] [-c|--new-branch] [--from <ref>] [--owner <name>] [-s|--slot <port>] [--force] [--wait]",
       "      Set up the workspace. With <branch>, create a sibling worktree for it",
       "      (add -c to create the branch first). Without, set up the current worktree",
       "      (idempotent; bootstrap and retry path).",
+      "      With -c, the new branch starts at the current worktree's HEAD, or at <ref> with --from.",
       "      Finalize runs in the background; add --wait to block until it reaches READY.",
-      "  remove [<branch>] [--no-remote-check]",
+      "  remove [<branch>] [--force]",
       "      Remove a workspace by branch, or the current one when omitted.",
+      "      Refuses on uncommitted changes unless --force.",
       "  list",
       "      List all registered workspaces (slot, status, branch, path, owner, created).",
       "  status [-s|--slot <port>]",

--- a/packages/workspace/src/slots.ts
+++ b/packages/workspace/src/slots.ts
@@ -5,7 +5,7 @@ import { dirname, join, resolve } from "node:path";
 import { allPorts, isValidPort, type PortScheme } from "./ports.js";
 import { getWorktreeBranch } from "./worktree.js";
 
-export const REGISTRY_SUBDIR = "shared-registry";
+export const REGISTRY_SUBDIR = "workspace-registry";
 
 const SLOTS_FILENAME = "slots.json";
 

--- a/packages/workspace/src/workspace.ts
+++ b/packages/workspace/src/workspace.ts
@@ -51,12 +51,11 @@ import {
 import {
   createBranch,
   detectWorktree,
-  enforceWorktreeMode,
   getWorktreeBranch,
+  isWorktreeDirty,
   removeWorktree,
   type RunCtx,
   useExistingBranch,
-  verifyBranchAbsentFromRemote,
   type WorktreeContext,
   type WorktreeDirNameFn,
 } from "./worktree.js";
@@ -274,7 +273,6 @@ export async function runWorkspace(config: WorkspaceConfig): Promise<void> {
   }
 
   const ctx = detectWorktree();
-  enforceWorktreeMode(command, ctx);
   const run: RunCtx = { verbose };
 
   switch (command.kind) {
@@ -705,10 +703,6 @@ async function handleRemove(
     process.exit(1);
   }
 
-  if (!command.noRemoteCheck) {
-    verifyBranchAbsentFromRemote(target.branch, run);
-  }
-
   const ownerSuffix = target.owner ? `, owner ${target.owner}` : "";
 
   if (!existsSync(target.worktreePath)) {
@@ -721,6 +715,13 @@ async function handleRemove(
       `Removed registry entry for branch "${target.branch}" (slot ${target.slotPort}${ownerSuffix}).`,
     );
     return;
+  }
+
+  if (!command.force && isWorktreeDirty(target.worktreePath)) {
+    console.error(
+      `Error: Uncommitted changes in ${target.worktreePath}. Commit or stash them, or pass --force.`,
+    );
+    process.exit(1);
   }
 
   const targetEntry = findOwnEntry(ctx.mainWorktree, registryDir, target.worktreePath);
@@ -876,7 +877,7 @@ function ensureWorktree(
   dirNameFn: WorktreeDirNameFn | undefined,
 ): WorktreeContext {
   if (command.branch === undefined) return ctx;
-  if (command.newBranch) return createBranch(command.branch, ctx, run, dirNameFn);
+  if (command.newBranch) return createBranch(command.branch, ctx, run, dirNameFn, command.from);
   return useExistingBranch(command.branch, ctx, run, dirNameFn);
 }
 

--- a/packages/workspace/src/workspace.ts
+++ b/packages/workspace/src/workspace.ts
@@ -361,7 +361,7 @@ async function runSetup(
   }
 
   linkSharedDirectories(setupCtx, config.sharedDirs, verboseLog);
-  linkSharedRegistry(setupCtx, config.runtimeDir, verboseLog);
+  linkWorkspaceRegistry(setupCtx, config.runtimeDir, verboseLog);
   generateConfigFiles(setupCtx, config.configFiles, slot, ports, command.force, verboseLog);
 
   teeLog(
@@ -800,7 +800,7 @@ function handleSetOwnerMode(
 
 type MigrateCommand = Extract<WorkspaceCommand, { kind: "migrate" }>;
 
-/** Transitional (0.16 only): merge a pre-0.16 registry into `${runtimeDir}/shared-registry`. */
+/** Transitional (0.16 only): merge a pre-0.16 registry into `${runtimeDir}/workspace-registry`. */
 function handleMigrate(command: MigrateCommand, config: WorkspaceConfig, newRel: string): void {
   const ctx = detectWorktree();
   const oldRel = command.oldRegistryDir;
@@ -859,7 +859,7 @@ function relinkWorktrees(slots: SlotsRegistry, mainWorktree: string, runtimeDir:
       console.warn(`Warning: worktree ${entry.worktree} not found; skipping symlink.`);
       continue;
     }
-    linkSharedRegistry(
+    linkWorkspaceRegistry(
       { currentWorktree: entry.worktree, mainWorktree, isMainWorktree: false },
       runtimeDir,
       console.log,
@@ -902,11 +902,11 @@ function linkSharedDirectories(
 }
 
 /**
- * Symlinks the linked worktree's `${runtimeDir}/shared-registry` to the main worktree's, so the
+ * Symlinks the linked worktree's `${runtimeDir}/workspace-registry` to the main worktree's, so the
  * cwd-relative registry read in `resolveCurrentSlot` reaches main. `runtimeDir` is per-worktree and
  * not in `sharedDirs`, so this is distinct from {@link linkSharedDirectories}.
  */
-function linkSharedRegistry(
+function linkWorkspaceRegistry(
   ctx: WorktreeContext,
   runtimeDir: string,
   log: (msg: string) => void,
@@ -923,17 +923,17 @@ function linkSharedRegistry(
   const linkStat = lstatSync(link, { throwIfNoEntry: false });
   if (linkStat) {
     if (!linkStat.isSymbolicLink()) {
-      log("Skipped shared-registry symlink (a real directory exists here).");
+      log("Skipped workspace-registry symlink (a real directory exists here).");
       return;
     }
     if (!opts?.force && existsSync(link)) {
-      log("Skipped shared-registry symlink (already exists).");
+      log("Skipped workspace-registry symlink (already exists).");
       return;
     }
     rmSync(link);
   }
   symlinkSync(relative(runtimeRoot, mainDir), link);
-  log("Created shared-registry symlink → main worktree.");
+  log("Created workspace-registry symlink → main worktree.");
 }
 
 function generateConfigFiles(

--- a/packages/workspace/src/worktree.ts
+++ b/packages/workspace/src/worktree.ts
@@ -63,7 +63,7 @@ export function createBranch(
   const worktreePath = dedupeWorktreePath(
     computeWorktreePath(ctx.mainWorktree, finalBranch, dirNameFn),
   );
-  const addArgs = ["worktree", "add", "-b", finalBranch, worktreePath];
+  const addArgs = ["worktree", "add", "-b", finalBranch, "--end-of-options", worktreePath];
   if (from !== undefined) addArgs.push(from);
   execFileSync("git", addArgs, { stdio: stdioFor(run) });
   return { ...ctx, currentWorktree: worktreePath, isMainWorktree: false };
@@ -72,7 +72,10 @@ export function createBranch(
 function verifyFromRef(from: string): void {
   try {
     // `^{commit}` accepts any commit-ish: branch, origin/x, tag, SHA.
-    execFileSync("git", ["rev-parse", "--verify", `${from}^{commit}`], { stdio: "pipe" });
+    // `--end-of-options` guards against option-like refs (rev-parse treats args after `--` as paths).
+    execFileSync("git", ["rev-parse", "--verify", "--end-of-options", `${from}^{commit}`], {
+      stdio: "pipe",
+    });
   } catch {
     console.error(`Error: --from ref "${from}" does not resolve to a commit.`);
     process.exit(1);
@@ -80,12 +83,19 @@ function verifyFromRef(from: string): void {
 }
 
 export function isWorktreeDirty(worktreePath: string): boolean {
-  const out = execFileSync("git", ["status", "--porcelain"], {
-    stdio: "pipe",
-    cwd: worktreePath,
-    encoding: "utf-8",
-  });
-  return out.trim().length > 0;
+  try {
+    const out = execFileSync("git", ["status", "--porcelain"], {
+      stdio: "pipe",
+      cwd: worktreePath,
+      encoding: "utf-8",
+    });
+    return out.trim().length > 0;
+  } catch {
+    console.error(
+      `Error: Cannot check for uncommitted changes in ${worktreePath}. Pass --force to remove anyway.`,
+    );
+    process.exit(1);
+  }
 }
 
 export function getWorktreeBranch(worktreePath: string): string | undefined {

--- a/packages/workspace/src/worktree.ts
+++ b/packages/workspace/src/worktree.ts
@@ -2,8 +2,6 @@ import { execFileSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { basename, dirname, join, resolve } from "node:path";
 
-import type { WorkspaceCommand } from "./cli.js";
-
 export interface WorktreeContext {
   currentWorktree: string;
   mainWorktree: string;
@@ -28,15 +26,6 @@ export function detectWorktree(): WorktreeContext {
   return { currentWorktree, mainWorktree, isMainWorktree };
 }
 
-export function enforceWorktreeMode(command: WorkspaceCommand, ctx: WorktreeContext): void {
-  // Adding a worktree for a branch must happen from the main worktree. A branch-less
-  // `workspace setup` runs anywhere: linked worktree (retry path) or main (initial bootstrap).
-  if (command.kind === "setup" && command.branch !== undefined && !ctx.isMainWorktree) {
-    console.error("Error: Adding a workspace for a branch must be run from the main worktree.");
-    process.exit(1);
-  }
-}
-
 export function useExistingBranch(
   branch: string,
   ctx: WorktreeContext,
@@ -57,7 +46,9 @@ export function createBranch(
   ctx: WorktreeContext,
   run: RunCtx,
   dirNameFn: WorktreeDirNameFn = defaultWorktreeDirName,
+  from?: string,
 ): WorktreeContext {
+  if (from !== undefined) verifyFromRef(from);
   let finalBranch = requestedBranch;
   if (branchExists(finalBranch)) {
     let suffix = 2;
@@ -72,23 +63,29 @@ export function createBranch(
   const worktreePath = dedupeWorktreePath(
     computeWorktreePath(ctx.mainWorktree, finalBranch, dirNameFn),
   );
-  execFileSync("git", ["worktree", "add", "-b", finalBranch, worktreePath], {
-    stdio: stdioFor(run),
-  });
+  const addArgs = ["worktree", "add", "-b", finalBranch, worktreePath];
+  if (from !== undefined) addArgs.push(from);
+  execFileSync("git", addArgs, { stdio: stdioFor(run) });
   return { ...ctx, currentWorktree: worktreePath, isMainWorktree: false };
 }
 
-export function verifyBranchAbsentFromRemote(branch: string, run: RunCtx): void {
-  execFileSync("git", ["fetch"], { stdio: stdioFor(run) });
-  const remoteBranches = execFileSync("git", ["branch", "-r", "--list", `origin/${branch}`], {
-    encoding: "utf-8",
-  }).trim();
-  if (remoteBranches.length > 0) {
-    console.error(
-      `Error: Branch "${branch}" still exists on the remote. Use --no-remote-check to skip this verification.`,
-    );
+function verifyFromRef(from: string): void {
+  try {
+    // `^{commit}` accepts any commit-ish: branch, origin/x, tag, SHA.
+    execFileSync("git", ["rev-parse", "--verify", `${from}^{commit}`], { stdio: "pipe" });
+  } catch {
+    console.error(`Error: --from ref "${from}" does not resolve to a commit.`);
     process.exit(1);
   }
+}
+
+export function isWorktreeDirty(worktreePath: string): boolean {
+  const out = execFileSync("git", ["status", "--porcelain"], {
+    stdio: "pipe",
+    cwd: worktreePath,
+    encoding: "utf-8",
+  });
+  return out.trim().length > 0;
 }
 
 export function getWorktreeBranch(worktreePath: string): string | undefined {

--- a/packages/workspace/test/cli.test.ts
+++ b/packages/workspace/test/cli.test.ts
@@ -43,6 +43,28 @@ describe("parseWorkspaceArgs", () => {
     expect(verbose).toBe(true);
   });
 
+  it("parses `setup <branch> -c --from <ref>`", () => {
+    const { command } = parseWorkspaceArgs([
+      "setup",
+      "feat/456",
+      "-c",
+      "--from",
+      "origin/feat/123",
+    ]);
+    expect(command).toMatchObject({
+      kind: "setup",
+      branch: "feat/456",
+      newBranch: true,
+      from: "origin/feat/123",
+    });
+  });
+
+  it("rejects `--from` without `-c`", () => {
+    expect(() => parseWorkspaceArgs(["setup", "feat/456", "--from", "origin/feat/123"])).toThrow(
+      ConfigError,
+    );
+  });
+
   it("rejects `-c` without a branch", () => {
     expect(() => parseWorkspaceArgs(["setup", "-c"])).toThrow(ConfigError);
   });
@@ -57,12 +79,16 @@ describe("parseWorkspaceArgs", () => {
 
   it("parses `remove` without a branch", () => {
     const { command } = parseWorkspaceArgs(["remove"]);
-    expect(command).toEqual({ kind: "remove", branch: undefined, noRemoteCheck: false });
+    expect(command).toEqual({ kind: "remove", branch: undefined, force: false });
   });
 
-  it("parses `remove <branch> --no-remote-check`", () => {
-    const { command } = parseWorkspaceArgs(["remove", "feat/42", "--no-remote-check"]);
-    expect(command).toEqual({ kind: "remove", branch: "feat/42", noRemoteCheck: true });
+  it("parses `remove <branch> --force`", () => {
+    const { command } = parseWorkspaceArgs(["remove", "feat/42", "--force"]);
+    expect(command).toEqual({ kind: "remove", branch: "feat/42", force: true });
+  });
+
+  it("rejects the removed `--no-remote-check` flag", () => {
+    expect(() => parseWorkspaceArgs(["remove", "--no-remote-check"])).toThrow(ConfigError);
   });
 
   it("parses `set-owner <name>`", () => {

--- a/packages/workspace/test/slots.test.ts
+++ b/packages/workspace/test/slots.test.ts
@@ -9,8 +9,8 @@ function slot(worktree: string, status: SlotEntry["status"] = "ready"): SlotEntr
 }
 
 describe("registryDirFor", () => {
-  it("appends the shared-registry subdir to runtimeDir", () => {
-    expect(registryDirFor(".local-wt")).toBe(join(".local-wt", "shared-registry"));
+  it("appends the workspace-registry subdir to runtimeDir", () => {
+    expect(registryDirFor(".local-wt")).toBe(join(".local-wt", "workspace-registry"));
   });
 });
 

--- a/skills/workspace-guide/SKILL.md
+++ b/skills/workspace-guide/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Requires git. Template scripts are in Node.js but the approach wo
 license: CC0 1.0
 metadata:
   author: Paleo
-  version: "0.10.2"
+  version: "0.11.0"
   repository: https://github.com/paleo/skills
 ---
 
@@ -107,7 +107,7 @@ The package's `runWorkspace(config: WorkspaceConfig)` performs the lifecycle bel
 
 **Lifecycle for setup (with `workspace setup <branch>`):**
 
-1. **Creates the worktree.** Path computed automatically (`../<reponame>-<slug>`). The default slug strips a recognizable ticket suffix from the last branch segment (`feat/ABC-123-extra` → `feat-ABC-123`), caps at 22 chars, and trims trailing dashes. Override via `config.worktreeDirName` (see below). With `-c`, branch-name dedup (appends `-2`, `-3`...) when the name is taken; the directory is independently deduped if a directory of the same name already exists on disk.
+1. **Creates the worktree.** Path computed automatically (`../<reponame>-<slug>`). The default slug strips a recognizable ticket suffix from the last branch segment (`feat/ABC-123-extra` → `feat-ABC-123`), caps at 22 chars, and trims trailing dashes. Override via `config.worktreeDirName` (see below). With `-c`, the new branch starts at the current worktree's HEAD, or at any commit-ish via `--from <ref>`; branch-name dedup (appends `-2`, `-3`...) when the name is taken; the directory is independently deduped if a directory of the same name already exists on disk.
 2. **Detects worktrees.** Finds the main worktree via `git rev-parse --git-common-dir` (parent of `.git`).
 3. **Assigns a slot.** Auto-assigns the first available port, or accepts `--slot PORT`. Records `{ worktree, branch, owner? }` in the slot registry. `owner` is undefined by default; `--owner NAME` sets it; on re-setup without `--owner`, the existing owner is preserved.
 4. **Symlinks shared directories** from `config.sharedDirs` (default `[".local", ".plans"]`) to the main worktree using relative paths. On a linked worktree it also creates the `shared-registry` symlink, pointing the worktree's `${runtimeDir}/shared-registry` at the main worktree's.
@@ -118,7 +118,7 @@ The package's `runWorkspace(config: WorkspaceConfig)` performs the lifecycle bel
 **Lifecycle for removal (with `workspace remove [<branch>]`):**
 
 1. Looks up the branch in the slot registry to find the worktree path and slot.
-2. Verifies the branch is absent from the remote (skipped with `--no-remote-check`).
+2. Refuses when the worktree has uncommitted changes, unless `--force` is passed.
 3. Stops the dev server by shelling out to `node <devServerScript> down` with `cwd: <target worktree>`.
 4. Calls optional `config.purgeInfrastructure(ctx)` — destructive teardown (typically `docker compose down -v` to wipe volumes). Runs after the dev-server stop.
 5. Frees the slot, drops the matching `dev-servers.json` entry, and removes the worktree via `git worktree remove --force`.
@@ -129,7 +129,7 @@ The package's `runWorkspace(config: WorkspaceConfig)` performs the lifecycle bel
 | --- | --- |
 | `workspace setup` | Set up the local environment in the current worktree (idempotent; bootstrap/retry path) |
 | `workspace setup <branch>` | Create a worktree for an existing branch, then set up the local environment |
-| `workspace setup <branch> -c` | Create a new branch (`-c`/`--new-branch`, with suffix dedup) + worktree, then set up. Mirrors `git switch -c` |
+| `workspace setup <branch> -c` | Create a new branch (`-c`/`--new-branch`, with suffix dedup) + worktree, then set up. Mirrors `git switch -c`: the branch starts at the current worktree's HEAD, or at any commit-ish via `--from <ref>` |
 | `workspace remove [<branch>]` | Stop dev server + free slot + remove worktree by branch, or the current worktree when omitted |
 | `workspace list` | Print all registered worktrees (slot, type, status, dev, branch, path, owner, created). The `DEV` column shows `up` when a live dev-server is registered for that slot's worktree, `-` otherwise |
 | `workspace status` | Print the summary (ports, branch, readiness) for the current worktree. Status shows elapsed time since `createdAt` / `failure.at` for `pending` / `failed` slots (e.g. `pending, started 4m 12s ago`); a `Dev-server:` block reports whether the dev-server is running, with PIDs and log paths |
@@ -137,7 +137,7 @@ The package's `runWorkspace(config: WorkspaceConfig)` performs the lifecycle bel
 | `workspace set-owner <name>` | Update the owner of the current linked worktree's slot — no rebuild |
 | `workspace migrate-0.16 <old-registryDir>` | Transitional (0.16 only): merge a pre-0.16 registry into `${runtimeDir}/shared-registry` and relink worktrees. Removed in the next release |
 
-Per-subcommand flags: `setup` accepts `-c`/`--new-branch`, `--owner <name>`, `-s`/`--slot <port>`, `--force`, `--wait`; `remove` accepts `--no-remote-check`; `status`/`wait` accept `-s`/`--slot <port>`; `-v`/`--verbose` is global. `workspace --help` prints help and exits 0; bare `workspace` (or an unknown command) prints a warning then help and exits 1.
+Per-subcommand flags: `setup` accepts `-c`/`--new-branch`, `--from <ref>`, `--owner <name>`, `-s`/`--slot <port>`, `--force`, `--wait`; `remove` accepts `--force` (proceed despite uncommitted changes); `status`/`wait` accept `-s`/`--slot <port>`; `-v`/`--verbose` is global. `workspace --help` prints help and exits 0; bare `workspace` (or an unknown command) prints a warning then help and exits 1.
 
 **Config fields to populate:**
 
@@ -242,6 +242,9 @@ Decide what each callback's `stop()` does based on the soft-stop intent: contain
 
 ```sh
 npm run workspace -- setup feat/42 -c       # new branch + worktree (dedup: appends -2, -3… if taken)
+npm run workspace -- setup feat/456 -c --from origin/feat/123   # new branch based on another branch
+# --from accepts any commit-ish (local branch, tag, SHA); without it, the branch starts at the
+# current worktree's HEAD, like `git switch -c`.
 npm run workspace -- setup feat/42          # new worktree on an existing branch
 npm run workspace -- setup                  # set up the current worktree
 
@@ -260,7 +263,7 @@ npm run dev -- up
 ```sh
 npm run workspace -- remove feat/42       # remove by branch name
 npm run workspace -- remove               # remove the current worktree
-npm run workspace -- remove feat/42 --no-remote-check # skip remote branch check
+npm run workspace -- remove feat/42 --force # discard uncommitted changes in a dirty worktree
 ```
 
 `workspace remove` (no branch, from inside the worktree) prints the main worktree path. The parent shell's CWD will point to a deleted directory — run `cd <main-worktree>` afterward.

--- a/skills/workspace-guide/SKILL.md
+++ b/skills/workspace-guide/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Requires git. Template scripts are in Node.js but the approach wo
 license: CC0 1.0
 metadata:
   author: Paleo
-  version: "0.11.0"
+  version: "0.12.0"
   repository: https://github.com/paleo/skills
 ---
 
@@ -65,7 +65,7 @@ Each worktree gets a unique "slot" that determines its port(s). A central **slot
 
 The slot is identified by the primary port number itself (e.g., `--slot 8120`).
 
-**Registry format** (stored under the main worktree's `runtimeDir`, e.g. `.local-wt/shared-registry/slots.json`):
+**Registry format** (stored under the main worktree's `runtimeDir`, e.g. `.local-wt/workspace-registry/slots.json`):
 
 ```json
 {
@@ -82,7 +82,7 @@ The main worktree is registered at `basePort` (the first slot); linked worktrees
 
 Host RAM is shared. Without a cap, parallel dev-servers (especially when an AI bot fans out worktrees) can exhaust memory. The wrapper passes an optional `devLimit` number to `runDevServer`; omit it for no limit. A hardcoded `5` is a sensible default — bump it if your stack is light, lower it if it's heavy.
 
-A second registry, `.local-wt/shared-registry/dev-servers.json`, tracks live dev-servers. It lives under the main worktree's `runtimeDir`; linked worktrees reach it via a `shared-registry` symlink created by `workspace setup`. An entry is **live** if at least one PID in its `pids` map is alive; dead entries are pruned on every read. When `live >= limit`, `dev` / `dev up` aborts and lists the active servers (slot, branch, owner, pids, started-at, worktree path). Re-run with `--evict` to stop the oldest live dev-server across all worktrees and start the new one instead of aborting.
+A second registry, `.local-wt/workspace-registry/dev-servers.json`, tracks live dev-servers. It lives under the main worktree's `runtimeDir`; linked worktrees reach it via a `workspace-registry` symlink created by `workspace setup`. An entry is **live** if at least one PID in its `pids` map is alive; dead entries are pruned on every read. When `live >= limit`, `dev` / `dev up` aborts and lists the active servers (slot, branch, owner, pids, started-at, worktree path). Re-run with `--evict` to stop the oldest live dev-server across all worktrees and start the new one instead of aborting.
 
 ### Config files must be gitignored
 
@@ -110,7 +110,7 @@ The package's `runWorkspace(config: WorkspaceConfig)` performs the lifecycle bel
 1. **Creates the worktree.** Path computed automatically (`../<reponame>-<slug>`). The default slug strips a recognizable ticket suffix from the last branch segment (`feat/ABC-123-extra` → `feat-ABC-123`), caps at 22 chars, and trims trailing dashes. Override via `config.worktreeDirName` (see below). With `-c`, the new branch starts at the current worktree's HEAD, or at any commit-ish via `--from <ref>`; branch-name dedup (appends `-2`, `-3`...) when the name is taken; the directory is independently deduped if a directory of the same name already exists on disk.
 2. **Detects worktrees.** Finds the main worktree via `git rev-parse --git-common-dir` (parent of `.git`).
 3. **Assigns a slot.** Auto-assigns the first available port, or accepts `--slot PORT`. Records `{ worktree, branch, owner? }` in the slot registry. `owner` is undefined by default; `--owner NAME` sets it; on re-setup without `--owner`, the existing owner is preserved.
-4. **Symlinks shared directories** from `config.sharedDirs` (default `[".local", ".plans"]`) to the main worktree using relative paths. On a linked worktree it also creates the `shared-registry` symlink, pointing the worktree's `${runtimeDir}/shared-registry` at the main worktree's.
+4. **Symlinks shared directories** from `config.sharedDirs` (default `[".local", ".plans"]`) to the main worktree using relative paths. On a linked worktree it also creates the `workspace-registry` symlink, pointing the worktree's `${runtimeDir}/workspace-registry` at the main worktree's.
 5. **Generates config files** by iterating `config.configFiles`. Each entry is `{ path, source?, patch(content, ctx), optional? }`; the source (the main worktree's `path` by default) is read and run through `patch`. `optional: true` downgrades a missing source from an error to a skip+warning.
 6. **Runs `await config.finalizeWorktree(ctx)`** in a detached background process. This callback owns infrastructure startup, dependency install / build, database provisioning, migrations, and seeding (see "Database provisioning" below). It MUST be idempotent — `workspace setup` re-runs it as the documented retry path.
 7. **Prints a summary** by calling `config.printSummary(ctx)` and `console.log`-ing the returned string.
@@ -135,7 +135,7 @@ The package's `runWorkspace(config: WorkspaceConfig)` performs the lifecycle bel
 | `workspace status` | Print the summary (ports, branch, readiness) for the current worktree. Status shows elapsed time since `createdAt` / `failure.at` for `pending` / `failed` slots (e.g. `pending, started 4m 12s ago`); a `Dev-server:` block reports whether the dev-server is running, with PIDs and log paths |
 | `workspace wait` | Block until the background finalize reaches `READY:` (exit 0, prints the worktree summary) or `FAILED:` (exit 1). Uses the current worktree's slot, or `--slot PORT` to target another. Use for CI / agent orchestration |
 | `workspace set-owner <name>` | Update the owner of the current linked worktree's slot — no rebuild |
-| `workspace migrate-0.16 <old-registryDir>` | Transitional (0.16 only): merge a pre-0.16 registry into `${runtimeDir}/shared-registry` and relink worktrees. Removed in the next release |
+| `workspace migrate-0.16 <old-registryDir>` | Transitional: merge a pre-0.16 registry into `${runtimeDir}/workspace-registry` and relink worktrees |
 
 Per-subcommand flags: `setup` accepts `-c`/`--new-branch`, `--from <ref>`, `--owner <name>`, `-s`/`--slot <port>`, `--force`, `--wait`; `remove` accepts `--force` (proceed despite uncommitted changes); `status`/`wait` accept `-s`/`--slot <port>`; `-v`/`--verbose` is global. `workspace --help` prints help and exits 0; bare `workspace` (or an unknown command) prints a warning then help and exits 1.
 
@@ -147,7 +147,7 @@ Per-subcommand flags: `setup` accepts `-c`/`--new-branch`, `--from <ref>`, `--ow
 - `portStep` (default `10`), `maxSlotCount` (default `19`).
 - `ports(slot)` or `portNames` — supply either a function returning the port map for a slot, or a list of names that defaults to consecutive ports (`{ name0: slot, name1: slot+1, ... }`).
 - `sharedDirs: string[]` — required. Directories symlinked from the main worktree (e.g. `[".local", ".plans"]`).
-- `runtimeDir: string` — required. Per-worktree runtime directory relative to the worktree root (e.g. `.local-wt`). Holds the setup log and dev-server logs. The registry lives at `${runtimeDir}/shared-registry` (`slots.json`, `dev-servers.json`), symlinked to the main worktree per linked worktree by `workspace setup`.
+- `runtimeDir: string` — required. Per-worktree runtime directory relative to the worktree root (e.g. `.local-wt`). Holds the setup log and dev-server logs. The registry lives at `${runtimeDir}/workspace-registry` (`slots.json`, `dev-servers.json`), symlinked to the main worktree per linked worktree by `workspace setup`.
 - `configFiles: Array<{ path, source?, patch, optional? }>` — one entry per gitignored config file. `patch(content, { slot, ports, mainWorktree, currentWorktree })` returns the rewritten content. Use `helpers.patchEnvFile` for `KEY=VALUE` files and `helpers.extractHost` to preserve non-localhost hosts. `source` overrides where the initial content comes from (default: `path` read from the main worktree): `{ path }` (relative to the main worktree, e.g. a committed example), `{ content }` (verbatim), or a callback `(ctx) => { path } | { content }` receiving the same `PatchContext`. `optional: true` skips the entry (warning) when a `{ path }` source is missing instead of aborting.
 - `finalizeWorktree(ctx)` — required callback. Runs in a detached background process after the foreground command returns. Owns infrastructure startup (e.g. `docker compose up -d`), database readiness wait, `npm install` / build, migrations, and seeding. **MUST be idempotent** — `workspace setup` is the documented retry path and re-runs this same callback. **Run `npm install` first** so any later failure leaves a worktree with usable `node_modules/`; otherwise the `workspace setup` retry can't import `@paleo/workspace`. Failures are logged to `<runtimeDir>/logs/workspace-setup.log` with a `FAILED:` banner.
 - `purgeInfrastructure(ctx)` — optional. Called by `workspace remove` after the dev-server stop. The standard pattern is `docker compose down -v` if you use Docker — destructive teardown that wipes volumes, complementing the soft `docker compose down` in the callback `stop()`.

--- a/skills/workspace-guide/assets/dev-server.mjs
+++ b/skills/workspace-guide/assets/dev-server.mjs
@@ -16,7 +16,7 @@ import { helpers, runDevServer } from "@paleo/workspace";
 
 await runDevServer({
   basePort: 8100, // ADAPT
-  runtimeDir: ".local-wt", // Per-worktree runtime directory. The symlinked registry lives at `${runtimeDir}/shared-registry`.
+  runtimeDir: ".local-wt", // Per-worktree runtime directory. The symlinked registry lives at `${runtimeDir}/workspace-registry`.
   devLimit: 5,    // ADAPT — cap on concurrent dev-servers across worktrees; omit for no limit.
 
   servers: [

--- a/skills/workspace-guide/assets/workspace.md
+++ b/skills/workspace-guide/assets/workspace.md
@@ -138,5 +138,5 @@ npm run dev -- down                     # 4. stop when done (same directory)
 
 - **`.local/`** — Shared across worktrees (symlinked). It's the right place for any gitignored working files (e.g. personal notes…).
 - **`.local-wt/`** — Per-worktree. Runtime data: databases, caches, `logs/` (dev server logs).
-  - `shared-registry/` — The workspace registry. Symlinked to the main worktree in linked worktrees.
+  - `workspace-registry/` — The workspace registry. Symlinked to the main worktree in linked worktrees.
 - **`.plans/`** — Shared across worktrees (symlinked). Task planning files.

--- a/skills/workspace-guide/assets/workspace.md
+++ b/skills/workspace-guide/assets/workspace.md
@@ -18,9 +18,12 @@ When the user asks to "set up a new workspace" or "set up a new worktree":
 
 ```sh
 npm run workspace -- setup fix/123 -c    # new branch + worktree (dedup: appends -2, -3… if taken)
+npm run workspace -- setup fix/456 -c --from origin/fix/123   # new branch based on another branch
 npm run workspace -- setup fix/123       # new worktree on an existing branch
 npm run workspace -- setup               # set up the current worktree (idempotent — also the retry path)
 ```
+
+With `-c`, the new branch starts at the current worktree's HEAD (like `git switch -c`); `--from <ref>` accepts any commit-ish as the base.
 
 <!-- ADAPT: Update the setup command if your project uses a different task runner.
      Document any project-specific ports or URLs the developer should know about. -->
@@ -78,12 +81,11 @@ npm run workspace -- set-owner bob   # update later, no rebuild
 ```sh
 npm run workspace -- remove fix/123    # remove by branch name
 npm run workspace -- remove            # remove the current worktree
-npm run workspace -- remove fix/123 --no-remote-check # skip remote branch check
 ```
 
 Stops the dev server (if running), frees the slot, and removes the worktree.
 
-By default, it verifies the branch has been removed from the remote first. Use `--no-remote-check` to skip that. When run from inside the worktree (`workspace remove` with no branch), the script prints the main worktree path. You'll have to run `cd <main-worktree>` afterward.
+Removal refuses when the worktree has uncommitted changes; pass `--force` to discard them. When run from inside the worktree (`workspace remove` with no branch), the script prints the main worktree path. You'll have to run `cd <main-worktree>` afterward.
 
 **NEVER** delete a branch unless the user explicitly requests it.
 


### PR DESCRIPTION
- `workspace remove` no longer checks the remote; the `--no-remote-check` flag is removed.
- `workspace remove` refuses on uncommitted changes unless `--force` is passed.
- `workspace setup <branch> [-c]` runs from any worktree; new `--from <ref>` option bases the new branch on any commit-ish.
- Guide skill (v0.11.0) and docs updated accordingly.
