### PR TITLE
feat: alcode detects lost coding-agent session

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@
 
 ## Docmap - Seek Documentation
 
-**Before any investigation or code exploration**, run `npm run docmap`, then read the relevant documentation. Mandatory for every task.
+*Before* any investigation or code exploration, run `npm run docmap`, then read the relevant documentation. Mandatory for every task.
 
 ## AlignFirst - Ticket ID, Commit Message, Branch Name
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5990,7 +5990,7 @@
     },
     "packages/alcode": {
       "name": "@paleo/alcode",
-      "version": "0.5.3",
+      "version": "0.6.0",
       "license": "CC0-1.0",
       "bin": {
         "alcode": "bin/alcode.mjs"

--- a/packages/alcode/CHANGELOG.md
+++ b/packages/alcode/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @paleo/alcode
 
+## 0.6.0
+
+### Minor Changes
+
+- Detect when the coding agent's session is lost or expired: alcode now seals the session file with `exitReason: auth_required`, exits `2`, and prints a clear message telling an administrator to re-login on the host.
+
 ## 0.5.3
 
 ### Patch Changes

--- a/packages/alcode/README.md
+++ b/packages/alcode/README.md
@@ -12,6 +12,8 @@ Coding runs can be very long: the caller always runs `alcode` as a background ta
 
 If `alcode` is terminated, its signal handlers seal the session file (`status: failed`, `exitReason: terminated`) so it never stays frozen at `running`, then send `SIGTERM` to the coding-agent child, giving it a short grace to tear down its own subprocesses before a `SIGKILL` backstop guarantees no orphan is left behind. Only a `SIGKILL` of `alcode` itself (uncatchable) can leave a stale `running` status.
 
+When the coding agent's own session on the host is missing or expired, `alcode` detects the `authentication_failed` signal in its stream, seals the session file with `exitReason: auth_required`, and exits `2` (distinct from `1`) with a one-line stderr message.
+
 ## Usage
 
 ```bash

--- a/packages/alcode/package.json
+++ b/packages/alcode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paleo/alcode",
-  "version": "0.5.3",
+  "version": "0.6.0",
   "license": "CC0-1.0",
   "author": "Thomas MUR",
   "description": "Run a coding agent through AlignFirst protocols.",

--- a/packages/alcode/src/cli.ts
+++ b/packages/alcode/src/cli.ts
@@ -14,6 +14,10 @@ import {
 import { buildPrompt, PROTOCOLS } from "./prompt.js";
 import { type RunConfig, type RunOutput, runClaude } from "./run-claude.js";
 
+// Distinct from 1 (ordinary run failure) so a script can branch on an auth failure that needs an
+// operator re-login rather than a retry.
+const EXIT_AUTH_REQUIRED = 2;
+
 export interface MainOptions {
   argv?: string[];
   stdout?: RunOutput;
@@ -107,6 +111,13 @@ async function runSession(parsed: AlcodeArgs, ctx: RunContext): Promise<number> 
 
   if (parsed.isNew && result.sessionId) {
     stdout.write(`\nSession ID: ${result.sessionId}\n`);
+  }
+  if (result.authRequired) {
+    stderr.write(
+      "alcode: coding agent not authenticated — an administrator must re-login on the host " +
+        "(`claude`, then `/login`).\n",
+    );
+    return EXIT_AUTH_REQUIRED;
   }
   return result.status === "succeeded" ? 0 : 1;
 }

--- a/packages/alcode/src/run-claude.ts
+++ b/packages/alcode/src/run-claude.ts
@@ -24,6 +24,10 @@ export interface RunOutput {
 
 export interface RunResult {
   status: "succeeded" | "failed";
+  // The coding-agent CLI reported an authentication failure that no run can recover from until an
+  // administrator re-authenticates on the host. Distinct from an ordinary failure so the caller
+  // reports the right remedy instead of retrying.
+  authRequired: boolean;
   sessionId: string | null;
   result: string;
 }
@@ -36,15 +40,25 @@ export async function runClaude(config: RunConfig, out: RunOutput): Promise<RunR
   const state = createStreamState();
   const outcome = await spawnClaude(config, state, out);
   const failed = state.isError || outcome.exitCode !== 0 || state.result === undefined;
-  const result = state.result ?? failureMessage(outcome);
+  // An auth signal only matters when the run actually failed: claude retries a 401, so a signal it
+  // recovered from (run still succeeded) is not a problem to report.
+  const authRequired = failed && state.authFailed;
+  const result = authRequired
+    ? authFailureMessage(state.result)
+    : (state.result ?? failureMessage(outcome));
   applyCompletion(config.sessionFilePath, {
     status: failed ? "failed" : "succeeded",
     endedAt: new Date().toISOString(),
-    exitReason: failed ? "error" : "completed",
+    exitReason: authRequired ? "auth_required" : failed ? "error" : "completed",
     sessionId: state.sessionId ?? null,
     result,
   });
-  return { status: failed ? "failed" : "succeeded", sessionId: state.sessionId ?? null, result };
+  return {
+    status: failed ? "failed" : "succeeded",
+    authRequired,
+    sessionId: state.sessionId ?? null,
+    result,
+  };
 }
 
 interface ClaudeOutcome {
@@ -216,10 +230,14 @@ export interface StreamState {
   sessionId?: string;
   result?: string;
   isError: boolean;
+  // Set once any event carries `error: "authentication_failed"` — the synthetic `assistant` event
+  // (no/expired session) or a `system`/`api_retry` event (rejected key). The structured enum is
+  // stable across CLI versions, unlike the human-readable result text.
+  authFailed: boolean;
 }
 
 export function createStreamState(): StreamState {
-  return { isError: false };
+  return { isError: false, authFailed: false };
 }
 
 export function parseEventLine(line: string): unknown {
@@ -235,6 +253,7 @@ export function parseEventLine(line: string): unknown {
 export function renderEvent(event: unknown, state: StreamState): string | undefined {
   if (!isRecord(event)) return;
   captureSessionId(event, state);
+  captureAuthFailure(event, state);
   switch (event.type) {
     case "system":
       return event.subtype === "init" ? `[init] session ${asString(event.session_id)}` : undefined;
@@ -255,6 +274,10 @@ export function renderEvent(event: unknown, state: StreamState): string | undefi
 function captureSessionId(event: Record<string, unknown>, state: StreamState): void {
   const id = asString(event.session_id);
   if (id) state.sessionId = id;
+}
+
+function captureAuthFailure(event: Record<string, unknown>, state: StreamState): void {
+  if (event.error === "authentication_failed") state.authFailed = true;
 }
 
 function captureResult(event: Record<string, unknown>, state: StreamState): void {
@@ -299,6 +322,17 @@ function renderToolResult(content: unknown): string {
 function failureMessage(outcome: ClaudeOutcome): string {
   const stderr = outcome.stderr.trim();
   return stderr || `claude exited with code ${outcome.exitCode ?? "unknown"}`;
+}
+
+// The remedy is an operator action on the host, not a retry — so the result block names it and
+// keeps claude's own reason line (e.g. "OAuth session expired…") beneath it.
+function authFailureMessage(claudeReason: string | undefined): string {
+  const base =
+    "Coding agent not authenticated (authentication_failed): the host session is missing, expired, " +
+    "or rejected. An administrator must re-login on the host (run `claude`, then `/login`) before " +
+    "alcode can run again.";
+  const detail = claudeReason?.trim();
+  return detail ? `${base}\n\n${detail}` : base;
 }
 
 // --- Shared helpers ---

--- a/packages/alcode/src/session-file.ts
+++ b/packages/alcode/src/session-file.ts
@@ -73,7 +73,7 @@ export function writeInitialSessionFile(
 export interface CompletionUpdate {
   status: "succeeded" | "failed";
   endedAt: string;
-  exitReason: "completed" | "error" | "terminated";
+  exitReason: "completed" | "error" | "terminated" | "auth_required";
   sessionId: string | null;
   result: string;
 }

--- a/packages/alcode/templates/generic-guide.md
+++ b/packages/alcode/templates/generic-guide.md
@@ -14,6 +14,8 @@ Running under OpenClaw? Read `alcode --openclaw-guide` instead — the same manu
 
 Read the run's session file (the path `alcode` prints on its first line, under `_alcode/`): its frontmatter carries `status` (`succeeded`/`failed`) and the `sessionId`, and the `---- Result ----` block holds the outcome. Report it to the user where the work was requested. If the run failed, say so plainly and propose the next step.
 
+An `exitReason` of `auth_required` in the frontmatter (alcode also exits `2`) means the coding agent is not authenticated on the host: an administrator must re-login there before any run can succeed. Report that and do not retry.
+
 Do **not** re-verify the repo, re-run the agent, or inspect `git` — the session file is authoritative. Keep session files in place; they are the durable audit trail.
 
 {{CLI_REFERENCE}}

--- a/packages/alcode/templates/openclaw-guide.md
+++ b/packages/alcode/templates/openclaw-guide.md
@@ -45,4 +45,6 @@ Any heartbeat received while an `alcode` run is **still pending** (running, or f
 
 If the session file says the run failed, report that plainly and propose the next step; don't silently retry. When a session turns bad, keep everything in place — session files, directories, and records are the durable audit trail; never delete them; just start a new session.
 
+If the frontmatter's `exitReason` is `auth_required`, the coding agent itself is not authenticated on the host (its session is missing or expired). No run can succeed until an administrator re-logs it in on the host. Tell the user exactly that, and do not retry — a retry hits the same wall.
+
 {{CLI_REFERENCE}}

--- a/packages/alcode/test/run-claude.test.ts
+++ b/packages/alcode/test/run-claude.test.ts
@@ -113,4 +113,32 @@ describe("renderEvent", () => {
     renderEvent({ type: "result", result: "boom", is_error: true }, state);
     expect(state.isError).toBe(true);
   });
+
+  it("flags an auth failure from the synthetic assistant event (no/expired session)", () => {
+    const state = createStreamState();
+    renderEvent(
+      {
+        type: "assistant",
+        message: { model: "<synthetic>", content: [{ type: "text", text: "Not logged in" }] },
+        error: "authentication_failed",
+      },
+      state,
+    );
+    expect(state.authFailed).toBe(true);
+  });
+
+  it("flags an auth failure from an api_retry event (rejected key)", () => {
+    const state = createStreamState();
+    renderEvent(
+      { type: "system", subtype: "api_retry", error_status: 401, error: "authentication_failed" },
+      state,
+    );
+    expect(state.authFailed).toBe(true);
+  });
+
+  it("leaves authFailed unset for ordinary events", () => {
+    const state = createStreamState();
+    renderEvent({ type: "result", result: "boom", is_error: true }, state);
+    expect(state.authFailed).toBe(false);
+  });
 });

--- a/skills/alignfirst-setup-guide/SKILL.md
+++ b/skills/alignfirst-setup-guide/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Requires git and a Node.js package manager (npm, pnpm, yarn, or b
 license: CC0 1.0
 metadata:
   author: Paleo
-  version: "0.20.0"
+  version: "0.20.1"
   repository: https://github.com/paleo/alignfirst
 ---
 

--- a/skills/alignfirst-setup-guide/references/docmap-migrate-skills.md
+++ b/skills/alignfirst-setup-guide/references/docmap-migrate-skills.md
@@ -90,7 +90,7 @@ If `AGENTS.md` (or an equivalent top-level agent instructions file) exists, add 
 
 > ## Docmap - Seek Documentation
 >
-> **Before any investigation or code exploration**, run `npm run docmap`, then read the relevant documentation. Mandatory for every task.
+> *Before* any investigation or code exploration, run `npm run docmap`, then read the relevant documentation. Mandatory for every task.
 >
 > ### Essential Documentation
 >

--- a/skills/alignfirst-setup-guide/references/docmap-setup.md
+++ b/skills/alignfirst-setup-guide/references/docmap-setup.md
@@ -18,7 +18,7 @@ Install the docmap CLI in a consumer repo so humans and agents share one set of 
    ```markdown
    ## Docmap - Seek Documentation
 
-   **Before any investigation or code exploration**, run `npm run docmap`, then read the relevant documentation. Mandatory for every task.
+   *Before* any investigation or code exploration, run `npm run docmap`, then read the relevant documentation. Mandatory for every task.
 
    ### Essential Documentation
 


### PR DESCRIPTION
`alcode` now distinguishes a lost/expired coding-agent session from an ordinary coding failure:

- Adds a dedicated `auth_required` outcome, recorded as `exitReason: "auth_required"` in the session file and surfaced through a distinct CLI exit code (`2`) plus a one-line stderr message.
- Detects the authentication failure deterministically from claude's `authentication_failed` signal and emits an actionable result block that keeps claude's own reason line.
- Updates the guides and README to instruct callers to have an admin re-login on the host, and not to retry, on an `auth_required` outcome.
