### PR TITLE
feat: team plans repository tool

### DIFF
--- a/.changeset/plans-repo-package.md
+++ b/.changeset/plans-repo-package.md
@@ -1,0 +1,5 @@
+---
+"@paleo/plans-repo": minor
+---
+
+New `plans-repo` CLI: share the `.plans` directory through a dedicated team plans repository. `plans-repo setup <dir> --repo <url> --folder <name>` clones (or reuses) the plans repository and links `.plans` to the project's folder inside it, migrating any existing content. `plans-repo sync` pulls, commits, and pushes the plans repository.

--- a/.changeset/plans-repo-package.md
+++ b/.changeset/plans-repo-package.md
@@ -1,5 +1,0 @@
----
-"@paleo/plans-repo": minor
----
-
-New `plans-repo` CLI: share the `.plans` directory through a dedicated team plans repository. `plans-repo setup <dir> --repo <url> --folder <name>` clones (or reuses) the plans repository and links `.plans` to the project's folder inside it, migrating any existing content. `plans-repo sync` pulls, commits, and pushes the plans repository.

--- a/.changeset/workspace-shared-dirs.md
+++ b/.changeset/workspace-shared-dirs.md
@@ -1,0 +1,5 @@
+---
+"@paleo/workspace": minor
+---
+
+`workspace setup` now creates a missing shared directory in the main worktree instead of skipping its symlink, so directories like `.local` exist before the first linked worktree needs them. A broken symlink at a shared directory's place in the main worktree is reported as an error.

--- a/.changeset/workspace-shared-dirs.md
+++ b/.changeset/workspace-shared-dirs.md
@@ -1,5 +1,0 @@
----
-"@paleo/workspace": minor
----
-
-`workspace setup` now creates a missing shared directory in the main worktree instead of skipping its symlink, so directories like `.local` exist before the first linked worktree needs them. A broken symlink at a shared directory's place in the main worktree is reported as an error.

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,5 @@
 .local
-.plans/**
-!.plans/**/
-!.plans/**/*.shared.md
+.plans
 .env
 node_modules
 dist/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@
 - `@paleo/openclaw-discord-mock` — Discord-shaped channel plugin for test scenarios
 - `@paleo/openclaw-test` — Dockerised regression-test harness (bus, scenario driver, judge, Compose stack)
 - `@paleo/workspace` — run multiple git-worktree dev environments side by side
+- `@paleo/plans-repo` — share the `.plans` directory through a team plans repository
 
 ## Docmap - Seek Documentation
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,8 +23,8 @@
 - `@paleo/openclaw-slack-mock` — Slack-shaped channel plugin for test scenarios
 - `@paleo/openclaw-discord-mock` — Discord-shaped channel plugin for test scenarios
 - `@paleo/openclaw-test` — Dockerised regression-test harness (bus, scenario driver, judge, Compose stack)
-- `@paleo/workspace` — run multiple git-worktree dev environments side by side
 - `@paleo/plans-repo` — share the `.plans` directory through a team plans repository
