### PR TITLE
fix: [#30] harden setup playbook and add CLI --version

### DIFF
--- a/openclaw-coder/playbook-test/scenarios/A07-status-existing-worktree.ts
+++ b/openclaw-coder/playbook-test/scenarios/A07-status-existing-worktree.ts
@@ -1,5 +1,6 @@
 import { existsSync, readdirSync } from "node:fs";
 import type { ScenarioContext } from "@paleo/openclaw-test";
+import { execMatches, invokesAlcode } from "./_lib/agent-tool-calls.ts";
 import { statusExistingWorktreeRubric } from "./_lib/common-constants.ts";
 import { seedWorktree, worktreePath } from "./_lib/fixture-state.ts";
 import { waitForOutboundSkippingNarration } from "./_lib/meta-narration.ts";
@@ -40,9 +41,10 @@ export default async function statusExistingWorktree(ctx: ScenarioContext): Prom
   const threadId = requireThreadId(starterWait);
   ctx.log({ attachTo: starterWait.entry, label: `starter received in thread ${threadId}` });
 
-  // Accept the report in the thread OR auto-streamed to the parent channel —
-  // some iterations of the agent emit free-form text after thread-create which
-  // auto-streams to the channel. Per the playbook-test README.md tolerance, the user still sees it.
+  // The report text is matched at conversation level on purpose: free-form text
+  // after `thread-create` auto-streams to the parent channel, and a thread-scoped
+  // predicate would only reveal that leak as a timeout. Match the text, then
+  // assert placement — a leaked report fails fast with the real cause.
   const branchRe = new RegExp(
     `\\b${TICKET_ID}/${BRANCH_DESC}\\b|nimbus-${TICKET_ID}-${BRANCH_DESC}\\b`,
   );
@@ -61,11 +63,29 @@ export default async function statusExistingWorktree(ctx: ScenarioContext): Prom
     },
   );
   ctx.log({ attachTo: reportWait.entry, label: "status report received" });
+  ctx.assertEqual(reportWait.match.threadId, threadId, "status report posted in the thread");
   await ctx.judgeLLM({
     attachTo: reportWait.entry,
     message: reportWait.match.text,
     rubric: statusExistingWorktreeRubric(TICKET_ID, BRANCH),
     label: "status-existing-worktree",
+  });
+
+  // project-workspace-setup.md prerequisite: run the delegation manual on every
+  // WORK-mode turn. The trajectory snapshot flushes when the session run ends,
+  // after the report — hence the generous timeout.
+  await ctx.waitForAgentToolCall((c) => execMatches(c, /alcode\s+--openclaw-guide\b/), {
+    label: "agent runs `alcode --openclaw-guide`",
+    timeoutMs: 120_000,
+  });
+
+  // Work-content status is delegated (project-workspace-setup.md Step 5): the
+  // agent must run the alcode read protocol for the ticket, never inspect the
+  // work itself. The backgrounded run and its wake report are not awaited —
+  // the delegation call is the regression target.
+  await ctx.waitForAgentToolCall((c) => invokesAlcode(c) && execMatches(c, /--protocol\s+read\b/), {
+    label: "agent delegates work-content status via `alcode read`",
+    timeoutMs: 180_000,
   });
 
   assertOnlySeededWorktreeDir(ctx);

--- a/openclaw-coder/playbook-test/scenarios/A08-status-branch-only.ts
+++ b/openclaw-coder/playbook-test/scenarios/A08-status-branch-only.ts
@@ -1,4 +1,5 @@
 import type { ScenarioContext } from "@paleo/openclaw-test";
+import { execMatches } from "./_lib/agent-tool-calls.ts";
 import { assertBranch, seedBranch, waitForWorktreeDir } from "./_lib/fixture-state.ts";
 import { waitForOutboundSkippingNarration } from "./_lib/meta-narration.ts";
 import { setupClaudeMock } from "./_lib/mock-claude.ts";
@@ -66,6 +67,9 @@ export default async function statusBranchOnly(ctx: ScenarioContext): Promise<vo
     },
   );
   ctx.log({ attachTo: reportWait.entry, label: "status report received" });
