### PR TITLE
fix: keep the placeholder version out of the release flow

### DIFF
--- a/packages/alproject/test/cli.test.ts
+++ b/packages/alproject/test/cli.test.ts
@@ -94,7 +94,7 @@ describe("main", () => {
     for (const option of ["-v", "--version"]) {
       const stdout = makeSink();
       expect(await run([option], { stdout })).toBe(0);
-      expect(stdout.text()).toBe("0.0.0\n");
+      expect(stdout.text()).toBe(`${packageVersion()}\n`);
     }
   });
 
@@ -340,4 +340,11 @@ function run(
   },
 ) {
   return main({ argv: ["node", "alproject", ...args], ...options });
+}
+
+function packageVersion(): string {
+  const packageFile = JSON.parse(
+    readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+  ) as { version: string };
+  return packageFile.version;
 }

--- a/scripts/release-pending.mjs
+++ b/scripts/release-pending.mjs
@@ -4,12 +4,16 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const packagesDir = join(dirname(dirname(fileURLToPath(import.meta.url))), "packages");
+// A package awaiting its first release sits at this placeholder until Changesets bumps it.
+// The registry has no such version, so without this guard it reads as a pending release.
+const UNRELEASED_VERSION = "0.0.0";
 
 console.log(JSON.stringify(findPendingReleases()));
 
 function findPendingReleases() {
   const pending = [];
   for (const { name, version } of readPublicManifests()) {
+    if (version === UNRELEASED_VERSION) continue;
     if (!publishedVersions(name).includes(version)) pending.push(`${name}@${version}`);
   }
   return pending;


### PR DESCRIPTION
## Description

`@paleo/alproject` sits at the `0.0.0` placeholder until its first release. Two places treated that placeholder as a real version, and both surfaced once Changesets opened the Version Packages PR (#57).

- Assert the `--version` output against `package.json` instead of a hardcoded `0.0.0`. The literal broke the moment Changesets bumped the manifest to `0.1.0`, failing `test (22)` and `test (24)` on #57. Since `ci:publish` runs `npm run test` before `changeset publish`, that failure also blocked the release.
- Skip the placeholder in the release check. `release-pending.mjs` compares each manifest version against the registry, and `0.0.0` is never published, so it reported `@paleo/alproject@0.0.0` as a pending release and requested a publish approval. Approving it would have published the placeholder as the package's first version.

## Verification

- `npm run lint`, `npm run build`, `npm test` — all green (646 tests).
- The version test passes with the manifest at both `0.0.0` and `0.1.0`.
- `release-pending.mjs` returns `[]` at `0.0.0` and `["@paleo/alproject@0.1.0"]` when bumped.

No changeset: `test/` is outside the published `files` and `scripts/` is not a package, so nothing here reaches consumers.

## Follow-ups

- `npm access set mfa=publish @paleo/alproject` — needs an existing published version, so it has to wait until `0.1.0` lands.
- `docs/releasing.md` — add `@paleo/alproject` to the trusted-publisher registration list, and note that a new package needs `npm trust github` before its first release.
