### PR TITLE
fix: harden the release verify job

### DIFF
--- a/.changeset/verify-pipeline.md
+++ b/.changeset/verify-pipeline.md
@@ -1,0 +1,5 @@
+---
+"@paleo/openclaw-test": patch
+---
+
+No functional change. Released to exercise the publishing pipeline.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,7 +81,7 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
-      - name: Install published packages and verify signatures
+      - name: Verify signatures and provenance
         shell: bash
         env:
           PUBLISHED: ${{ needs.publish.outputs.published-packages }}
@@ -90,11 +90,17 @@ jobs:
           echo "Verifying: $pkgs"
           cd "$(mktemp -d)"
           npm init -y > /dev/null
+          # --omit=peer: auto-installed peers drag unrelated trees into the audit
           for i in 1 2 3 4 5; do
-            if npm install $pkgs; then break; fi
+            if npm install --omit=peer $pkgs; then break; fi
             if [ "$i" = 5 ]; then echo "Install failed after 5 attempts"; exit 1; fi
             echo "Registry not ready, retrying in 30s"
             sleep 30
           done
-          npm audit signatures | tee audit.txt
-          grep -q "verified attestations" audit.txt
+          npm audit signatures
+          # npm audit signatures reports invalid signatures, never absent ones
+          for spec in $pkgs; do
+            predicate=$(npm view "$spec" dist.attestations.provenance.predicateType)
+            echo "$spec -> ${predicate:-MISSING}"
+            [ -n "$predicate" ] || { echo "No provenance attestation for $spec"; exit 1; }
+          done

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -17,7 +17,7 @@ Packages publish from GitHub Actions through npm trusted publishing (OIDC). Ther
 2. `.github/workflows/release.yml` runs on the push. Its `version` job creates or updates the **release: version packages** PR, which applies the pending changesets to the manifests and changelogs.
 3. Merging that PR pushes the bumped versions to `main`. The `check` job now finds versions absent from the registry and enables the `publish` job.
 4. `publish` is bound to the `release` environment, so it waits for one approval. After approval it builds, tests, strips the `scripts` field from the workspace manifests, and runs `changeset publish`. npm attaches a provenance attestation to each tarball. The action then pushes git tags and creates the GitHub releases.
-5. `verify` installs the freshly published versions in an empty directory and asserts that `npm audit signatures` reports verified attestations.
+5. `verify` installs the freshly published versions in an empty directory, runs `npm audit signatures`, then asserts that each version carries a provenance attestation.
 
 A push that publishes nothing — a feature merge, a docs-only merge — leaves `check` reporting no pending version, so no approval is ever requested.
 
@@ -30,6 +30,14 @@ npm audit signatures
 ```
 
 Each package must report a verified registry signature and a verified attestation. The attestation links the tarball to the `main` commit and the workflow run that built it.
+
+The command reports *invalid* signatures; it exits 0 when a package has no attestation at all. To check that one exists, read it directly:
+
+```bash
+npm view <package>@<version> dist.attestations.provenance.predicateType
+```
+
+npm attaches provenance only when the repository and the package are both public and no `provenance` config overrides the default. A failure of any of those conditions is logged at verbose level and leaves the publish green, which is what the `verify` job guards against.
 
 ## Trusted-publisher bindings
 


### PR DESCRIPTION
The first release published all 8 packages with provenance, but the `verify` job failed. Two independent defects, both fixed.

- The install pulled `openclaw` in as an auto-installed peer dependency, putting 325 unrelated packages in the audit scope and failing on an aliased dependency inside that tree. It now installs with `--omit=peer`.
- The attestation assertion could pass without any of the published packages carrying an attestation. It now asserts provenance per published package.

`docs/releasing.md` documents both commands and the conditions under which npm skips provenance without failing.

Includes a patch changeset on `@paleo/openclaw-test`, with no functional change, so that merging this exercises the corrected job on a real release. That package is a leaf, so the release covers it alone, and its `openclaw` peer dependency is what triggered the failure.