+  // Free-form text after `thread-create` auto-streams to the parent channel —
+  // the report must land in the thread, and a leak fails here with the real cause.
+  ctx.assertEqual(reportWait.match.threadId, threadId, "status report posted in the thread");
   ctx.assertRegex(
     reportWait.match.text,
     new RegExp(`nimbus-${TICKET_ID}-${BRANCH_DESC}`),
@@ -81,6 +85,14 @@ export default async function statusBranchOnly(ctx: ScenarioContext): Promise<vo
     /\b(running|ready|failed|pending|ok|prêt|en cours|terminé)\b/i,
     "report mentions a bootstrap status",
   );
+
+  // project-workspace-setup.md prerequisite: run the delegation manual on every
+  // WORK-mode turn. The trajectory snapshot flushes when the session run ends,
+  // after the report — hence the generous timeout.
+  await ctx.waitForAgentToolCall((c) => execMatches(c, /alcode\s+--openclaw-guide\b/), {
+    label: "agent runs `alcode --openclaw-guide`",
+    timeoutMs: 120_000,
+  });
 
   ctx.markScenarioAsEnded("PASS");
   ctx.log("PASS");

--- a/openclaw-coder/playbook-test/scenarios/A09-status-no-branch.ts
+++ b/openclaw-coder/playbook-test/scenarios/A09-status-no-branch.ts
@@ -1,5 +1,6 @@
 import { existsSync, readdirSync } from "node:fs";
 import type { ScenarioContext } from "@paleo/openclaw-test";
+import { execMatches } from "./_lib/agent-tool-calls.ts";
 import { statusNoBranchRubric } from "./_lib/common-constants.ts";
 import { waitForOutboundSkippingNarration } from "./_lib/meta-narration.ts";
 import { setupClaudeMock } from "./_lib/mock-claude.ts";
@@ -73,6 +74,14 @@ export default async function statusNoBranch(ctx: ScenarioContext): Promise<void
     message: reportText,
     rubric: statusNoBranchRubric(TICKET_ID),
     label: "status-no-branch",
+  });
+
+  // project-workspace-setup.md prerequisite: run the delegation manual on every
+  // WORK-mode turn — including the no-branch sub-path. The trajectory snapshot
+  // flushes when the session run ends, after the report — hence the generous timeout.
+  await ctx.waitForAgentToolCall((c) => execMatches(c, /alcode\s+--openclaw-guide\b/), {
+    label: "agent runs `alcode --openclaw-guide`",
+    timeoutMs: 120_000,
   });
 
   assertNoWorktreeDirs(ctx);

--- a/openclaw-coder/playbook-test/scenarios/_lib/workspace-flow.ts
+++ b/openclaw-coder/playbook-test/scenarios/_lib/workspace-flow.ts
@@ -22,7 +22,7 @@ export interface WorkspaceFlowOptions {
 /**
  * Drive the post-thread-ack phase shared by A1 / A2: wait for the worktree on
  * disk, assert its branch, let the agent settle on its workspace report, unblock
- * it past the step-5 validation gate, then expect the coding delegation. The
+ * it past the step-6 validation gate, then expect the coding delegation. The
  * scenario ends here — the coding stub returns a "test passed, just acknowledge"
  * message so the agent stops cleanly.
  */
@@ -84,7 +84,7 @@ export async function runWorkspaceFlow(
     );
   }
 
