### PR TITLE
feat: plans-repo setup requires an existing clone

### DIFF
--- a/.changeset/plans-repo-no-autoclone.md
+++ b/.changeset/plans-repo-no-autoclone.md
@@ -1,0 +1,5 @@
+---
+"@paleo/plans-repo": minor
+---
+
+`plans-repo setup` no longer clones the plans repository: point it at an existing clone (clone it yourself, with your own SSH configuration). The `--repo` option is removed — update the `plans:setup` npm script to `plans-repo setup --folder <name>` and document the repository URL in the instruction file.

--- a/.changeset/plans-repo-no-autoclone.md
+++ b/.changeset/plans-repo-no-autoclone.md
@@ -1,5 +1,0 @@
----
-"@paleo/plans-repo": minor
----
-
-`plans-repo setup` no longer clones the plans repository: point it at an existing clone (clone it yourself, with your own SSH configuration). The `--repo` option is removed — update the `plans:setup` npm script to `plans-repo setup --folder <name>` and document the repository URL in the instruction file.

--- a/openclaw-coder/playbook-test/package.json
+++ b/openclaw-coder/playbook-test/package.json
@@ -23,7 +23,7 @@
     "openclaw": "2026.7.1"
   },
   "devDependencies": {
-    "@types/node": "^24.12.4",
-    "typescript": "^6.0.3"
+    "@types/node": "~24.12.4",
+    "typescript": "~6.0.3"
   }
 }