+- `@paleo/workspace` — run multiple git-worktree dev environments side by side
 
 ## Docmap - Seek Documentation
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ Collaborative spec/plan/AAD/review protocols. See [alignfirst-skills.md](alignfi
 
 `@paleo/workspace` runs multiple dev environments side by side using git worktrees. See [packages/workspace/README.md](packages/workspace/README.md).
 
+## Team plans repository
+
+`@paleo/plans-repo` shares the `.plans` directory of the AlignFirst skills among a team, through a dedicated plans repository. See [packages/plans-repo/README.md](packages/plans-repo/README.md).
+
 ## OpenClaw Test toolkit
 
 `@paleo/openclaw-test` and three companion channel packages: they are a Dockerised regression-test harness that drives OpenClaw through synthetic Discord and Slack channels. See [packages/openclaw-test/README.md](packages/openclaw-test/README.md).

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ Companion products for AI-assisted software work. They can be used independently
 
 Collaborative spec/plan/AAD/review protocols. See [alignfirst-skills.md](alignfirst-skills.md).
 
+### Team plans repository
+
+`@paleo/plans-repo` shares the `.plans` directory of the AlignFirst skills among a team, through a dedicated plans repository. See [packages/plans-repo/README.md](packages/plans-repo/README.md).
+
 ## Docmap - Agent-discoverable documentation
 
 `@paleo/docmap` is a lightweight table of contents that lets agents navigate documentation files. This way we have one set of docs, shared by humans and AI agents. See [packages/docmap/README.md](packages/docmap/README.md).
@@ -13,10 +17,6 @@ Collaborative spec/plan/AAD/review protocols. See [alignfirst-skills.md](alignfi
 ## Workspaces - Local environments with worktrees
 
 `@paleo/workspace` runs multiple dev environments side by side using git worktrees. See [packages/workspace/README.md](packages/workspace/README.md).
-
-## Team plans repository
-
-`@paleo/plans-repo` shares the `.plans` directory of the AlignFirst skills among a team, through a dedicated plans repository. See [packages/plans-repo/README.md](packages/plans-repo/README.md).
 
 ## OpenClaw Test toolkit
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6137,7 +6137,7 @@
     },
     "packages/plans-repo": {
       "name": "@paleo/plans-repo",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "license": "CC0-1.0",
       "bin": {
         "plans-repo": "bin/plans-repo.mjs"
@@ -6154,7 +6154,7 @@
     },
     "packages/workspace": {
       "name": "@paleo/workspace",
-      "version": "0.28.0",
+      "version": "0.29.0",
       "license": "CC0-1.0",
       "devDependencies": {
         "@types/node": "~24.12.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -552,6 +552,10 @@
       "resolved": "packages/openclaw-test",
       "link": true
     },
+    "node_modules/@paleo/plans-repo": {
+      "resolved": "packages/plans-repo",
+      "link": true
+    },
     "node_modules/@paleo/workspace": {
       "resolved": "packages/workspace",
       "link": true
@@ -6129,6 +6133,23 @@
         "zod": {
           "optional": true
         }
+      }
+    },
+    "packages/plans-repo": {
+      "name": "@paleo/plans-repo",
+      "version": "0.0.0",
+      "license": "CC0-1.0",
+      "bin": {
+        "plans-repo": "bin/plans-repo.mjs"
+      },
+      "devDependencies": {
+        "@types/node": "~24.12.4",
+        "rimraf": "~6.1.3",
+        "typescript": "~6.0.3",
+        "vitest": "~4.1.7"
+      },
+      "engines": {
+        "node": ">=22.11.0"
       }
     },
     "packages/workspace": {

--- a/packages/plans-repo/CHANGELOG.md
+++ b/packages/plans-repo/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @paleo/plans-repo
+
+## 0.1.0
+
+### Minor Changes
+
+- 60afd89: New `plans-repo` CLI: share the `.plans` directory through a dedicated team plans repository. `plans-repo setup <dir> --repo <url> --folder <name>` clones (or reuses) the plans repository and links `.plans` to the project's folder inside it, migrating any existing content. `plans-repo sync` pulls, commits, and pushes the plans repository.

--- a/packages/plans-repo/README.md
+++ b/packages/plans-repo/README.md
@@ -16,7 +16,7 @@ team-plans/
     103/
 ```
 
-Each developer clones it once per machine. In each project, `.plans` in the main worktree becomes a symlink to the project's folder inside the clone. Plans never enter the product repository: its `.gitignore` carries a bare `.plans` line.
+Each developer clones it once per machine. In each project, `.plans` in the main worktree becomes a symlink to the project's folder inside the clone. Plans never enter the product repository: its `.gitignore` contains `.plans`.
 
 Plan history has no value, so the plans repository only receives synchronization commits — pull, commit `sync`, push — at each user's discretion.
 

--- a/packages/plans-repo/README.md
+++ b/packages/plans-repo/README.md
@@ -1,0 +1,60 @@
+# @paleo/plans-repo
+
+Share the `.plans` directory of the [AlignFirst skills](https://github.com/paleo/alignfirst) through a dedicated team plans repository.
+
+## How it works
+
+A team hosts a plans repository, multi-project — one folder per code repo, ticket directories inside:
+
+```text
+team-plans/
+  project-a/
+    250/
+      A1-spec.md
+    _archives/
+  project-b/
+    103/
+```
+
+Each developer clones it once per machine. In each project, `.plans` in the main worktree becomes a symlink to the project's folder inside the clone. Plans never enter the product repository: its `.gitignore` carries a bare `.plans` line.
+
+Plan history has no value, so the plans repository only receives synchronization commits — pull, commit `sync`, push — at each user's discretion.
+
+## Install
+
+```sh
+npm install -D @paleo/plans-repo
+```
+
+Add the npm scripts, with the remote URL and project folder baked in:
+
+```json
+{
+  "plans:setup": "plans-repo setup --repo git@example.com:team/team-plans.git --folder project-a",
+  "plans:sync": "plans-repo sync"
+}
+```
+
+## Commands
+
+Once per machine, from the main worktree root, passing the clone location:
+
+```sh
+npm run plans:setup -- ../team-plans
+```
+
+`setup` clones the repository there (or verifies an existing clone's origin), migrates any existing `.plans` content into it, and creates the symlink. Re-run it with the new location if the clone moves.
+
+To synchronize, from any worktree:
+
+```sh
+npm run plans:sync
+```
+
+## Archiving
+
+To keep `.plans` small, move finished tickets to `_archives/` inside the project folder — anyone, anytime:
+
+```sh
+mv .plans/250 .plans/_archives/
+```

--- a/packages/plans-repo/bin/plans-repo.mjs
+++ b/packages/plans-repo/bin/plans-repo.mjs
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+import { main } from "../dist/cli.js";
+process.exit(main());

--- a/packages/plans-repo/bin/plans-repo.mjs
+++ b/packages/plans-repo/bin/plans-repo.mjs
@@ -1,3 +1,3 @@
 #!/usr/bin/env node
 import { main } from "../dist/cli.js";
-process.exit(main());
+process.exitCode = main();

--- a/packages/plans-repo/package.json
+++ b/packages/plans-repo/package.json
@@ -7,9 +7,10 @@
   "keywords": [
     "alignfirst",
     "plans",
+    "specs",
+    "repository",
     "ai",
-    "agent",
-    "worktree"
+    "agent"
   ],
   "repository": {
     "type": "git",

--- a/packages/plans-repo/package.json
+++ b/packages/plans-repo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paleo/plans-repo",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "license": "CC0-1.0",
   "author": "Thomas MUR",
   "description": "Share AlignFirst plans through a team plans repository.",

--- a/packages/plans-repo/package.json
+++ b/packages/plans-repo/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@paleo/plans-repo",
+  "version": "0.0.0",
+  "license": "CC0-1.0",
+  "author": "Thomas MUR",
+  "description": "Share AlignFirst plans through a team plans repository.",
+  "keywords": [
+    "alignfirst",
+    "plans",
+    "ai",
+    "agent",
+    "worktree"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/paleo/alignfirst.git",
+    "directory": "packages/plans-repo"
+  },
+  "engines": {
+    "node": ">=22.11.0"
+  },
+  "packageManager": "npm@11.12.1",
+  "type": "module",
+  "bin": {
+    "plans-repo": "bin/plans-repo.mjs"
+  },
+  "files": [
+    "bin",
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "clear": "rimraf dist/*",
+    "lint": "biome check",
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "@types/node": "~24.12.4",
+    "rimraf": "~6.1.3",
+    "typescript": "~6.0.3",
+    "vitest": "~4.1.7"
+  }
+}

--- a/packages/plans-repo/src/cli.ts
+++ b/packages/plans-repo/src/cli.ts
@@ -1,0 +1,79 @@
+import { readFileSync } from "node:fs";
+import { CliError, type CliContext } from "./context.js";
+import { runSetup } from "./setup.js";
+import { runSync } from "./sync.js";
+
+const HELP = `plans-repo — share the .plans directory through a team plans repository.
+
+Usage:
+  plans-repo setup <dir> --repo <url> --folder <name>
+  plans-repo sync
+  plans-repo --help | --version
+
+setup   Clone the plans repository at <dir> (or reuse an existing clone), then link .plans
+        to <dir>/<name>/, migrating any existing .plans content. Once per machine; re-run
+        with the new location if the clone moves.
+sync    Pull, commit, and push the plans repository.
+`;
+
+export interface MainOptions {
+  argv?: string[];
+  stdout?: { write(s: string): void };
+  stderr?: { write(s: string): void };
+  cwd?: string;
+  userAgent?: string;
+}
+
+export function main(options?: MainOptions): number {
+  const argv = options?.argv ?? process.argv;
+  const ctx: CliContext = {
+    cwd: options?.cwd ?? process.cwd(),
+    stdout: options?.stdout ?? process.stdout,
+    stderr: options?.stderr ?? process.stderr,
+    syncCommand: syncCommand(options?.userAgent ?? process.env.npm_config_user_agent ?? ""),
+  };
+  const [command, ...rest] = argv.slice(2);
+  try {
+    switch (command) {
+      case "setup":
+        runSetup(ctx, rest);
+        return 0;
+      case "sync":
+        runSync(ctx);
+        return 0;
+      case "--version":
+        ctx.stdout.write(`${readPackageVersion()}\n`);
+        return 0;
+      case "--help":
+      case "-h":
+      case undefined:
+        ctx.stdout.write(HELP);
+        return 0;
+      default:
+        throw new CliError(`Unknown command: ${command}\n\n${HELP}`);
+    }
+  } catch (err) {
+    if (err instanceof CliError) {
+      ctx.stderr.write(`${err.message}\n`);
+      return 1;
+    }
+    throw err;
+  }
+}
+
+// The consumer repo wires `plans:sync` to this bin, so suggest the script through the package
+// manager that launched us (`npm_config_user_agent` is empty for a bare global binary).
+function syncCommand(userAgent: string): string {
+  if (userAgent.startsWith("pnpm")) return "pnpm plans:sync";
+  if (userAgent.startsWith("yarn")) return "yarn plans:sync";
+  if (userAgent.startsWith("bun")) return "bun run plans:sync";
+  return "npm run plans:sync";
+}
+
+function readPackageVersion(): string {
+  const pkg = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf-8")) as {
+    version?: string;
+  };
+  if (pkg.version === undefined) throw new Error("plans-repo: package.json is missing 'version'");
+  return pkg.version;
+}

--- a/packages/plans-repo/src/context.ts
+++ b/packages/plans-repo/src/context.ts
@@ -1,0 +1,10 @@
+export interface CliContext {
+  cwd: string;
+  stdout: { write(s: string): void };
+  stderr: { write(s: string): void };
+  /** The `plans:sync` script invocation for the package manager that launched us. */
+  syncCommand: string;
+}
+
+/** A user-facing failure, reported on stderr with exit code 1. */
+export class CliError extends Error {}

--- a/packages/plans-repo/src/git.ts
+++ b/packages/plans-repo/src/git.ts
@@ -1,0 +1,18 @@
+import { execFileSync } from "node:child_process";
+
+export function git(dir: string, ...args: string[]): void {
+  execFileSync("git", ["-C", dir, ...args], { stdio: "inherit" });
+}
+
+export function gitOutput(dir: string, ...args: string[]): string {
+  return execFileSync("git", ["-C", dir, ...args], { encoding: "utf-8" }).trim();
+}
+
+export function gitSucceeds(dir: string, ...args: string[]): boolean {
+  try {
+    execFileSync("git", ["-C", dir, ...args], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/plans-repo/src/git.ts
+++ b/packages/plans-repo/src/git.ts
@@ -1,11 +1,25 @@
 import { execFileSync } from "node:child_process";
+import { CliError } from "./context.js";
 
 export function git(dir: string, ...args: string[]): void {
-  execFileSync("git", ["-C", dir, ...args], { stdio: "inherit" });
+  try {
+    execFileSync("git", ["-C", dir, ...args], { stdio: "inherit" });
+  } catch {
+    throw gitFailure(args);
+  }
+}
+
+// Git's own stderr is already on screen: callers let the child write to it.
+function gitFailure(args: string[]): CliError {
+  return new CliError(`git ${args[0]} failed. See the git output above.`);
 }
 
 export function gitOutput(dir: string, ...args: string[]): string {
-  return execFileSync("git", ["-C", dir, ...args], { encoding: "utf-8" }).trim();
+  try {
+    return execFileSync("git", ["-C", dir, ...args], { encoding: "utf-8" }).trim();
+  } catch {
+    throw gitFailure(args);
+  }
 }
 
 export function gitSucceeds(dir: string, ...args: string[]): boolean {

--- a/packages/plans-repo/src/setup.ts
+++ b/packages/plans-repo/src/setup.ts
@@ -1,0 +1,114 @@
+import {
+  cpSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readdirSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+} from "node:fs";
+import { join, relative, resolve } from "node:path";
+import { CliError, type CliContext } from "./context.js";
+import { git, gitOutput } from "./git.js";
+
+export function runSetup(ctx: CliContext, args: string[]): void {
+  const options = parseSetupArgs(args);
+  checkMainWorktreeRoot(ctx);
+  const cloneDir = resolve(ctx.cwd, options.dir);
+  ensureClone(ctx, cloneDir, options.repoUrl);
+  const projectDir = join(cloneDir, options.folder);
+  mkdirSync(projectDir, { recursive: true });
+  linkPlans(ctx, projectDir);
+}
+
+interface SetupOptions {
+  dir: string;
+  repoUrl: string;
+  folder: string;
+}
+
+function parseSetupArgs(args: string[]): SetupOptions {
+  let dir: string | undefined;
+  let repoUrl: string | undefined;
+  let folder: string | undefined;
+  for (let i = 0; i < args.length; ++i) {
+    const arg = args[i];
+    if (arg === "--repo") repoUrl = args[++i];
+    else if (arg === "--folder") folder = args[++i];
+    else if (arg.startsWith("-")) throw new CliError(`Unknown option: ${arg}`);
+    else if (dir === undefined) dir = arg;
+    else throw new CliError(`Unexpected argument: ${arg}`);
+  }
+  if (dir === undefined || repoUrl === undefined || folder === undefined)
+    throw new CliError("Usage: plans-repo setup <dir> --repo <url> --folder <name>");
+  return { dir, repoUrl, folder };
+}
+
+function checkMainWorktreeRoot(ctx: CliContext): void {
+  const toplevel = gitOutput(ctx.cwd, "rev-parse", "--show-toplevel");
+  if (realpathSync(toplevel) !== realpathSync(ctx.cwd))
+    throw new CliError("Run this command from the repository root.");
+  const gitDir = gitOutput(ctx.cwd, "rev-parse", "--absolute-git-dir");
+  const commonDir = gitOutput(ctx.cwd, "rev-parse", "--git-common-dir");
+  if (realpathSync(gitDir) !== realpathSync(resolve(ctx.cwd, commonDir)))
+    throw new CliError(
+      "Run this command from the main worktree. Linked worktrees reach .plans through it.",
+    );
+}
+
+function ensureClone(ctx: CliContext, cloneDir: string, repoUrl: string): void {
+  if (existsSync(join(cloneDir, ".git"))) {
+    const origin = gitOutput(cloneDir, "remote", "get-url", "origin");
+    if (normalizeGitUrl(origin) !== normalizeGitUrl(repoUrl))
+      throw new CliError(`${cloneDir} is a clone of ${origin}, expected ${repoUrl}.`);
+    ctx.stdout.write(`Using the existing clone at ${cloneDir}.\n`);
+    return;
+  }
+  if (existsSync(cloneDir) && readdirSync(cloneDir).length > 0)
+    throw new CliError(`${cloneDir} exists and is not a git clone.`);
+  git(ctx.cwd, "clone", "--quiet", repoUrl, cloneDir);
+  ctx.stdout.write(`Cloned ${repoUrl} into ${cloneDir}.\n`);
+}
+
+function normalizeGitUrl(url: string): string {
+  return url
+    .trim()
+    .replace(/\/+$/, "")
+    .replace(/\.git$/, "");
+}
+
+function linkPlans(ctx: CliContext, projectDir: string): void {
+  const plansPath = join(ctx.cwd, ".plans");
+  const stats = lstatSync(plansPath, { throwIfNoEntry: false });
+  if (stats?.isSymbolicLink()) {
+    if (existsSync(plansPath) && realpathSync(plansPath) === realpathSync(projectDir)) {
+      ctx.stdout.write(".plans already links to the plans repository.\n");
+      return;
+    }
+    rmSync(plansPath);
+  } else if (stats?.isDirectory()) {
+    migratePlansContent(ctx, plansPath, projectDir);
+  } else if (stats) {
+    throw new CliError(".plans exists and is not a directory.");
+  }
+  const target = relative(ctx.cwd, projectDir);
+  symlinkSync(target, plansPath);
+  ctx.stdout.write(`Linked .plans → ${target}\n`);
+  ctx.stdout.write(`Publish with: ${ctx.syncCommand}\n`);
+}
+
+function migratePlansContent(ctx: CliContext, plansPath: string, projectDir: string): void {
+  const entries = readdirSync(plansPath);
+  for (const entry of entries) {
+    const dest = join(projectDir, entry);
+    if (existsSync(dest))
+      throw new CliError(
+        `Cannot migrate .plans/${entry}: ${dest} already exists. Merge it manually, then re-run.`,
+      );
+    cpSync(join(plansPath, entry), dest, { recursive: true });
+  }
+  rmSync(plansPath, { recursive: true });
+  if (entries.length > 0)
+    ctx.stdout.write(`Migrated ${entries.length} entries from the local .plans directory.\n`);
+}

--- a/packages/plans-repo/src/setup.ts
+++ b/packages/plans-repo/src/setup.ts
@@ -100,14 +100,14 @@ function linkPlans(ctx: CliContext, projectDir: string): void {
 
 function migratePlansContent(ctx: CliContext, plansPath: string, projectDir: string): void {
   const entries = readdirSync(plansPath);
-  for (const entry of entries) {
-    const dest = join(projectDir, entry);
-    if (existsSync(dest))
-      throw new CliError(
-        `Cannot migrate .plans/${entry}: ${dest} already exists. Merge it manually, then re-run.`,
-      );
-    cpSync(join(plansPath, entry), dest, { recursive: true });
-  }
+  const collisions = entries.filter((entry) => existsSync(join(projectDir, entry)));
+  if (collisions.length > 0)
+    throw new CliError(
+      `Cannot migrate .plans: already in ${projectDir}: ${collisions.join(", ")}. ` +
+        "Merge them manually, then re-run.",
+    );
+  for (const entry of entries)
+    cpSync(join(plansPath, entry), join(projectDir, entry), { recursive: true });
   rmSync(plansPath, { recursive: true });
   if (entries.length > 0)
     ctx.stdout.write(`Migrated ${entries.length} entries from the local .plans directory.\n`);

--- a/packages/plans-repo/src/sync.ts
+++ b/packages/plans-repo/src/sync.ts
@@ -1,0 +1,45 @@
+import { existsSync, lstatSync } from "node:fs";
+import { join } from "node:path";
+import { CliError, type CliContext } from "./context.js";
+import { git, gitOutput, gitSucceeds } from "./git.js";
+
+export function runSync(ctx: CliContext): void {
+  const plansDir = resolvePlansDir(ctx);
+  // A fresh clone of an empty plans repository has no HEAD yet: nothing to rebase onto.
+  if (hasHead(plansDir)) git(plansDir, "pull", "--rebase", "--autostash");
+  git(plansDir, "add", "-A");
+  if (hasStagedChanges(plansDir)) git(plansDir, "commit", "--quiet", "-m", "sync");
+  // Still no HEAD after the commit step: an empty clone with nothing staged, nothing to push.
+  if (hasHead(plansDir)) git(plansDir, "push", "--quiet", "-u", "origin", "HEAD");
+  ctx.stdout.write("Plans synchronized.\n");
+}
+
+function hasHead(dir: string): boolean {
+  return gitSucceeds(dir, "rev-parse", "--verify", "-q", "HEAD");
+}
+
+function resolvePlansDir(ctx: CliContext): string {
+  const plansPath = join(ctx.cwd, ".plans");
+  if (!existsSync(plansPath)) {
+    if (isBrokenSymlink(plansPath))
+      throw new CliError(
+        "The .plans symlink is broken. Re-run the plans:setup script with the clone location.",
+      );
+    throw new CliError("No .plans directory here. Run this command from a worktree root.");
+  }
+  const plansToplevel = gitOutput(plansPath, "rev-parse", "--show-toplevel");
+  const repoToplevel = gitOutput(ctx.cwd, "rev-parse", "--show-toplevel");
+  if (plansToplevel === repoToplevel)
+    throw new CliError(
+      ".plans is not linked to a team plans repository. Run the plans:setup script first.",
+    );
+  return plansToplevel;
+}
+
+function isBrokenSymlink(path: string): boolean {
+  return lstatSync(path, { throwIfNoEntry: false })?.isSymbolicLink() ?? false;
+}
+
+function hasStagedChanges(dir: string): boolean {
+  return !gitSucceeds(dir, "diff", "--cached", "--quiet");
+}

--- a/packages/plans-repo/test/plans-repo.test.ts
+++ b/packages/plans-repo/test/plans-repo.test.ts
@@ -1,0 +1,184 @@
+import { execFileSync } from "node:child_process";
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readlinkSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+
+import { main } from "../src/cli.js";
+
+let suiteDir: string;
+let fixtureDir: string;
+
+beforeAll(() => {
+  suiteDir = mkdtempSync(join(tmpdir(), "plans-repo-suite-"));
+  const gitConfig = join(suiteDir, "gitconfig");
+  writeFileSync(
+    gitConfig,
+    "[user]\n\tname = Test\n\temail = test@example.com\n[init]\n\tdefaultBranch = main\n",
+  );
+  process.env.GIT_CONFIG_GLOBAL = gitConfig;
+  process.env.GIT_CONFIG_SYSTEM = "/dev/null";
+});
+
+afterAll(() => {
+  rmSync(suiteDir, { recursive: true, force: true });
+});
+
+afterEach(() => {
+  if (fixtureDir) rmSync(fixtureDir, { recursive: true, force: true });
+});
+
+interface Fixture {
+  root: string;
+  product: string;
+  remoteUrl: string;
+}
+
+function makeFixture(): Fixture {
+  fixtureDir = mkdtempSync(join(tmpdir(), "plans-repo-"));
+  const remoteUrl = join(fixtureDir, "remote.git");
+  execGit(fixtureDir, "init", "--quiet", "--bare", remoteUrl);
+  const product = join(fixtureDir, "product");
+  execGit(fixtureDir, "init", "--quiet", product);
+  writeFileSync(join(product, "README.md"), "product\n");
+  execGit(product, "add", "-A");
+  execGit(product, "commit", "--quiet", "-m", "init");
+  return { root: fixtureDir, product, remoteUrl };
+}
+
+function execGit(dir: string, ...args: string[]): string {
+  return execFileSync("git", ["-C", dir, ...args], { encoding: "utf-8" }).trim();
+}
+
+interface RunResult {
+  code: number;
+  stdout: string;
+  stderr: string;
+}
+
+function run(cwd: string, ...args: string[]): RunResult {
+  let stdout = "";
+  let stderr = "";
+  const code = main({
+    argv: ["node", "plans-repo", ...args],
+    cwd,
+    stdout: { write: (s) => (stdout += s) },
+    stderr: { write: (s) => (stderr += s) },
+  });
+  return { code, stdout, stderr };
+}
+
+function runSetup(fixture: Fixture, dir = join(fixture.root, "team-plans")): RunResult {
+  return run(fixture.product, "setup", dir, "--repo", fixture.remoteUrl, "--folder", "myproj");
+}
+
+describe("plans-repo setup", () => {
+  it("clones the plans repository and links .plans", () => {
+    const fixture = makeFixture();
+    const result = runSetup(fixture);
+    expect(result.stderr).toBe("");
+    expect(result.code).toBe(0);
+    expect(lstatSync(join(fixture.product, ".plans")).isSymbolicLink()).toBe(true);
+    expect(readlinkSync(join(fixture.product, ".plans"))).toBe(join("..", "team-plans", "myproj"));
+    expect(existsSync(join(fixture.root, "team-plans", "myproj"))).toBe(true);
+  });
+
+  it("migrates existing .plans content into the clone", () => {
+    const fixture = makeFixture();
+    const ticketDir = join(fixture.product, ".plans", "123");
+    mkdirSync(ticketDir, { recursive: true });
+    writeFileSync(join(ticketDir, "A1-spec.md"), "spec\n");
+    const result = runSetup(fixture);
+    expect(result.code).toBe(0);
+    expect(existsSync(join(fixture.root, "team-plans", "myproj", "123", "A1-spec.md"))).toBe(true);
+    expect(lstatSync(join(fixture.product, ".plans")).isSymbolicLink()).toBe(true);
+  });
+
+  it("is idempotent once linked", () => {
+    const fixture = makeFixture();
+    runSetup(fixture);
+    const result = runSetup(fixture);
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain("already links");
+  });
+
+  it("rejects a clone with a different origin", () => {
+    const fixture = makeFixture();
+    const otherRemote = join(fixture.root, "other.git");
+    execGit(fixture.root, "init", "--quiet", "--bare", otherRemote);
+    const dir = join(fixture.root, "team-plans");
+    execGit(fixture.root, "clone", "--quiet", otherRemote, dir);
+    const result = runSetup(fixture, dir);
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain("is a clone of");
+  });
+
+  it("re-links after the clone moved", () => {
+    const fixture = makeFixture();
+    runSetup(fixture);
+    const movedDir = join(fixture.root, "moved-plans");
+    renameSync(join(fixture.root, "team-plans"), movedDir);
+    const result = runSetup(fixture, movedDir);
+    expect(result.code).toBe(0);
+    expect(readlinkSync(join(fixture.product, ".plans"))).toBe(join("..", "moved-plans", "myproj"));
+  });
+
+  it("refuses to run from a linked worktree", () => {
+    const fixture = makeFixture();
+    const worktree = join(fixture.root, "product-feat");
+    execGit(fixture.product, "worktree", "add", "--quiet", worktree, "-b", "feat");
+    const result = run(
+      worktree,
+      "setup",
+      join(fixture.root, "team-plans"),
+      "--repo",
+      fixture.remoteUrl,
+      "--folder",
+      "myproj",
+    );
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain("main worktree");
+  });
+});
+
+describe("plans-repo sync", () => {
+  it("publishes plan files to the remote", () => {
+    const fixture = makeFixture();
+    runSetup(fixture);
+    const ticketDir = join(fixture.product, ".plans", "77");
+    mkdirSync(ticketDir, { recursive: true });
+    writeFileSync(join(ticketDir, "A1-spec.md"), "spec\n");
+    const result = run(fixture.product, "sync");
+    expect(result.stderr).toBe("");
+    expect(result.code).toBe(0);
+    const remoteFiles = execGit(fixture.remoteUrl, "ls-tree", "-r", "HEAD", "--name-only");
+    expect(remoteFiles).toContain("myproj/77/A1-spec.md");
+  });
+
+  it("succeeds when there is nothing to publish", () => {
+    const fixture = makeFixture();
+    runSetup(fixture);
+    run(fixture.product, "sync");
+    const result = run(fixture.product, "sync");
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain("Plans synchronized.");
+  });
+
+  it("fails when .plans is not linked to a plans repository", () => {
+    const fixture = makeFixture();
+    mkdirSync(join(fixture.product, ".plans"));
+    const result = run(fixture.product, "sync");
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain("not linked");
+  });
+});

--- a/packages/plans-repo/test/plans-repo.test.ts
+++ b/packages/plans-repo/test/plans-repo.test.ts
@@ -104,6 +104,22 @@ describe("plans-repo setup", () => {
     expect(lstatSync(join(fixture.product, ".plans")).isSymbolicLink()).toBe(true);
   });
 
+  it("reports all migration collisions without copying anything", () => {
+    const fixture = makeFixture();
+    const cloneDir = join(fixture.root, "team-plans");
+    execGit(fixture.root, "clone", "--quiet", fixture.remoteUrl, cloneDir);
+    mkdirSync(join(cloneDir, "myproj", "123"), { recursive: true });
+    mkdirSync(join(cloneDir, "myproj", "456"), { recursive: true });
+    mkdirSync(join(fixture.product, ".plans", "123"), { recursive: true });
+    mkdirSync(join(fixture.product, ".plans", "456"), { recursive: true });
+    mkdirSync(join(fixture.product, ".plans", "789"), { recursive: true });
+    const result = runSetup(fixture);
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain("123, 456");
+    expect(existsSync(join(cloneDir, "myproj", "789"))).toBe(false);
+    expect(lstatSync(join(fixture.product, ".plans")).isDirectory()).toBe(true);
+  });
+
   it("is idempotent once linked", () => {
     const fixture = makeFixture();
     runSetup(fixture);

--- a/packages/plans-repo/tsconfig.build.json
+++ b/packages/plans-repo/tsconfig.build.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/packages/plans-repo/tsconfig.json
+++ b/packages/plans-repo/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.build.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "noEmit": true
+  },
+  "include": ["src", "test"]
+}

--- a/packages/workspace/CHANGELOG.md
+++ b/packages/workspace/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @paleo/workspace
 
+## 0.29.0
+
+### Minor Changes
+
+- 60afd89: `workspace setup` now creates a missing shared directory in the main worktree instead of skipping its symlink, so directories like `.local` exist before the first linked worktree needs them. A broken symlink at a shared directory's place in the main worktree is reported as an error.
+
 ## 0.28.0
 
 ### Minor Changes

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paleo/workspace",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "description": "Run multiple git-worktree dev environments side by side.",
   "keywords": [
     "workspace",

--- a/packages/workspace/src/workspace.ts
+++ b/packages/workspace/src/workspace.ts
@@ -1193,17 +1193,27 @@ function ensureWorktree(
   return useExistingBranch(command.branch, ctx, run, dirNameFn);
 }
 
-function linkSharedDirectories(
+export function linkSharedDirectories(
   ctx: WorktreeContext,
   dirs: string[],
   log: (msg: string) => void,
 ): void {
   for (const dirName of dirs) {
-    const link = join(ctx.currentWorktree, dirName);
     const mainDir = join(ctx.mainWorktree, dirName);
     if (!existsSync(mainDir)) {
-      log(`Skipped ${dirName} symlink (not present in main worktree).`);
-    } else if (existsSync(link)) {
+      // A dead symlink (e.g. `.plans` pointing at a moved plans-repo clone) must be repaired by the
+      // user, not shadowed by a fresh directory.
+      if (lstatSync(mainDir, { throwIfNoEntry: false })?.isSymbolicLink()) {
+        throw new WorkspaceError(
+          `'${dirName}' in the main worktree is a broken symlink. Repair it, then retry.`,
+        );
+      }
+      mkdirSync(mainDir, { recursive: true });
+      log(`Created ${dirName} in the main worktree (shared directory was missing).`);
+    }
+    if (ctx.isMainWorktree) continue;
+    const link = join(ctx.currentWorktree, dirName);
+    if (existsSync(link)) {
       log(`Skipped ${dirName} symlink (already exists).`);
     } else {
       const relTarget = relative(ctx.currentWorktree, mainDir);

--- a/packages/workspace/test/shared-dirs.test.ts
+++ b/packages/workspace/test/shared-dirs.test.ts
@@ -1,0 +1,85 @@
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readlinkSync,
+  rmSync,
+  symlinkSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { WorkspaceError } from "../src/errors.js";
+import { linkSharedDirectories } from "../src/workspace.js";
+import type { WorktreeContext } from "../src/worktree.js";
+
+let tempRoot: string;
+
+afterEach(() => {
+  if (tempRoot) rmSync(tempRoot, { recursive: true, force: true });
+});
+
+function makeWorktrees(): { main: string; linked: string } {
+  tempRoot = mkdtempSync(join(tmpdir(), "shared-dirs-"));
+  const main = join(tempRoot, "main");
+  const linked = join(tempRoot, "linked");
+  mkdirSync(main);
+  mkdirSync(linked);
+  return { main, linked };
+}
+
+function linkedCtx(main: string, linked: string): WorktreeContext {
+  return { currentWorktree: linked, mainWorktree: main, isMainWorktree: false };
+}
+
+describe("linkSharedDirectories", () => {
+  it("creates a missing shared directory in the main worktree, then links it", () => {
+    const { main, linked } = makeWorktrees();
+    linkSharedDirectories(linkedCtx(main, linked), [".local"], () => {});
+    expect(lstatSync(join(main, ".local")).isDirectory()).toBe(true);
+    expect(readlinkSync(join(linked, ".local"))).toBe(join("..", "main", ".local"));
+  });
+
+  it("creates missing shared directories on a main-worktree setup, without symlinks", () => {
+    const { main } = makeWorktrees();
+    const ctx: WorktreeContext = {
+      currentWorktree: main,
+      mainWorktree: main,
+      isMainWorktree: true,
+    };
+    linkSharedDirectories(ctx, [".local", ".plans"], () => {});
+    expect(lstatSync(join(main, ".local")).isDirectory()).toBe(true);
+    expect(lstatSync(join(main, ".plans")).isDirectory()).toBe(true);
+    expect(lstatSync(join(main, ".plans")).isSymbolicLink()).toBe(false);
+  });
+
+  it("keeps an existing shared directory and an existing link untouched", () => {
+    const { main, linked } = makeWorktrees();
+    mkdirSync(join(main, ".local"));
+    symlinkSync(join("..", "main", ".local"), join(linked, ".local"));
+    const messages: string[] = [];
+    linkSharedDirectories(linkedCtx(main, linked), [".local"], (msg) => messages.push(msg));
+    expect(messages).toEqual(["Skipped .local symlink (already exists)."]);
+  });
+
+  it("follows a valid symlink in the main worktree (team plans repo layout)", () => {
+    const { main, linked } = makeWorktrees();
+    const clone = join(tempRoot, "clone");
+    mkdirSync(clone);
+    symlinkSync(join("..", "clone"), join(main, ".plans"));
+    linkSharedDirectories(linkedCtx(main, linked), [".plans"], () => {});
+    expect(readlinkSync(join(linked, ".plans"))).toBe(join("..", "main", ".plans"));
+  });
+
+  it("fails on a broken symlink in the main worktree instead of shadowing it", () => {
+    const { main, linked } = makeWorktrees();
+    symlinkSync(join("..", "gone"), join(main, ".plans"));
+    expect(() => linkSharedDirectories(linkedCtx(main, linked), [".plans"], () => {})).toThrow(
+      WorkspaceError,
+    );
+    expect(existsSync(join(linked, ".plans"))).toBe(false);
+  });
+});

--- a/skills/alignfirst-setup-guide/SKILL.md
+++ b/skills/alignfirst-setup-guide/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Requires git and a Node.js package manager (npm, pnpm, yarn, or b
 license: CC0 1.0
 metadata:
   author: Paleo
-  version: "0.20.1"
+  version: "0.21.0"
   repository: https://github.com/paleo/alignfirst
 ---
 
@@ -44,7 +44,7 @@ Require a clean working tree first (`git status`). If it isn't clean, stop and a
 
 - [docmap-setup.md](references/docmap-setup.md) — install the docmap CLI, then optionally bootstrap or migrate docs.
 - [workspace-setup.md](references/workspace-setup.md) — implement the worktree system (adapt the [asset scripts](assets/), install `@paleo/workspace`).
-- [alignfirst-skills-setup.md](references/alignfirst-skills-setup.md) — install the AlignFirst skills and configure the project.
+- [alignfirst-skills-setup.md](references/alignfirst-skills-setup.md) — install the AlignFirst skills and configure the project. For a team sharing plans through a dedicated repository, continue with [plans-repo-setup.md](references/plans-repo-setup.md).
 
 **Upgrading from an older AlignFirst** (v1/v2): route through [alignfirst-upgrade.md](references/alignfirst-upgrade.md), which detects the version and follows [alignfirst-upgrade-from-v1.md](references/alignfirst-upgrade-from-v1.md) or [alignfirst-upgrade-from-v2.md](references/alignfirst-upgrade-from-v2.md).
 

--- a/skills/alignfirst-setup-guide/references/alignfirst-skills-setup.md
+++ b/skills/alignfirst-setup-guide/references/alignfirst-skills-setup.md
@@ -4,15 +4,9 @@ Configure a consumer repo for the AlignFirst skills: add the `.plans` ignore rul
 
 ## Step 1 — Configure the project
 
-1. Create the `.plans/` directory if it doesn't exist, and ensure `.gitignore` contains this block:
+1. Create the `.plans/` directory if it doesn't exist, and ensure `.gitignore` contains a bare `.plans` line.
 
-   ```text
-   .plans/**
-   !.plans/**/
-   !.plans/**/*.shared.md
-   ```
-
-   These rules ignore the `.plans` directory but keep `*.shared.md` files tracked, so plans handed over with the `.shared.md` suffix get committed. Insert the three lines as a block — the two `!` lines depend on the first. If a bare `.plans` line already exists, replace it; left in place it shadows the un-ignore rules.
+   **Upgrading from the `.shared.md` mechanism:** if `.gitignore` carries the old block (`.plans/**`, `!.plans/**/`, `!.plans/**/*.shared.md`), replace the three lines with the bare `.plans` line, then untrack any committed `*.shared.md` files (`git rm --cached`) and tell the user about them.
 2. Check if `AGENTS.md` or `CLAUDE.md` exists. If one exists, use it. If neither exists, create `AGENTS.md`. This file is the INSTRUCTION_FILE.
 3. Look at git branches (`git branch -a`) to detect the ticket ID format (e.g., `ABC-###`, `PROJ-###`, or numeric).
    - If no pattern is found, ask the user:
@@ -47,3 +41,7 @@ npx skills add https://github.com/paleo/alignfirst --global --skill alignfirst -
 ```
 
 We recommend installing these skills globally. After installation, the user must restart their agent (new session) for the skills to load.
+
+## Step 3 — Team Plans Repository (Optional)
+
+By default, `.plans/` stays local to each machine. A team that wants to share plans hosts a dedicated plans repository: follow [plans-repo-setup.md](plans-repo-setup.md). Skip this step for solo use — the skills behave identically in both modes.

--- a/skills/alignfirst-setup-guide/references/alignfirst-skills-setup.md
+++ b/skills/alignfirst-setup-guide/references/alignfirst-skills-setup.md
@@ -4,9 +4,9 @@ Configure a consumer repo for the AlignFirst skills: add the `.plans` ignore rul
 
 ## Step 1 — Configure the project
 
-1. Create the `.plans/` directory if it doesn't exist, and ensure `.gitignore` contains a bare `.plans` line.
+1. Create the `.plans/` directory if it doesn't exist, and ensure `.gitignore` contains `.plans`.
 
-   **Upgrading from the `.shared.md` mechanism:** if `.gitignore` carries the old block (`.plans/**`, `!.plans/**/`, `!.plans/**/*.shared.md`), replace the three lines with the bare `.plans` line, then untrack any committed `*.shared.md` files (`git rm --cached`) and tell the user about them.
+   **Upgrading from the `.shared.md` mechanism:** if `.gitignore` carries the old block (`.plans/**`, `!.plans/**/`, `!.plans/**/*.shared.md`), replace the three lines with `.plans`, then untrack any committed `*.shared.md` files (`git rm --cached`) and tell the user about them.
 2. Check if `AGENTS.md` or `CLAUDE.md` exists. If one exists, use it. If neither exists, create `AGENTS.md`. This file is the INSTRUCTION_FILE.
 3. Look at git branches (`git branch -a`) to detect the ticket ID format (e.g., `ABC-###`, `PROJ-###`, or numeric).
    - If no pattern is found, ask the user:

--- a/skills/alignfirst-setup-guide/references/alignfirst-upgrade-from-v1.md
+++ b/skills/alignfirst-setup-guide/references/alignfirst-upgrade-from-v1.md
@@ -56,15 +56,7 @@ Search the entire codebase for any references to `_plans` (in source code, confi
 
 Remove all lines referencing `_plans` (e.g., `_plans/*`, `!_plans/.gitkeep`, `_plans`).
 
-Ensure this block is present, replacing any bare `.plans` line:
-
-```text
-.plans/**
-!.plans/**/
-!.plans/**/*.shared.md
-```
-
-These rules ignore the `.plans` directory but keep `*.shared.md` files tracked, so shared plans get committed. Insert the three lines as a block — the two `!` lines depend on the first. A leftover bare `.plans` line shadows the un-ignore rules.
+Ensure a bare `.plans` line is present, replacing the old block (`.plans/**`, `!.plans/**/`, `!.plans/**/*.shared.md`) if found. If any `*.shared.md` files are committed, untrack them (`git rm --cached`) and tell the user about them.
 
 ## Step 5 — Clean AGENTS.md
 

--- a/skills/alignfirst-setup-guide/references/alignfirst-upgrade-from-v1.md
+++ b/skills/alignfirst-setup-guide/references/alignfirst-upgrade-from-v1.md
@@ -56,7 +56,7 @@ Search the entire codebase for any references to `_plans` (in source code, confi
 
 Remove all lines referencing `_plans` (e.g., `_plans/*`, `!_plans/.gitkeep`, `_plans`).
 
-Ensure a bare `.plans` line is present, replacing the old block (`.plans/**`, `!.plans/**/`, `!.plans/**/*.shared.md`) if found. If any `*.shared.md` files are committed, untrack them (`git rm --cached`) and tell the user about them.
+Ensure `.gitignore` contains `.plans`, replacing the old block (`.plans/**`, `!.plans/**/`, `!.plans/**/*.shared.md`) if found. If any `*.shared.md` files are committed, untrack them (`git rm --cached`) and tell the user about them.
 
 ## Step 5 — Clean AGENTS.md
 

--- a/skills/alignfirst-setup-guide/references/alignfirst-upgrade-from-v2.md
+++ b/skills/alignfirst-setup-guide/references/alignfirst-upgrade-from-v2.md
@@ -53,7 +53,7 @@ Search the entire codebase for any references to `_plans` (in source code, confi
 
 Remove all lines referencing `_plans` (e.g., `_plans/*`, `!_plans/.gitkeep`, `_plans`).
 
-Ensure a bare `.plans` line is present, replacing the old block (`.plans/**`, `!.plans/**/`, `!.plans/**/*.shared.md`) if found. If any `*.shared.md` files are committed, untrack them (`git rm --cached`) and tell the user about them.
+Ensure `.gitignore` contains `.plans`, replacing the old block (`.plans/**`, `!.plans/**/`, `!.plans/**/*.shared.md`) if found. If any `*.shared.md` files are committed, untrack them (`git rm --cached`) and tell the user about them.
 
 ## Step 6 — Clean AGENTS.md
 

--- a/skills/alignfirst-setup-guide/references/alignfirst-upgrade-from-v2.md
+++ b/skills/alignfirst-setup-guide/references/alignfirst-upgrade-from-v2.md
@@ -53,15 +53,7 @@ Search the entire codebase for any references to `_plans` (in source code, confi
 
 Remove all lines referencing `_plans` (e.g., `_plans/*`, `!_plans/.gitkeep`, `_plans`).
 
-Ensure this block is present, replacing any bare `.plans` line:
-
-```text
-.plans/**
-!.plans/**/
-!.plans/**/*.shared.md
-```
-
-These rules ignore the `.plans` directory but keep `*.shared.md` files tracked, so shared plans get committed. Insert the three lines as a block — the two `!` lines depend on the first. A leftover bare `.plans` line shadows the un-ignore rules.
+Ensure a bare `.plans` line is present, replacing the old block (`.plans/**`, `!.plans/**/`, `!.plans/**/*.shared.md`) if found. If any `*.shared.md` files are committed, untrack them (`git rm --cached`) and tell the user about them.
 
 ## Step 6 — Clean AGENTS.md
 

--- a/skills/alignfirst-setup-guide/references/plans-repo-setup.md
+++ b/skills/alignfirst-setup-guide/references/plans-repo-setup.md
@@ -36,7 +36,7 @@ Create the plans repository on the team's git host (recommended name: `{team-nam
    "plans:sync": "plans-repo sync"
    ```
 
-3. Ensure `.gitignore` contains a bare `.plans` line (the skills setup already does this).
+3. Ensure `.gitignore` contains `.plans` (the skills setup already does this).
 4. Add this section to the instruction file (`AGENTS.md` or `CLAUDE.md`), adapting the commands to the detected package manager:
 
    > ## Team Plans Repository

--- a/skills/alignfirst-setup-guide/references/plans-repo-setup.md
+++ b/skills/alignfirst-setup-guide/references/plans-repo-setup.md
@@ -1,0 +1,60 @@
+# Team Plans Repository Setup
+
+Share `.plans/` among the developers of a team through a dedicated **plans repository**. This is an optional overlay over the AlignFirst skills setup: solo users skip it, and the skills read and write `.plans` identically in both modes.
+
+## How It Works
+
+The team hosts a plans repository, multi-project — one folder per code repo, ticket directories inside:
+
+```text
+team-plans/
+  project-a/
+    250/
+      A1-spec.md
+    _archives/
+  project-b/
+    103/
+```
+
+On each machine, the repository is cloned once, wherever the user wants (typically next to the other repos). In each project, `.plans` in the main worktree is a symlink to the project's folder inside the clone. Plans never enter the product repository. Linked worktrees created by the workspace system keep pointing at the main worktree's `.plans`; the symlink chain resolves on its own.
+
+Plan history has no value, so the plans repository only receives synchronization commits (`sync`). Syncing is manual, at each user's discretion — a forgotten sync means a teammate sees a stale version, never pollution. The skills never trigger a sync and never detect which mode they run in.
+
+To keep `.plans/` small, finished tickets are moved to `_archives/` inside the project folder — by anyone, at any time (e.g. `mv .plans/250 .plans/_archives/`).
+
+## Setup, Once Per Team
+
+Create the plans repository on the team's git host (recommended name: `{team-name}-plans`). Keep it private; its access rights define who sees the plans. Plans of a project must be visible to all its contributors, so a repo contributed to by several teams must pick a single plans repository.
+
+## Setup, Once Per Project
+
+1. Install the tool: `npm install -D @paleo/plans-repo`.
+2. Add the npm scripts, with the remote URL and the project's folder name baked in:
+
+   ```json
+   "plans:setup": "plans-repo setup --repo git@example.com:team/team-plans.git --folder project-a",
+   "plans:sync": "plans-repo sync"
+   ```
+
+3. Ensure `.gitignore` contains a bare `.plans` line (the skills setup already does this).
+4. Add this section to the instruction file (`AGENTS.md` or `CLAUDE.md`), adapting the commands to the detected package manager:
+
+   > ## Team Plans Repository
+   >
+   > In the main worktree, `.plans` is a symlink into a clone of the team plans repository (see the `plans:setup` script for the URL). Plans are shared with the team through that repository and are never committed in this one.
+   >
+   > To synchronize: `npm run plans:sync`.
+   >
+   > On a new machine: `npm run plans:setup -- <clone-location>`.
+
+## Setup, Once Per Machine
+
+From the main worktree root, pass the clone location — an existing clone or the place to create one:
+
+```sh
+npm run plans:setup -- ../team-plans
+```
+
+The command clones the repository there (or verifies an existing clone's origin), creates the project folder, migrates any existing `.plans` content into it, and replaces `.plans` with the symlink. A moved clone leaves a broken symlink — re-run the command with the new location.
+
+Then publish any migrated content: `npm run plans:sync`.

--- a/skills/alignfirst-setup-guide/references/workspace-setup.md
+++ b/skills/alignfirst-setup-guide/references/workspace-setup.md
@@ -39,7 +39,9 @@ For each gitignored directory, decide: **shared** across worktrees, or **isolate
 | `.plans/`      | Shared (symlinked) | Task planning files           |
 | `.local-wt/`   | Per-worktree       | Databases, caches, logs       |
 
-Setup symlinks the shared directories and creates fresh per-worktree ones. The names are customizable.
+Setup symlinks the shared directories and creates fresh per-worktree ones. A shared directory missing from the main worktree is created there first, so every symlink resolves. The names are customizable.
+
+The main worktree's `.plans` may itself be a symlink — into a clone of a team plans repository (see [plans-repo-setup.md](plans-repo-setup.md)); the symlink chain resolves on its own.
 
 ### Contiguous port scheme
 

--- a/skills/alignfirst/SKILL.md
+++ b/skills/alignfirst/SKILL.md
@@ -4,7 +4,7 @@ description: "Collaborative problem-solving protocols. Write technical specifica
 license: CC0 1.0
 metadata:
   author: Paleo
-  version: "3.6.0"
+  version: "3.7.0"
   repository: https://github.com/paleo/alignfirst
 ---
 
@@ -27,6 +27,8 @@ If you don't already know which protocol to use, read [overview.md](references/o
 
 - Create TASK_DIR if it doesn't exist
 - Or, list all existing files (do not truncate)
+
+**Work without a ticket:** when the user says there is no ticket, use `nt-{N}` as the TICKET_ID: find the highest `nt-{N}` directory in `.plans/` and take N + 1 (`nt-1` if there is none). Reuse an existing `nt-{N}` directory when the user refers to that earlier work. Omit the ticket ID from commit messages.
 
 ## File Naming Convention
 
@@ -51,8 +53,6 @@ Format: `{CYCLE_LETTER}{FILE_NUMBER}-{FILE_TYPE}.md`
 │   └── A3-AAD.summary.md
 │   └── B1-spec.md
 ```
-
-**Shared files:** the `.plans` directory is gitignored, except for files renamed with a `.shared.md` suffix (e.g. `A1-spec.shared.md`). We use this suffix to hand work over to another team member, or to collaborate on it.
 
 ## Notes
 

--- a/skills/alignfirst/references/aad-protocol.md
+++ b/skills/alignfirst/references/aad-protocol.md
@@ -42,16 +42,17 @@ Do not use your question tool. Always ask in plain text. Your questions will be 
 
 ## 3. Act
 
-When you and the user agree, start implementing.
+When you and the user agree, create the summary file in TASK_DIR, then start implementing.
 
-For **complex work** only (risk of context exhaustion):
+Compose the filename using the current CYCLE_LETTER and the bumped FILE_NUMBER, then append `-AAD.summary.md`. For example, if the last file is `E5-plan-something.md`, create `E6-AAD.summary.md`. Do not overwrite an existing file.
 
-- Create your summary file as you go, then update it as a working document.
-- Use subagents (your subagent tool) for distinct, isolated units of work when beneficial.
+Maintain the file as a **live report** while you work: the decisions made with the user, then progress and notable findings as they come. If the session dies, this file is what survives.
+
+Use subagents (your subagent tool) for distinct, isolated units of work when beneficial.
 
 ## 4. Summarize
 
-Write the summary file in TASK_DIR. Compose the filename using the current CYCLE_LETTER and the bumped FILE_NUMBER, then append `-AAD.summary.md`. For example, if the last file is `E5-plan-something.md`, create `E6-AAD.summary.md`. Do not overwrite an existing file.
+Finalize the summary file: replace the working notes with the final content described below.
 
 Start the summary with a header, then a suggested commit message (follow the convention you are aware of, or default to `<type>: [<ticket_id>] very short description`). The shorter the better. Omit any field with nothing to list. Always exclude `alignfirst` from skills.
 

--- a/skills/alignfirst/references/aad-protocol.md
+++ b/skills/alignfirst/references/aad-protocol.md
@@ -46,7 +46,7 @@ When you and the user agree, create the summary file in TASK_DIR, then start imp
 
 Compose the filename using the current CYCLE_LETTER and the bumped FILE_NUMBER, then append `-AAD.summary.md`. For example, if the last file is `E5-plan-something.md`, create `E6-AAD.summary.md`. Do not overwrite an existing file.
 
-Maintain the file as a **live report** while you work: the decisions made with the user, then progress and notable findings as they come. If the session dies, this file is what survives.
+Maintain the file as a **live report** while you work.
 
 Use subagents (your subagent tool) for distinct, isolated units of work when beneficial.
 

--- a/skills/alignfirst/references/description-protocol.md
+++ b/skills/alignfirst/references/description-protocol.md
@@ -12,9 +12,10 @@ Identify and state these values before starting the protocol.
 ## Steps
 
 1. Find the current ticket plan directory.
-2. If a `*description.md` file already exists in the TASK_DIR, find the latest one. Only read `*spec.md` and `*summary.md` files that come *after* it — earlier work is already covered.
+2. Create your description as a new file `{CYCLE_LETTER}1-description.md` with the next cycle letter, containing just the header — this reserves the filename.
+3. If a previous `*description.md` file exists in the TASK_DIR, find the latest one. Only read `*spec.md` and `*summary.md` files that come *after* it — earlier work is already covered.
    Otherwise, read all `*spec.md` and `*summary.md` files.
-3. Write a new file `{CYCLE_LETTER}1-description.md` with the next cycle letter, containing a commit message and a description.
+4. Write the commit message and description into your file.
 
 ## Output Format
 

--- a/skills/alignfirst/references/merge-protocol.md
+++ b/skills/alignfirst/references/merge-protocol.md
@@ -25,6 +25,8 @@ Take the time to understand how things work in the incoming branch and in the cu
 
 ## 3. Resolve
 
+Create the summary file now: a new file `{CYCLE_LETTER}{FILE_NUMBER}-merge.summary.md` in the TASK_DIR. Log each notable resolution in it as you resolve (see step 5 for the expected content).
+
 Resolve the conflicts properly — preserve both intents whenever possible. Do not blindly accept one side.
 
 **Special case for lock files:** If a lock file has conflicts:
@@ -38,7 +40,7 @@ Finalize the merge using git's default commit message (e.g. `git commit --no-edi
 
 ## 5. Summarize
 
-Write your summary in a new file `{CYCLE_LETTER}{FILE_NUMBER}-merge.summary.md` in the TASK_DIR.
+Finalize the summary file.
 
 **Keep it lean.** Only document challenging conflicts and the choices made to resolve them. Do not list straightforward resolutions — if everything was trivial, the summary should be almost empty (just a header and a one-line note that there was nothing tricky). Do not include a commit message — git already provides one for merges.
 

--- a/skills/alignfirst/references/review-protocol.md
+++ b/skills/alignfirst/references/review-protocol.md
@@ -25,7 +25,7 @@ We need:
 
 Be very concise.
 
-Before reviewing, create your report as a new file `{CYCLE_LETTER}1-review.md` in the TASK_DIR, containing just the header — this reserves the filename, so a concurrent protocol session takes the next one. Write the report into it at the end.
+Before reviewing, create your report as a new file `{CYCLE_LETTER}1-review.md` in the TASK_DIR, containing just the header — this reserves the filename. Write the report into it at the end.
 
 ## Output Format
 

--- a/skills/alignfirst/references/review-protocol.md
+++ b/skills/alignfirst/references/review-protocol.md
@@ -25,7 +25,7 @@ We need:
 
 Be very concise.
 
-Create your report as a new file `{CYCLE_LETTER}1-review.md` in the TASK_DIR before reviewing — start with the header and base branch, fill the sections as findings accumulate, and finalize it at the end.
+Before reviewing, create your report as a new file `{CYCLE_LETTER}1-review.md` in the TASK_DIR, containing just the header — this reserves the filename, so a concurrent protocol session takes the next one. Write the report into it at the end.
 
 ## Output Format
 

--- a/skills/alignfirst/references/review-protocol.md
+++ b/skills/alignfirst/references/review-protocol.md
@@ -25,7 +25,7 @@ We need:
 
 Be very concise.
 
-Write your report in a new file `{CYCLE_LETTER}1-review.md` in the TASK_DIR.
+Create your report as a new file `{CYCLE_LETTER}1-review.md` in the TASK_DIR before reviewing — start with the header and base branch, fill the sections as findings accumulate, and finalize it at the end.
 
 ## Output Format
 


### PR DESCRIPTION
- New package `@paleo/plans-repo`: a CLI to share the `.plans` directory through a team plans repository (`setup` clones the repo and symlinks `.plans`; `sync` synchronizes it).
- Setup guide: team plans repository setup reference, bare `.plans` gitignore rule, `.shared.md` mechanism removed.
- Workspace: a missing shared directory in the main worktree is now created instead of skipped.
- alignfirst skill: `nt-{N}` convention for tickets without an ID; AAD, merge, and review protocols now write their report early as a live document.