### PR TITLE
feat: plans-repo check command

### DIFF
--- a/.changeset/plans-repo-check.md
+++ b/.changeset/plans-repo-check.md
@@ -1,0 +1,5 @@
+---
+"@paleo/plans-repo": minor
+---
+
+New `plans-repo check` command: verifies that `.plans` is linked to a team plans repository, and exits 1 with guidance otherwise. For automation — e.g. the workspace `preSetup` callback — so a missing link fails the environment bootstrap instead of being discovered later.

--- a/.changeset/plans-repo-check.md
+++ b/.changeset/plans-repo-check.md
@@ -2,4 +2,4 @@
 "@paleo/plans-repo": minor
 ---
 
-New `plans-repo check` command: verifies that `.plans` is linked to a team plans repository, and exits 1 with guidance otherwise. For automation — e.g. the workspace `preSetup` callback — so a missing link fails the environment bootstrap instead of being discovered later.
+New `plans-repo check` command: verifies that `.plans` is linked to a team plans repository, and exits 1 with guidance otherwise.

--- a/.changeset/plans-repo-check.md
+++ b/.changeset/plans-repo-check.md
@@ -1,5 +1,0 @@
----
-"@paleo/plans-repo": minor
----
-
-New `plans-repo check` command: verifies that `.plans` is linked to a team plans repository, and exits 1 with guidance otherwise.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6137,7 +6137,7 @@
     },
     "packages/plans-repo": {
       "name": "@paleo/plans-repo",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "CC0-1.0",
       "bin": {
         "plans-repo": "bin/plans-repo.mjs"

--- a/packages/plans-repo/CHANGELOG.md
+++ b/packages/plans-repo/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @paleo/plans-repo
 
+## 0.3.0
+
+### Minor Changes
+
+- 21d52a7: New `plans-repo check` command: verifies that `.plans` is linked to a team plans repository, and exits 1 with guidance otherwise.
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/plans-repo/README.md
+++ b/packages/plans-repo/README.md
@@ -53,14 +53,10 @@ To synchronize, from any worktree:
 npm run plans:sync
 ```
 
-## Enforcing the link in automation
+To verify that `.plans` is linked to a team plans repository:
 
-`plans-repo check` verifies that `.plans` is linked to a team plans repository and exits 1 with guidance otherwise. Call it from a bootstrap hook — e.g. the `preSetup` callback of [`@paleo/workspace`](https://www.npmjs.com/package/@paleo/workspace) — to make the link a prerequisite of the local environment, without hardcoding any clone location:
-
-```js
-if (isMainWorktree) {
-  execFileSync("npx", ["plans-repo", "check"], { cwd: currentWorktree, stdio: "inherit" });
-}
+```sh
+npm run plans-repo -- check
 ```
 
 ## Archiving

--- a/packages/plans-repo/README.md
+++ b/packages/plans-repo/README.md
@@ -53,6 +53,16 @@ To synchronize, from any worktree:
 npm run plans:sync
 ```
 
+## Enforcing the link in automation
+
+`plans-repo check` verifies that `.plans` is linked to a team plans repository and exits 1 with guidance otherwise. Call it from a bootstrap hook — e.g. the `preSetup` callback of [`@paleo/workspace`](https://www.npmjs.com/package/@paleo/workspace) — to make the link a prerequisite of the local environment, without hardcoding any clone location:
+
+```js
+if (isMainWorktree) {
+  execFileSync("npx", ["plans-repo", "check"], { cwd: currentWorktree, stdio: "inherit" });
+}
+```
+
 ## Archiving
 
 To keep `.plans` small, move finished tickets to `_archives/` inside the project folder — anyone, anytime:

--- a/packages/plans-repo/package.json
+++ b/packages/plans-repo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paleo/plans-repo",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "CC0-1.0",
   "author": "Thomas MUR",
   "description": "Share AlignFirst plans through a team plans repository.",

--- a/packages/plans-repo/src/check.ts
+++ b/packages/plans-repo/src/check.ts
@@ -1,0 +1,24 @@
+import { existsSync, lstatSync } from "node:fs";
+import { join } from "node:path";
+import { CliError, type CliContext } from "./context.js";
+import { gitOutput } from "./git.js";
+
+export function runCheck(ctx: CliContext): void {
+  const plansPath = join(ctx.cwd, ".plans");
+  const stats = lstatSync(plansPath, { throwIfNoEntry: false });
+  if (!stats)
+    throw new CliError(
+      ".plans is missing. Clone the team plans repository, then run the plans:setup script (see the project documentation).",
+    );
+  if (stats.isSymbolicLink() && !existsSync(plansPath))
+    throw new CliError(
+      "The .plans symlink is broken. Re-run the plans:setup script with the clone location.",
+    );
+  const plansToplevel = gitOutput(plansPath, "rev-parse", "--show-toplevel");
+  const repoToplevel = gitOutput(ctx.cwd, "rev-parse", "--show-toplevel");
+  if (plansToplevel === repoToplevel)
+    throw new CliError(
+      ".plans is not linked to the team plans repository. Run the plans:setup script first (see the project documentation).",
+    );
+  ctx.stdout.write(".plans is linked to the team plans repository.\n");
+}

--- a/packages/plans-repo/src/check.ts
+++ b/packages/plans-repo/src/check.ts
@@ -2,6 +2,7 @@ import { existsSync, lstatSync } from "node:fs";
 import { join } from "node:path";
 import { CliError, type CliContext } from "./context.js";
 import { gitOutput } from "./git.js";
+import { checkPlansIsDirectory, plansRepoToplevel } from "./plans-path.js";
 
 export function runCheck(ctx: CliContext): void {
   const plansPath = join(ctx.cwd, ".plans");
@@ -14,7 +15,8 @@ export function runCheck(ctx: CliContext): void {
     throw new CliError(
       "The .plans symlink is broken. Re-run the plans:setup script with the clone location.",
     );
-  const plansToplevel = gitOutput(plansPath, "rev-parse", "--show-toplevel");
+  checkPlansIsDirectory(plansPath);
+  const plansToplevel = plansRepoToplevel(plansPath);
   const repoToplevel = gitOutput(ctx.cwd, "rev-parse", "--show-toplevel");
   if (plansToplevel === repoToplevel)
     throw new CliError(

--- a/packages/plans-repo/src/cli.ts
+++ b/packages/plans-repo/src/cli.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from "node:fs";
+import { runCheck } from "./check.js";
 import { CliError, type CliContext } from "./context.js";
 import { runSetup } from "./setup.js";
 import { runSync } from "./sync.js";
@@ -8,12 +9,15 @@ const HELP = `plans-repo — share the .plans directory through a team plans rep
 Usage:
   plans-repo setup <dir> --folder <name>
   plans-repo sync
+  plans-repo check
   plans-repo --help | --version
 
 setup   Link .plans to <dir>/<name>/, where <dir> is an existing clone of the plans
         repository, migrating any existing .plans content. Once per machine; re-run
         with the new location if the clone moves.
 sync    Pull, commit, and push the plans repository.
+check   Verify that .plans is linked to a team plans repository; exit 1 otherwise.
+        For automation, e.g. a workspace preSetup callback.
 `;
 
 export interface MainOptions {
@@ -40,6 +44,9 @@ export function main(options?: MainOptions): number {
         return 0;
       case "sync":
         runSync(ctx);
+        return 0;
+      case "check":
+        runCheck(ctx);
         return 0;
       case "--version":
         ctx.stdout.write(`${readPackageVersion()}\n`);

--- a/packages/plans-repo/src/plans-path.ts
+++ b/packages/plans-repo/src/plans-path.ts
@@ -1,0 +1,20 @@
+import { statSync } from "node:fs";
+import { CliError } from "./context.js";
+import { gitOutput } from "./git.js";
+
+export function checkPlansIsDirectory(plansPath: string): void {
+  if (!statSync(plansPath).isDirectory())
+    throw new CliError(
+      ".plans is not a directory. Remove it, then run the plans:setup script (see the project documentation).",
+    );
+}
+
+export function plansRepoToplevel(plansPath: string): string {
+  try {
+    return gitOutput(plansPath, "rev-parse", "--show-toplevel");
+  } catch {
+    throw new CliError(
+      ".plans points outside any git repository. Re-run the plans:setup script with the clone location.",
+    );
+  }
+}

--- a/packages/plans-repo/src/sync.ts
+++ b/packages/plans-repo/src/sync.ts
@@ -2,6 +2,7 @@ import { existsSync, lstatSync } from "node:fs";
 import { join } from "node:path";
 import { CliError, type CliContext } from "./context.js";
 import { git, gitOutput, gitSucceeds } from "./git.js";
+import { checkPlansIsDirectory, plansRepoToplevel } from "./plans-path.js";
 
 export function runSync(ctx: CliContext): void {
   const plansDir = resolvePlansDir(ctx);
@@ -27,7 +28,8 @@ function resolvePlansDir(ctx: CliContext): string {
       );
     throw new CliError("No .plans directory here. Run this command from a worktree root.");
   }
-  const plansToplevel = gitOutput(plansPath, "rev-parse", "--show-toplevel");
+  checkPlansIsDirectory(plansPath);
+  const plansToplevel = plansRepoToplevel(plansPath);
   const repoToplevel = gitOutput(ctx.cwd, "rev-parse", "--show-toplevel");
   if (plansToplevel === repoToplevel)
     throw new CliError(

--- a/packages/plans-repo/test/plans-repo.test.ts
+++ b/packages/plans-repo/test/plans-repo.test.ts
@@ -7,6 +7,7 @@ import {
   readlinkSync,
   renameSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -204,6 +205,23 @@ describe("plans-repo check", () => {
     expect(result.code).toBe(1);
     expect(result.stderr).toContain("broken");
   });
+
+  it("fails when .plans is a regular file", () => {
+    const fixture = makeFixture();
+    writeFileSync(join(fixture.product, ".plans"), "oops\n");
+    const result = run(fixture.product, "check");
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain("not a directory");
+  });
+
+  it("fails when .plans links to a directory outside any git repository", () => {
+    const fixture = makeFixture();
+    mkdirSync(join(fixture.root, "plain"));
+    symlinkSync(join("..", "plain"), join(fixture.product, ".plans"));
+    const result = run(fixture.product, "check");
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain("outside any git repository");
+  });
 });
 
 describe("plans-repo sync", () => {
@@ -235,5 +253,13 @@ describe("plans-repo sync", () => {
     const result = run(fixture.product, "sync");
     expect(result.code).toBe(1);
     expect(result.stderr).toContain("not linked");
+  });
+
+  it("fails when .plans is a regular file", () => {
+    const fixture = makeFixture();
+    writeFileSync(join(fixture.product, ".plans"), "oops\n");
+    const result = run(fixture.product, "sync");
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain("not a directory");
   });
 });

--- a/packages/plans-repo/test/plans-repo.test.ts
+++ b/packages/plans-repo/test/plans-repo.test.ts
@@ -171,6 +171,41 @@ describe("plans-repo setup", () => {
   });
 });
 
+describe("plans-repo check", () => {
+  it("succeeds when .plans is linked to a plans repository", () => {
+    const fixture = makeFixture();
+    runSetup(fixture);
+    const result = run(fixture.product, "check");
+    expect(result.stderr).toBe("");
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain("linked to the team plans repository");
+  });
+
+  it("fails when .plans is missing", () => {
+    const fixture = makeFixture();
+    const result = run(fixture.product, "check");
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain("Clone the team plans repository");
+  });
+
+  it("fails when .plans is a plain directory", () => {
+    const fixture = makeFixture();
+    mkdirSync(join(fixture.product, ".plans"));
+    const result = run(fixture.product, "check");
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain("not linked");
+  });
+
+  it("fails when the .plans symlink is broken", () => {
+    const fixture = makeFixture();
+    runSetup(fixture);
+    renameSync(join(fixture.root, "team-plans"), join(fixture.root, "moved-plans"));
+    const result = run(fixture.product, "check");
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain("broken");
+  });
+});
+
 describe("plans-repo sync", () => {
   it("publishes plan files to the remote", () => {
     const fixture = makeFixture();

--- a/skills/alignfirst-setup-guide/references/plans-repo-setup.md
+++ b/skills/alignfirst-setup-guide/references/plans-repo-setup.md
@@ -58,3 +58,19 @@ npm run plans:setup -- ../myteam-plans
 The command creates the project folder inside the clone, migrates any existing `.plans` content into it, and replaces `.plans` with the symlink. A moved clone leaves a broken symlink — re-run the command with the new location.
 
 Then publish any migrated content: `npm run plans:sync`.
+
+## With the Workspace System (Recommended)
+
+When the project also uses the workspace system, make the link a prerequisite of the local environment:
+
+1. In the `preSetup` callback of `workspace.mjs`, add the check — the clone location stays the user's choice, nothing is hardcoded:
+
+   ```js
+   if (isMainWorktree) {
+     execFileSync("npx", ["plans-repo", "check"], { cwd: currentWorktree, stdio: "inherit" });
+   }
+   ```
+
+   A missing or broken link then fails `workspace setup`, with the check's guidance on stderr.
+
+2. Document the new-machine steps — clone the plans repository, then `npm run plans:setup -- <clone-location>` — in the project's installation documentation (e.g. `README.md`, `DEVELOPMENT.md`), before the workspace bootstrap command. Then drop the "On a new machine" line from the instruction-file section: machine setup is covered where machines get installed.


### PR DESCRIPTION
- New `plans-repo check` command: succeeds when `.plans` is a healthy symlink into another git repository, fails with guidance otherwise; documented for use in workspace `preSetup` automation.
- `plans-repo setup` rejects the product repository itself as the plans clone.