--- a/openclaw-coder/playbook-test/projects-fixture/template/package.json
+++ b/openclaw-coder/playbook-test/projects-fixture/template/package.json
@@ -17,7 +17,7 @@
     "express": "5.2.1"
   },
   "devDependencies": {
-    "@paleo/docmap": "^0.7.2",
-    "@paleo/workspace": "^0.27.0"
+    "@paleo/docmap": "~0.7.2",
+    "@paleo/workspace": "~0.27.0"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6137,7 +6137,7 @@
     },
     "packages/plans-repo": {
       "name": "@paleo/plans-repo",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "CC0-1.0",
       "bin": {
         "plans-repo": "bin/plans-repo.mjs"

--- a/packages/plans-repo/CHANGELOG.md
+++ b/packages/plans-repo/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @paleo/plans-repo
 
+## 0.2.0
+
+### Minor Changes
+
+- 6d62bcf: `plans-repo setup` no longer clones the plans repository: point it at an existing clone (clone it yourself, with your own SSH configuration). The `--repo` option is removed — update the `plans:setup` npm script to `plans-repo setup --folder <name>` and document the repository URL in the instruction file.
+
 ## 0.1.0
 
 ### Minor Changes

--- a/packages/plans-repo/README.md
+++ b/packages/plans-repo/README.md
@@ -7,7 +7,7 @@ Share the `.plans` directory of the [AlignFirst skills](https://github.com/paleo
 A team hosts a plans repository, multi-project — one folder per code repo, ticket directories inside:
 
 ```text
-team-plans/
+myteam-plans/
   project-a/
     250/
       A1-spec.md
@@ -26,24 +26,26 @@ Plan history has no value, so the plans repository only receives synchronization
 npm install -D @paleo/plans-repo
 ```
 
-Add the npm scripts, with the remote URL and project folder baked in:
+Add the npm scripts, with the project folder baked in:
 
 ```json
 {
-  "plans:setup": "plans-repo setup --repo git@example.com:team/team-plans.git --folder project-a",
+  "plans:setup": "plans-repo setup --folder project-a",
   "plans:sync": "plans-repo sync"
 }
 ```
 
+Document the plans repository URL where developers will find it (e.g. `AGENTS.md`), since cloning is theirs to do — with their own SSH configuration.
+
 ## Commands
 
-Once per machine, from the main worktree root, passing the clone location:
+Once per machine: clone the plans repository anywhere (typically next to the other repos), then, from the main worktree root, pass the clone location:
 
 ```sh
-npm run plans:setup -- ../team-plans
+npm run plans:setup -- ../myteam-plans
 ```
 
-`setup` clones the repository there (or verifies an existing clone's origin), migrates any existing `.plans` content into it, and creates the symlink. Re-run it with the new location if the clone moves.
+`setup` migrates any existing `.plans` content into the clone and creates the symlink. Re-run it with the new location if the clone moves.
 
 To synchronize, from any worktree:
 

--- a/packages/plans-repo/package.json
+++ b/packages/plans-repo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paleo/plans-repo",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "CC0-1.0",
   "author": "Thomas MUR",
   "description": "Share AlignFirst plans through a team plans repository.",

--- a/packages/plans-repo/src/cli.ts
+++ b/packages/plans-repo/src/cli.ts
@@ -6,12 +6,12 @@ import { runSync } from "./sync.js";
 const HELP = `plans-repo — share the .plans directory through a team plans repository.
 
 Usage:
-  plans-repo setup <dir> --repo <url> --folder <name>
+  plans-repo setup <dir> --folder <name>
   plans-repo sync
   plans-repo --help | --version
 
-setup   Clone the plans repository at <dir> (or reuse an existing clone), then link .plans
-        to <dir>/<name>/, migrating any existing .plans content. Once per machine; re-run
+setup   Link .plans to <dir>/<name>/, where <dir> is an existing clone of the plans
+        repository, migrating any existing .plans content. Once per machine; re-run
         with the new location if the clone moves.
 sync    Pull, commit, and push the plans repository.
 `;

--- a/packages/plans-repo/src/setup.ts
+++ b/packages/plans-repo/src/setup.ts
@@ -16,7 +16,7 @@ export function runSetup(ctx: CliContext, args: string[]): void {
   const options = parseSetupArgs(args);
   checkMainWorktreeRoot(ctx);
   const cloneDir = resolve(ctx.cwd, options.dir);
-  checkClone(cloneDir);
+  checkClone(ctx, cloneDir);
   const projectDir = join(cloneDir, options.folder);
   mkdirSync(projectDir, { recursive: true });
   linkPlans(ctx, projectDir);
@@ -54,7 +54,7 @@ function checkMainWorktreeRoot(ctx: CliContext): void {
     );
 }
 
-function checkClone(cloneDir: string): void {
+function checkClone(ctx: CliContext, cloneDir: string): void {
   if (!existsSync(cloneDir))
     throw new CliError(
       `${cloneDir} does not exist. Clone the team plans repository there first (see the instruction file).`,
@@ -62,6 +62,10 @@ function checkClone(cloneDir: string): void {
   if (!existsSync(join(cloneDir, ".git")))
     throw new CliError(
       `${cloneDir} is not a git repository. Point plans:setup at a clone of the team plans repository.`,
+    );
+  if (realpathSync(cloneDir) === realpathSync(ctx.cwd))
+    throw new CliError(
+      `${cloneDir} is the product repository itself. Point plans:setup at a clone of the team plans repository.`,
     );
 }
 

--- a/packages/plans-repo/src/setup.ts
+++ b/packages/plans-repo/src/setup.ts
@@ -10,13 +10,13 @@ import {
 } from "node:fs";
 import { join, relative, resolve } from "node:path";
 import { CliError, type CliContext } from "./context.js";
-import { git, gitOutput } from "./git.js";
+import { gitOutput } from "./git.js";
 
 export function runSetup(ctx: CliContext, args: string[]): void {
   const options = parseSetupArgs(args);
   checkMainWorktreeRoot(ctx);
   const cloneDir = resolve(ctx.cwd, options.dir);
-  ensureClone(ctx, cloneDir, options.repoUrl);
+  checkClone(cloneDir);
   const projectDir = join(cloneDir, options.folder);
   mkdirSync(projectDir, { recursive: true });
   linkPlans(ctx, projectDir);
@@ -24,25 +24,22 @@ export function runSetup(ctx: CliContext, args: string[]): void {
 
 interface SetupOptions {
   dir: string;
-  repoUrl: string;
   folder: string;
 }
 
 function parseSetupArgs(args: string[]): SetupOptions {
   let dir: string | undefined;
-  let repoUrl: string | undefined;
   let folder: string | undefined;
   for (let i = 0; i < args.length; ++i) {
     const arg = args[i];
-    if (arg === "--repo") repoUrl = args[++i];
-    else if (arg === "--folder") folder = args[++i];
+    if (arg === "--folder") folder = args[++i];
     else if (arg.startsWith("-")) throw new CliError(`Unknown option: ${arg}`);
     else if (dir === undefined) dir = arg;
     else throw new CliError(`Unexpected argument: ${arg}`);
   }
-  if (dir === undefined || repoUrl === undefined || folder === undefined)
-    throw new CliError("Usage: plans-repo setup <dir> --repo <url> --folder <name>");
-  return { dir, repoUrl, folder };
+  if (dir === undefined || folder === undefined)
+    throw new CliError("Usage: plans-repo setup <dir> --folder <name>");
+  return { dir, folder };
 }
 
 function checkMainWorktreeRoot(ctx: CliContext): void {
@@ -57,25 +54,15 @@ function checkMainWorktreeRoot(ctx: CliContext): void {
     );
 }
 
-function ensureClone(ctx: CliContext, cloneDir: string, repoUrl: string): void {
-  if (existsSync(join(cloneDir, ".git"))) {
-    const origin = gitOutput(cloneDir, "remote", "get-url", "origin");
-    if (normalizeGitUrl(origin) !== normalizeGitUrl(repoUrl))
-      throw new CliError(`${cloneDir} is a clone of ${origin}, expected ${repoUrl}.`);
-    ctx.stdout.write(`Using the existing clone at ${cloneDir}.\n`);
-    return;
-  }
-  if (existsSync(cloneDir) && readdirSync(cloneDir).length > 0)
-    throw new CliError(`${cloneDir} exists and is not a git clone.`);
-  git(ctx.cwd, "clone", "--quiet", repoUrl, cloneDir);
-  ctx.stdout.write(`Cloned ${repoUrl} into ${cloneDir}.\n`);
-}
-
-function normalizeGitUrl(url: string): string {
-  return url
-    .trim()
-    .replace(/\/+$/, "")
-    .replace(/\.git$/, "");
+function checkClone(cloneDir: string): void {
+  if (!existsSync(cloneDir))
+    throw new CliError(
+      `${cloneDir} does not exist. Clone the team plans repository there first (see the instruction file).`,
+    );
+  if (!existsSync(join(cloneDir, ".git")))
+    throw new CliError(
+      `${cloneDir} is not a git repository. Point plans:setup at a clone of the team plans repository.`,
+    );
 }
 
 function linkPlans(ctx: CliContext, projectDir: string): void {

--- a/packages/plans-repo/test/plans-repo.test.ts
+++ b/packages/plans-repo/test/plans-repo.test.ts
@@ -48,6 +48,7 @@ function makeFixture(): Fixture {
   fixtureDir = mkdtempSync(join(tmpdir(), "plans-repo-"));
   const remoteUrl = join(fixtureDir, "remote.git");
   execGit(fixtureDir, "init", "--quiet", "--bare", remoteUrl);
+  execGit(fixtureDir, "clone", "--quiet", remoteUrl, join(fixtureDir, "team-plans"));
   const product = join(fixtureDir, "product");
   execGit(fixtureDir, "init", "--quiet", product);
   writeFileSync(join(product, "README.md"), "product\n");
@@ -79,11 +80,11 @@ function run(cwd: string, ...args: string[]): RunResult {
 }
 
 function runSetup(fixture: Fixture, dir = join(fixture.root, "team-plans")): RunResult {
-  return run(fixture.product, "setup", dir, "--repo", fixture.remoteUrl, "--folder", "myproj");
+  return run(fixture.product, "setup", dir, "--folder", "myproj");
 }
 
 describe("plans-repo setup", () => {
-  it("clones the plans repository and links .plans", () => {
+  it("links .plans to an existing clone", () => {
     const fixture = makeFixture();
     const result = runSetup(fixture);
     expect(result.stderr).toBe("");
@@ -107,7 +108,6 @@ describe("plans-repo setup", () => {
   it("reports all migration collisions without copying anything", () => {
     const fixture = makeFixture();
     const cloneDir = join(fixture.root, "team-plans");
-    execGit(fixture.root, "clone", "--quiet", fixture.remoteUrl, cloneDir);
     mkdirSync(join(cloneDir, "myproj", "123"), { recursive: true });
     mkdirSync(join(cloneDir, "myproj", "456"), { recursive: true });
     mkdirSync(join(fixture.product, ".plans", "123"), { recursive: true });
@@ -128,15 +128,20 @@ describe("plans-repo setup", () => {
     expect(result.stdout).toContain("already links");
   });
 
-  it("rejects a clone with a different origin", () => {
+  it("fails when the directory does not exist", () => {
     const fixture = makeFixture();
-    const otherRemote = join(fixture.root, "other.git");
-    execGit(fixture.root, "init", "--quiet", "--bare", otherRemote);
-    const dir = join(fixture.root, "team-plans");
-    execGit(fixture.root, "clone", "--quiet", otherRemote, dir);
-    const result = runSetup(fixture, dir);
+    const result = runSetup(fixture, join(fixture.root, "nowhere"));
     expect(result.code).toBe(1);
-    expect(result.stderr).toContain("is a clone of");
+    expect(result.stderr).toContain("does not exist");
+  });
+
+  it("fails when the directory is not a git repository", () => {
+    const fixture = makeFixture();
+    const plainDir = join(fixture.root, "plain");
+    mkdirSync(plainDir);
+    const result = runSetup(fixture, plainDir);
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain("not a git repository");
   });
 
   it("re-links after the clone moved", () => {
@@ -153,15 +158,7 @@ describe("plans-repo setup", () => {
     const fixture = makeFixture();
     const worktree = join(fixture.root, "product-feat");
     execGit(fixture.product, "worktree", "add", "--quiet", worktree, "-b", "feat");
-    const result = run(
-      worktree,
-      "setup",
-      join(fixture.root, "team-plans"),
-      "--repo",
-      fixture.remoteUrl,
-      "--folder",
-      "myproj",
-    );
+    const result = run(worktree, "setup", join(fixture.root, "team-plans"), "--folder", "myproj");
     expect(result.code).toBe(1);
     expect(result.stderr).toContain("main worktree");
   });

--- a/packages/plans-repo/test/plans-repo.test.ts
+++ b/packages/plans-repo/test/plans-repo.test.ts
@@ -144,6 +144,13 @@ describe("plans-repo setup", () => {
     expect(result.stderr).toContain("not a git repository");
   });
 
+  it("fails when the directory is the product repository itself", () => {
+    const fixture = makeFixture();
+    const result = runSetup(fixture, fixture.product);
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain("product repository itself");
+  });
+
   it("re-links after the clone moved", () => {
     const fixture = makeFixture();
     runSetup(fixture);

--- a/skills/alignfirst-setup-guide/SKILL.md
+++ b/skills/alignfirst-setup-guide/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Requires git and a Node.js package manager (npm, pnpm, yarn, or b
 license: CC0 1.0
 metadata:
   author: Paleo
-  version: "0.21.0"
+  version: "0.22.0"
   repository: https://github.com/paleo/alignfirst
 ---
 

--- a/skills/alignfirst-setup-guide/references/plans-repo-setup.md
+++ b/skills/alignfirst-setup-guide/references/plans-repo-setup.md
@@ -7,7 +7,7 @@ Share `.plans/` among the developers of a team through a dedicated **plans repos
 The team hosts a plans repository, multi-project — one folder per code repo, ticket directories inside:
 
 ```text
-team-plans/
+myteam-plans/
   project-a/
     250/
       A1-spec.md
@@ -29,32 +29,32 @@ Create the plans repository on the team's git host (recommended name: `{team-nam
 ## Setup, Once Per Project
 
 1. Install the tool: `npm install -D @paleo/plans-repo`.
-2. Add the npm scripts, with the remote URL and the project's folder name baked in:
+2. Add the npm scripts, with the project's folder name baked in:
 
    ```json
-   "plans:setup": "plans-repo setup --repo git@example.com:team/team-plans.git --folder project-a",
+   "plans:setup": "plans-repo setup --folder project-a",
    "plans:sync": "plans-repo sync"
    ```
 
 3. Ensure `.gitignore` contains `.plans` (the skills setup already does this).
-4. Add this section to the instruction file (`AGENTS.md` or `CLAUDE.md`), adapting the commands to the detected package manager:
+4. Add this section to the instruction file (`AGENTS.md` or `CLAUDE.md`), adapting the URL, folder, and commands to the project and the detected package manager:
 
    > ## Team Plans Repository
    >
-   > In the main worktree, `.plans` is a symlink into a clone of the team plans repository (see the `plans:setup` script for the URL). Plans are shared with the team through that repository and are never committed in this one.
+   > In the main worktree, `.plans` is a symlink into a clone of the team plans repository: `git@example.com:myteam/myteam-plans.git` (folder `project-a/`). Plans are shared with the team through that repository and are never committed in this one.
    >
    > To synchronize: `npm run plans:sync`.
    >
-   > On a new machine: `npm run plans:setup -- <clone-location>`.
+   > On a new machine: clone the plans repository anywhere (typically next to the worktrees), then run `npm run plans:setup -- <clone-location>`.
 
 ## Setup, Once Per Machine
 
-From the main worktree root, pass the clone location — an existing clone or the place to create one:
+Clone the plans repository anywhere (typically next to the worktrees) — cloning is the user's move, with their own SSH configuration. Then, from the main worktree root, pass the clone location:
 
 ```sh
-npm run plans:setup -- ../team-plans
+npm run plans:setup -- ../myteam-plans
 ```
 
-The command clones the repository there (or verifies an existing clone's origin), creates the project folder, migrates any existing `.plans` content into it, and replaces `.plans` with the symlink. A moved clone leaves a broken symlink — re-run the command with the new location.
+The command creates the project folder inside the clone, migrates any existing `.plans` content into it, and replaces `.plans` with the symlink. A moved clone leaves a broken symlink — re-run the command with the new location.
 
 Then publish any migrated content: `npm run plans:sync`.


### PR DESCRIPTION

`plans-repo setup` no longer clones the team plans repository: the target directory must be an existing clone (breaking: the `--repo` option is removed), and the remote URL with a clone hint moves to the instruction-file prose.