-  // Per project-workspace-setup.md Step 5, the agent may pause to ask
+  // Per project-workspace-setup.md Step 6, the agent may pause to ask
   // for validation before delegating coding work. Unblock it unconditionally.
   await ctx.sendInbound({
     senderId: "ROBIN01",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5924,7 +5924,7 @@
     },
     "packages/alcode": {
       "name": "@paleo/alcode",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "CC0-1.0",
       "bin": {
         "alcode": "bin/alcode.mjs"
@@ -5941,7 +5941,7 @@
     },
     "packages/docmap": {
       "name": "@paleo/docmap",
-      "version": "0.6.4",
+      "version": "0.7.0",
       "license": "CC0-1.0",
       "bin": {
         "docmap": "bin/docmap.mjs"
@@ -6067,7 +6067,7 @@
     },
     "packages/workspace": {
       "name": "@paleo/workspace",
-      "version": "0.26.0",
+      "version": "0.27.0",
       "license": "CC0-1.0",
       "devDependencies": {
         "@types/node": "~24.12.4",

--- a/packages/alcode/CHANGELOG.md
+++ b/packages/alcode/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @paleo/alcode
 
+## 0.3.0
+
+### Minor Changes
+
+- Add a `-v`/`--version` flag that prints the alcode version.
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/alcode/package.json
+++ b/packages/alcode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paleo/alcode",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "CC0-1.0",
   "author": "Thomas MUR",
   "description": "Run a coding agent through AlignFirst protocols, with a durable session file per run.",

--- a/packages/alcode/src/cli.ts
+++ b/packages/alcode/src/cli.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { relative } from "node:path";
 import { parseArgs } from "node:util";
 
@@ -34,6 +35,10 @@ export async function main(options?: MainOptions): Promise<number> {
     return 1;
   }
 
+  if (parsed.version) {
+    stdout.write(`${readPackageVersion()}\n`);
+    return 0;
+  }
   if (parsed.help) {
     stdout.write(renderHelp());
     return 0;
@@ -50,6 +55,14 @@ export async function main(options?: MainOptions): Promise<number> {
   }
 
   return runSession(parsed, { cwd, env, stdout, stderr });
+}
+
+function readPackageVersion(): string {
+  const pkg = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8")) as {
+    version?: string;
+  };
+  if (!pkg.version) throw new Error("alcode: package.json is missing 'version'");
+  return pkg.version;
 }
 
 interface RunContext {
@@ -146,6 +159,7 @@ export interface AlcodeArgs {
   guide: boolean;
   openclawGuide: boolean;
   help: boolean;
+  version: boolean;
 }
 
 export function parseAlcodeArgs(argv: string[]): AlcodeArgs {
@@ -162,6 +176,7 @@ export function parseAlcodeArgs(argv: string[]): AlcodeArgs {
       guide: { type: "boolean", default: false },
       "openclaw-guide": { type: "boolean", default: false },
       help: { type: "boolean", default: false },
+      version: { type: "boolean", short: "v", default: false },
     },
     strict: true,
   });
@@ -176,6 +191,7 @@ export function parseAlcodeArgs(argv: string[]): AlcodeArgs {
     guide: values.guide === true,
     openclawGuide: values["openclaw-guide"] === true,
     help: values.help === true,
+    version: values.version === true,
   };
 }
 
@@ -224,6 +240,7 @@ Usage:
   alcode --guide
   alcode --openclaw-guide
   alcode --help
+  alcode -v, --version
 
 Modes:
   --new                 Start a new session.

--- a/packages/docmap/CHANGELOG.md
+++ b/packages/docmap/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @paleo/docmap
 
+## 0.7.0
+
+### Minor Changes
+
+- Add a `-v`/`--version` flag that prints the docmap version.
+
 ## 0.6.4
 
 ### Patch Changes

--- a/packages/docmap/package.json
+++ b/packages/docmap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paleo/docmap",
-  "version": "0.6.4",
+  "version": "0.7.0",
   "license": "CC0-1.0",
   "author": "Thomas MUR",
   "description": "A lightweight documentation system for AI agents and humans.",

--- a/packages/docmap/src/cli.ts
+++ b/packages/docmap/src/cli.ts
@@ -29,7 +29,8 @@ export function main(options?: MainOptions): number {
   const stderr = options?.stderr ?? process.stderr;
   const cwd = options?.cwd ?? process.cwd();
 
-  const { paths, unknownFlags, recursive, root, check, help, guide, search } = parseArgs(argv);
+  const { paths, unknownFlags, recursive, root, check, help, guide, search, version } =
+    parseArgs(argv);
   const baseDir = root ? resolve(cwd, root) : resolve(cwd, "docs");
   // cwd-relative form of baseDir, prepended to every displayed path so output is copy-pasteable.
   // A `--root` outside cwd yields a `..`-leading prefix; paths still strip and resolve correctly.
@@ -39,8 +40,12 @@ export function main(options?: MainOptions): number {
 
   const pm = detectPackageManager(cwd);
 
-  // Mode precedence (each prints only its own output, then returns): help → guide → search →
-  // check → listing/read.
+  // Mode precedence (each prints only its own output, then returns): version → help → guide →
+  // search → check → listing/read.
+  if (version) {
+    stdout.write(`${readPackageVersion()}\n`);
+    return 0;
+  }
   if (help) {
     stdout.write(renderHelp(pm, { full: true }));
     return 0;
@@ -85,6 +90,14 @@ export function main(options?: MainOptions): number {
   return 0;
 }
 
+function readPackageVersion(): string {
+  const pkg = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf-8")) as {
+    version?: string;
+  };
+  if (!pkg.version) throw new Error("docmap: package.json is missing 'version'");
+  return pkg.version;
+}
+
 export interface ParsedArgs {
   paths: string[];
   unknownFlags: string[];
@@ -94,6 +107,7 @@ export interface ParsedArgs {
   help: boolean;
   guide: boolean;
   search: string | undefined;
+  version: boolean;
 }
 
 export function parseArgs(argv: string[]): ParsedArgs {
@@ -106,6 +120,7 @@ export function parseArgs(argv: string[]): ParsedArgs {
   let help = false;
   let guide = false;
   let search: string | undefined;
+  let version = false;
 
   for (let i = 0; i < args.length; ++i) {
     const arg = args[i];
@@ -121,6 +136,8 @@ export function parseArgs(argv: string[]): ParsedArgs {
       help = true;
     } else if (arg === "--guide") {
       guide = true;
+    } else if (arg === "--version" || arg === "-v") {
+      version = true;
     } else if (arg.startsWith("--")) {
       unknownFlags.push(arg);
     } else {
@@ -128,7 +145,7 @@ export function parseArgs(argv: string[]): ParsedArgs {
     }
   }
 
-  return { paths, unknownFlags, recursive, root, check, help, guide, search };
+  return { paths, unknownFlags, recursive, root, check, help, guide, search, version };
 }
 
 interface HelpOptions {
@@ -177,6 +194,7 @@ function moreCommands(pm: PackageManagerCommands): CommandRow[] {
   return [
     { command: `${pm.withArgs} --check`, comment: "validate names and frontmatter" },
     { command: `${pm.withArgs} --root <path>`, comment: "use a custom docs root" },
+    { command: `${pm.withArgs} -v`, comment: "print the docmap version (alias: --version)" },
   ];
 }
 

--- a/packages/workspace/CHANGELOG.md
+++ b/packages/workspace/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @paleo/workspace
 
+## 0.27.0
+
+### Minor Changes
+
+- The workspace CLI now prints its version with `-v`/`--version`. To free `-v` for this, the `--verbose` flag loses its `-v` short alias — use `--verbose` in full.
+
 ## 0.26.0
 
 ### Minor Changes

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paleo/workspace",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "description": "Run multiple git-worktree dev environments side by side.",
   "keywords": [
     "workspace",

--- a/packages/workspace/src/cli.ts
+++ b/packages/workspace/src/cli.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { parseArgs } from "node:util";
 import { ConfigError } from "./errors.js";
 
@@ -19,7 +20,8 @@ export type WorkspaceCommand =
   | { kind: "finalize"; slot: string; force: boolean }
   | { kind: "migrate"; oldRegistryDir: string }
   | { kind: "guide" }
-  | { kind: "help" };
+  | { kind: "help" }
+  | { kind: "version" };
 
 /** Picks an existing workspace. Empty = the current worktree. */
 export interface WorkspaceSelector {
@@ -41,6 +43,9 @@ export function parseWorkspaceArgs(argv: string[] = process.argv.slice(2)): Pars
   }
   if (subcommand === "--guide") {
     return { command: { kind: "guide" }, verbose: false };
+  }
+  if (subcommand === "--version" || subcommand === "-v") {
+    return { command: { kind: "version" }, verbose: false };
   }
   if (subcommand === undefined) throw new ConfigError("No command given.");
   try {
@@ -83,7 +88,7 @@ function parseSetup(tokens: string[]): ParsedWorkspaceArgs {
       slot: { type: "string", short: "s" },
       force: { type: "boolean" },
       go: { type: "boolean" },
-      verbose: { type: "boolean", short: "v" },
+      verbose: { type: "boolean" },
     },
     allowPositionals: true,
     strict: true,
@@ -120,7 +125,7 @@ function parseRemove(tokens: string[]): ParsedWorkspaceArgs {
     options: {
       slot: { type: "string", short: "s" },
       force: { type: "boolean" },
-      verbose: { type: "boolean", short: "v" },
+      verbose: { type: "boolean" },
     },
     allowPositionals: true,
     strict: true,
@@ -139,7 +144,7 @@ function parseRemove(tokens: string[]): ParsedWorkspaceArgs {
 function parseList(tokens: string[]): ParsedWorkspaceArgs {
   const { values, positionals } = parseArgs({
     args: tokens,
-    options: { verbose: { type: "boolean", short: "v" } },
+    options: { verbose: { type: "boolean" } },
     allowPositionals: true,
     strict: true,
   });
@@ -150,7 +155,7 @@ function parseList(tokens: string[]): ParsedWorkspaceArgs {
 function parsePrune(tokens: string[]): ParsedWorkspaceArgs {
   const { values, positionals } = parseArgs({
     args: tokens,
-    options: { verbose: { type: "boolean", short: "v" } },
+    options: { verbose: { type: "boolean" } },
     allowPositionals: true,
     strict: true,
   });
@@ -163,7 +168,7 @@ function parseStatus(tokens: string[]): ParsedWorkspaceArgs {
     args: tokens,
     options: {
       slot: { type: "string", short: "s" },
-      verbose: { type: "boolean", short: "v" },
+      verbose: { type: "boolean" },
     },
     allowPositionals: true,
     strict: true,
@@ -180,7 +185,7 @@ function parseWait(tokens: string[]): ParsedWorkspaceArgs {
     args: tokens,
     options: {
       slot: { type: "string", short: "s" },
-      verbose: { type: "boolean", short: "v" },
+      verbose: { type: "boolean" },
     },
     allowPositionals: true,
     strict: true,
@@ -206,7 +211,7 @@ function parseFinalize(tokens: string[]): ParsedWorkspaceArgs {
 function parseMigrate(tokens: string[]): ParsedWorkspaceArgs {
   const { values, positionals } = parseArgs({
     args: tokens,
-    options: { verbose: { type: "boolean", short: "v" } },
+    options: { verbose: { type: "boolean" } },
     allowPositionals: true,
     strict: true,
   });
@@ -277,11 +282,20 @@ export function printWorkspaceHelp(): void {
       "      Block until setup reaches READY (exit 0) or FAILED (exit 1).",
       "",
       "Global options:",
-      "  -v, --verbose   Show intermediate output.",
-      "      --guide     Print the full workspace + dev-server operating guide.",
-      "  -h, --help      Show this help message.",
+      "      --verbose       Show intermediate output.",
+      "      --guide         Print the full workspace + dev-server operating guide.",
+      "  -h, --help          Show this help message.",
+      "  -v, --version       Print the workspace version.",
     ].join("\n"),
   );
+}
+
+export function printWorkspaceVersion(): void {
+  const pkg = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf-8")) as {
+    version?: string;
+  };
+  if (!pkg.version) throw new ConfigError("workspace: package.json is missing 'version'");
+  console.log(pkg.version);
 }
 
 export type DevCommand =

--- a/packages/workspace/src/workspace.ts
+++ b/packages/workspace/src/workspace.ts
@@ -15,6 +15,7 @@ import { basename, dirname, isAbsolute, join, relative, resolve } from "node:pat
 import {
   parseWorkspaceArgs,
   printWorkspaceHelp,
+  printWorkspaceVersion,
   type WorkspaceCommand,
   type WorkspaceSelector,
 } from "./cli.js";
@@ -274,6 +275,11 @@ export async function runWorkspace(config: WorkspaceConfig): Promise<void> {
 
   if (command.kind === "help") {
     printWorkspaceHelp();
+    return;
+  }
+
+  if (command.kind === "version") {
+    printWorkspaceVersion();
     return;
   }
 

--- a/packages/workspace/test/cli.test.ts
+++ b/packages/workspace/test/cli.test.ts
@@ -27,7 +27,7 @@ describe("parseWorkspaceArgs", () => {
       "8110",
       "--force",
       "--go",
-      "-v",
+      "--verbose",
     ]);
     expect(command).toEqual({
       kind: "setup",
@@ -39,6 +39,15 @@ describe("parseWorkspaceArgs", () => {
       go: true,
     });
     expect(verbose).toBe(true);
+  });
+
+  it("rejects the removed `-v` verbose short on a subcommand", () => {
+    expect(() => parseWorkspaceArgs(["setup", "feat/42", "-v"])).toThrow(ConfigError);
+  });
+
+  it("parses `-v` and `--version` as the version command", () => {
+    expect(parseWorkspaceArgs(["-v"]).command).toEqual({ kind: "version" });
+    expect(parseWorkspaceArgs(["--version"]).command).toEqual({ kind: "version" });
   });
 
   it("rejects the removed `--wait` flag on setup", () => {

--- a/skills/openclaw-coder-playbook/SKILL.md
+++ b/skills/openclaw-coder-playbook/SKILL.md
@@ -4,7 +4,7 @@ description: "Operating-instructions dispatcher for the openclaw-coder autonomou
 license: CC0 1.0
 metadata:
   author: Paleo
-  version: "0.8.1"
+  version: "0.9.0"
   repository: https://github.com/paleo/alignfirst
 ---
 

--- a/skills/openclaw-coder-playbook/references/project-workspace-setup.md
+++ b/skills/openclaw-coder-playbook/references/project-workspace-setup.md
@@ -2,9 +2,11 @@
 
 Do NOT try to handle the user's request here. We need to set up the project workspace first, then hand off to a thread session where the actual work happens. This file covers the setup phase.
 
-## Prerequisites
+Discord: every user-facing post during this procedure is a `message` call carrying the thread's `threadId` — free-form assistant text streams to the parent channel, not the thread. Keep observations and intermediate findings internal; post only the banner and the reports this file prescribes.
 
-- run `alcode --openclaw-guide` (`exec`) and follow it — how to delegate to the coding agent.
+## Prerequisites — run both now, before Step 1
+
+- `alcode --openclaw-guide` (`exec`) — the delegation manual. Required on every WORK turn, status requests included; do not skip it because no coding seems planned.
 - read `~/projects/{PROJECT_NAME}/DEVELOPMENT.md` — how to create a worktree or a branch.
 
 ## Step 1 — Requirements
@@ -40,7 +42,7 @@ First, check what already exists for the {TICKET_ID} — two checks, both requir
 
 Never assume the branch is new; `git worktree list` alone does not answer the branch question.
 
-Whenever a branch exists, you work from its workspace — a status request included. "Status" here means: set up the workspace, then report its state — not `git log` from the main dir. Pick one sub-path:
+Whenever a branch exists, you work from its workspace — a status request included. "Status" means: set up the workspace, report its state (the block below), then report the work content (Step 5) — never `git log` from the main dir. Pick one sub-path:
 
 1. **Branch + workspace already registered** → use it (no setup needed).
 2. **Branch exists (local or remote), no workspace** → set up a workspace on the existing branch (don't create a new branch).
@@ -67,7 +69,13 @@ Once the workspace is set up, bring the branch up to date *before* inspecting or
 7. **Check for an open MR/PR** on this branch and note its state.
 8. **Report what changed.** If the fetch/merge pulled in new commits (remote or base), post a one-line summary so the user knows the ground shifted.
 
-## Step 5 — User's turn
+## Step 5 — Status request: the work content
+
+Only for a status request; otherwise skip to Step 6. The Step 4 block comes first — post it before delegating.
+
+The workspace block answers "is the env ready", not "where does the work stand". For the work content — what was done, what remains — delegate: `alcode`, `read` protocol, run from the worktree. Relay its answer in the thread. The sync output (`git status`, fetch) is for syncing only — never compose this report yourself from `git log`, `.plans/` reads, or code browsing.
+
+## Step 6 — User's turn
 
 When everything is ready:
 


### PR DESCRIPTION
- Tightened scenarios A07/A08/A09 to assert status reports land in the originating thread and that `alcode --openclaw-guide` runs; A07 also asserts `read`-protocol delegation for work content.
- Hardened the OpenClaw coder playbook (0.8.1 → 0.9.0): anchored prerequisites up front, added a status-request step delegating via `alcode`, and restated Discord thread discipline.
- Added a `-v`/`--version` flag printing the package version to the `docmap`, `alcode`, and `workspace` CLIs. On `workspace`, `-v` is no longer the short alias for `--verbose` (freed for version; `--verbose` stays as the long form).
