### PR TITLE
feat: add project status command

### DIFF
--- a/.changeset/alproject-status.md
+++ b/.changeset/alproject-status.md
@@ -1,0 +1,5 @@
+---
+"@paleo/alproject": minor
+---
+
+Added detailed project status output for humans and scripts.

--- a/.changeset/alproject-status.md
+++ b/.changeset/alproject-status.md
@@ -1,5 +1,5 @@
 ---
-"@paleo/alproject": minor
+"@paleo/alproject": major
 ---
 
-Added detailed project status output for humans and scripts.
+Added detailed project status, exact base-port registration, and parent-specific port ranges using the new object-based configuration.

--- a/packages/alproject/README.md
+++ b/packages/alproject/README.md
@@ -27,9 +27,12 @@ Create `~/.alproject.json` before running commands:
 
 ```text
 alproject list [--json]
+alproject status <path> [--json]
 alproject register <path> [--ports-per-workspace <n> --max-workspaces <n>]
 alproject unregister <path>
 ```
+
+`status` reports one discovered or registered project. It includes the canonical main path, registration and filesystem status, optional port allocation, preferred remote host, and every Git worktree with its path and branch. Relative paths resolve from `root`; absolute paths are accepted directly. Pass the main-worktree path.
 
 Run `alproject --guide` for the agent-facing operating guide. When `<root>/alproject-guide.md` exists, the command appends it verbatim after the generic guide — use it to describe how the project parents are organized. An unreadable custom guide is an error.
 

--- a/packages/alproject/README.md
+++ b/packages/alproject/README.md
@@ -14,21 +14,38 @@ Create `~/.alproject.json` before running commands:
 
 ```json
 {
-  "root": "~/projects",
-  "projectParents": ["~/projects", "~/work/projects"],
-  "firstPort": 8000,
-  "lastPort": 9999
+  "root": {
+    "path": "~/projects",
+    "portRange": {
+      "first": 8000,
+      "last": 9999
+    }
+  },
+  "projectParents": [
+    {
+      "path": "~/projects"
+    },
+    {
+      "path": "~/work/projects",
+      "portRange": {
+        "first": 9000,
+        "last": 9999
+      }
+    }
+  ]
 }
 ```
 
-`root` is the base for relative command paths and stores `alproject-registry.json`. `projectParents` lists the directories whose direct children may be discovered and registered. It defaults to `[root]`. All configured directories must exist. Alproject reads this configuration but never changes it.
+`root.path` is the base for relative command paths and stores `alproject-registry.json`. `root.portRange` is the inclusive global allocation range. `projectParents` lists the directories whose direct children may be discovered and registered. It defaults to the root path. All configured directories must exist.
+
+An optional parent `portRange` reserves part of the global range for projects under that parent. Parent ranges must be inside the global range and cannot overlap. Projects under parents without a dedicated range share the unreserved ports.
 
 ## Commands
 
 ```text
 alproject list [--json]
 alproject status <path> [--json]
-alproject register <path> [--ports-per-workspace <n> --max-workspaces <n>]
+alproject register <path> [--ports-per-workspace <n> --max-workspaces <n> [--base-port <n>]]
 alproject unregister <path>
 ```
 

--- a/packages/alproject/src/cli.ts
+++ b/packages/alproject/src/cli.ts
@@ -8,6 +8,7 @@ import { errorMessage } from "./errors.js";
 import { renderGuide } from "./guide.js";
 import { registerProject, unregisterProject } from "./mutations.js";
 import { readRegistry } from "./registry.js";
+import { getProjectStatus, type ProjectDetails } from "./status.js";
 
 const statusLabels: Record<ProjectStatus, string> = {
   missing: "registered but missing from filesystem",
@@ -78,6 +79,11 @@ export async function main(options: MainOptions = {}): Promise<number> {
       stdout.write(args.json ? renderProjectListJson(list) : renderProjectList(list));
       return 0;
     }
+    if (args.command === "status" && args.path !== undefined) {
+      const status = getProjectStatus(config, readRegistry(config), args.path);
+      stdout.write(args.json ? renderProjectStatusJson(status) : renderProjectStatus(status));
+      return 0;
+    }
     if (args.command === "register" && args.path !== undefined) {
       const result = await registerProject(config, args.path, {
         maxWorkspaces: args.maxWorkspaces,
@@ -139,7 +145,7 @@ export function parseAlprojectArgs(argv: string[]): AlprojectArgs {
 
   const [command, path, ...extraPaths] = positionals;
   if (command === undefined) {
-    if (values.json === true) throw new Error("--json is valid only with list");
+    if (values.json === true) throw new Error("--json is valid only with list or status");
     if (values["ports-per-workspace"] !== undefined || values["max-workspaces"] !== undefined) {
       throw new Error("Port options are valid only with register");
     }
@@ -148,8 +154,8 @@ export function parseAlprojectArgs(argv: string[]): AlprojectArgs {
   if (!isCommand(command)) throw new Error(`Unknown command: ${command}`);
   validateCommandPaths(command, path, extraPaths);
   validatePortOptionPlacement(command, values);
-  if (values.json === true && command !== "list") {
-    throw new Error("--json is valid only with list");
+  if (values.json === true && command !== "list" && command !== "status") {
+    throw new Error("--json is valid only with list or status");
   }
   const portsPerWorkspace = parsePositiveInteger(
     "--ports-per-workspace",
@@ -171,8 +177,8 @@ export function parseAlprojectArgs(argv: string[]): AlprojectArgs {
   };
 }
 
-function isCommand(value: string): value is "list" | "register" | "unregister" {
-  return value === "list" || value === "register" || value === "unregister";
+function isCommand(value: string): value is "list" | "register" | "status" | "unregister" {
+  return value === "list" || value === "register" || value === "status" || value === "unregister";
 }
 
 function validateCommandPaths(
@@ -225,12 +231,14 @@ function renderHelp(): string {
 
 Usage:
   alproject list [--json]
+  alproject status <path> [--json]
   alproject register <path> [--ports-per-workspace <n> --max-workspaces <n>]
   alproject unregister <path>
 
 Options:
   --guide              Print the complete guide
   -h, --help           Print this help
+  --json               Print structured list or status output
   -v, --version        Print the alproject version
 
 Run \`alproject --guide\` for configuration and operational procedures.
@@ -272,6 +280,40 @@ export function renderProjectList(list: ProjectList): string {
 
 export function renderProjectListJson(list: ProjectList): string {
   return `${escapeAdditionalJsonCharacters(JSON.stringify(list, undefined, 2))}\n`;
+}
+
+export function renderProjectStatus(status: ProjectDetails): string {
+  const lines = [
+    "Project:",
+    `  Name: ${renderOutputValue(status.name)}`,
+    `  Main path: ${renderOutputValue(status.path)}`,
+    `  Status: ${statusLabels[status.status]}`,
+    `  Remote host: ${status.remoteHost === null ? "(none)" : renderOutputValue(status.remoteHost)}`,
+  ];
+  if (status.ports === null) {
+    lines.push("  Port allocation: (none)");
+  } else {
+    lines.push(
+      `  Base port: ${status.ports.basePort}`,
+      `  Port range: ${status.ports.basePort}..${status.ports.endPort}`,
+      `  Ports per workspace: ${status.ports.portsPerWorkspace}`,
+      `  Maximum workspaces: ${status.ports.maxWorkspaces}`,
+    );
+  }
+  lines.push("  Worktrees:");
+  if (status.worktrees.length === 0) lines.push("    (none)");
+  for (const worktree of status.worktrees) {
+    lines.push(
+      `  - Name: ${renderOutputValue(worktree.name)}`,
+      `    Path: ${renderOutputValue(worktree.path)}`,
+      `    Branch: ${worktree.branch === null ? "(detached)" : renderOutputValue(worktree.branch)}`,
+    );
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+export function renderProjectStatusJson(status: ProjectDetails): string {
+  return `${escapeAdditionalJsonCharacters(JSON.stringify(status, undefined, 2))}\n`;
 }
 
 function renderRegistration(result: {

--- a/packages/alproject/src/cli.ts
+++ b/packages/alproject/src/cli.ts
@@ -29,6 +29,7 @@ export interface Output {
 }
 
 export interface AlprojectArgs {
+  basePort?: number;
   command?: string;
   guide: boolean;
   help: boolean;
@@ -37,6 +38,12 @@ export interface AlprojectArgs {
   path?: string;
   portsPerWorkspace?: number;
   version: boolean;
+}
+
+interface PortOptionValues {
+  "base-port"?: string;
+  "max-workspaces"?: string;
+  "ports-per-workspace"?: string;
 }
 
 export async function main(options: MainOptions = {}): Promise<number> {
@@ -66,7 +73,7 @@ export async function main(options: MainOptions = {}): Promise<number> {
   try {
     if (args.guide) {
       const config = readConfigIfPresent(home);
-      stdout.write(ensureTrailingNewline(renderGuide(config?.root)));
+      stdout.write(ensureTrailingNewline(renderGuide(config?.root.path)));
       return 0;
     }
     if (args.command === undefined) {
@@ -86,6 +93,7 @@ export async function main(options: MainOptions = {}): Promise<number> {
     }
     if (args.command === "register" && args.path !== undefined) {
       const result = await registerProject(config, args.path, {
+        basePort: args.basePort,
         maxWorkspaces: args.maxWorkspaces,
         portsPerWorkspace: args.portsPerWorkspace,
       });
@@ -109,6 +117,7 @@ export function parseAlprojectArgs(argv: string[]): AlprojectArgs {
     allowPositionals: true,
     args: argv.slice(2),
     options: {
+      "base-port": { type: "string" },
       guide: { default: false, type: "boolean" },
       help: { default: false, short: "h", type: "boolean" },
       json: { default: false, type: "boolean" },
@@ -128,11 +137,7 @@ export function parseAlprojectArgs(argv: string[]): AlprojectArgs {
   }
   if (selectedModes.length === 1) {
     if (positionals.length > 0) throw new Error(`${selectedModes[0]} does not accept a command`);
-    if (
-      values.json === true ||
-      values["ports-per-workspace"] !== undefined ||
-      values["max-workspaces"] !== undefined
-    ) {
+    if (values.json === true || hasPortOptions(values)) {
       throw new Error(`${selectedModes[0]} does not accept command options`);
     }
     return {
@@ -146,7 +151,7 @@ export function parseAlprojectArgs(argv: string[]): AlprojectArgs {
   const [command, path, ...extraPaths] = positionals;
   if (command === undefined) {
     if (values.json === true) throw new Error("--json is valid only with list or status");
-    if (values["ports-per-workspace"] !== undefined || values["max-workspaces"] !== undefined) {
+    if (hasPortOptions(values)) {
       throw new Error("Port options are valid only with register");
     }
     return { guide: false, help: false, json: false, version: false };
@@ -162,10 +167,15 @@ export function parseAlprojectArgs(argv: string[]): AlprojectArgs {
     values["ports-per-workspace"],
   );
   const maxWorkspaces = parsePositiveInteger("--max-workspaces", values["max-workspaces"]);
+  const basePort = parsePositiveInteger("--base-port", values["base-port"]);
   if ((portsPerWorkspace === undefined) !== (maxWorkspaces === undefined)) {
     throw new Error("--ports-per-workspace and --max-workspaces must be provided together");
   }
+  if (basePort !== undefined && portsPerWorkspace === undefined) {
+    throw new Error("--base-port requires --ports-per-workspace and --max-workspaces");
+  }
   return {
+    basePort,
     command,
     guide: false,
     help: false,
@@ -175,6 +185,14 @@ export function parseAlprojectArgs(argv: string[]): AlprojectArgs {
     portsPerWorkspace,
     version: false,
   };
+}
+
+function hasPortOptions(values: PortOptionValues): boolean {
+  return (
+    values["base-port"] !== undefined ||
+    values["ports-per-workspace"] !== undefined ||
+    values["max-workspaces"] !== undefined
+  );
 }
 
 function isCommand(value: string): value is "list" | "register" | "status" | "unregister" {
@@ -194,14 +212,8 @@ function validateCommandPaths(
   if (extraPaths.length > 0) throw new Error(`${command} requires exactly one path`);
 }
 
-function validatePortOptionPlacement(
-  command: string,
-  values: { "max-workspaces"?: string; "ports-per-workspace"?: string },
-): void {
-  if (
-    command !== "register" &&
-    (values["ports-per-workspace"] !== undefined || values["max-workspaces"] !== undefined)
-  ) {
+function validatePortOptionPlacement(command: string, values: PortOptionValues): void {
+  if (command !== "register" && hasPortOptions(values)) {
     throw new Error("Port options are valid only with register");
   }
 }
@@ -232,7 +244,7 @@ function renderHelp(): string {
 Usage:
   alproject list [--json]
   alproject status <path> [--json]
-  alproject register <path> [--ports-per-workspace <n> --max-workspaces <n>]
+  alproject register <path> [--ports-per-workspace <n> --max-workspaces <n> [--base-port <n>]]
   alproject unregister <path>
 
 Options:

--- a/packages/alproject/src/cli.ts
+++ b/packages/alproject/src/cli.ts
@@ -282,7 +282,7 @@ export function renderProjectListJson(list: ProjectList): string {
   return `${escapeAdditionalJsonCharacters(JSON.stringify(list, undefined, 2))}\n`;
 }
 
-export function renderProjectStatus(status: ProjectDetails): string {
+function renderProjectStatus(status: ProjectDetails): string {
   const lines = [
     "Project:",
     `  Name: ${renderOutputValue(status.name)}`,
@@ -312,7 +312,7 @@ export function renderProjectStatus(status: ProjectDetails): string {
   return `${lines.join("\n")}\n`;
 }
 
-export function renderProjectStatusJson(status: ProjectDetails): string {
+function renderProjectStatusJson(status: ProjectDetails): string {
   return `${escapeAdditionalJsonCharacters(JSON.stringify(status, undefined, 2))}\n`;
 }
 

--- a/packages/alproject/src/config.ts
+++ b/packages/alproject/src/config.ts
@@ -1,54 +1,78 @@
 import { accessSync, constants, readFileSync, statSync } from "node:fs";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 
 import { type } from "arktype";
 
 import { AlprojectError, errorMessage, isNodeError } from "./errors.js";
-import { canonicalizeParentPaths, resolveConfiguredPath } from "./paths.js";
+import { resolveConfiguredPath } from "./paths.js";
 
 export const CONFIG_FILENAME = ".alproject.json";
 
+const portRangeSchema = type({
+  "+": "reject",
+  first: "1 <= number.integer <= 65535",
+  last: "1 <= number.integer <= 65535",
+});
+const rootSchema = type({
+  "+": "reject",
+  path: "string > 0",
+  portRange: portRangeSchema,
+});
+const projectParentSchema = type({
+  "+": "reject",
+  path: "string > 0",
+  "portRange?": portRangeSchema,
+});
 const configSchema = type({
   "+": "reject",
-  firstPort: "1 <= number.integer <= 65535",
-  lastPort: "1 <= number.integer <= 65535",
-  "projectParents?": "(string > 0)[] > 0",
-  root: "string > 0",
+  "projectParents?": projectParentSchema.array(),
+  root: rootSchema,
 });
 
 type ConfigFile = typeof configSchema.infer;
+type ConfiguredProjectParent = typeof projectParentSchema.infer;
+type ConfiguredRoot = typeof rootSchema.infer;
 
 export interface AlprojectConfig {
   configPath: string;
-  firstPort: number;
-  lastPort: number;
-  projectParents: string[];
-  root: string;
+  projectParents: ProjectParent[];
+  root: AlprojectRoot;
+}
+
+export interface AlprojectRoot {
+  path: string;
+  portRange: PortRange;
+}
+
+export interface ProjectParent {
+  path: string;
+  portRange?: PortRange;
+}
+
+export interface PortRange {
+  first: number;
+  last: number;
 }
 
 export function readConfig(home: string): AlprojectConfig {
   const configPath = join(home, CONFIG_FILENAME);
   const configFile = readConfigFile(configPath);
-  const root = resolveConfigPath(configFile.root, home, configPath, "root");
-  const configuredParents = configFile.projectParents ?? [configFile.root];
-  const projectParents = resolveConfigParents(configuredParents, home, configPath);
+  const root = resolveRoot(configFile.root, home, configPath);
+  const configuredParents = configFile.projectParents ?? [{ path: configFile.root.path }];
+  const projectParents = resolveProjectParents(configuredParents, root.portRange, home, configPath);
 
-  if (configFile.firstPort > configFile.lastPort) {
-    throw configurationError(configPath, "firstPort must not exceed lastPort");
-  }
-
-  assertAccessibleDirectory(root, configPath, "root");
+  assertAccessibleDirectory(root.path, configPath, "root");
   for (const parent of projectParents) {
-    assertAccessibleDirectory(parent, configPath, "project parent");
+    assertAccessibleDirectory(parent.path, configPath, "project parent");
   }
 
-  return {
-    configPath,
-    firstPort: configFile.firstPort,
-    lastPort: configFile.lastPort,
-    projectParents,
-    root,
-  };
+  return { configPath, projectParents, root };
+}
+
+export function availablePortRanges(config: AlprojectConfig, projectPath: string): PortRange[] {
+  const parent = config.projectParents.find((candidate) => candidate.path === dirname(projectPath));
+  if (parent?.portRange !== undefined) return [parent.portRange];
+  return unreservedPortRanges(config.root.portRange, config.projectParents);
 }
 
 export function readConfigIfPresent(home: string): AlprojectConfig | undefined {
@@ -72,7 +96,124 @@ function readConfigFile(configPath: string): ConfigFile {
   if (config instanceof type.errors) {
     throw configurationError(configPath, config.summary);
   }
+  if (config.projectParents?.length === 0) {
+    throw configurationError(configPath, "projectParents must contain at least one entry");
+  }
   return config;
+}
+
+function resolveRoot(root: ConfiguredRoot, home: string, configPath: string): AlprojectRoot {
+  const portRange = validatePortRange(root.portRange, "root.portRange", configPath);
+  return {
+    path: resolveConfigPath(root.path, home, configPath, "root.path"),
+    portRange,
+  };
+}
+
+function resolveProjectParents(
+  parents: ConfiguredProjectParent[],
+  rootRange: PortRange,
+  home: string,
+  configPath: string,
+): ProjectParent[] {
+  const resolved = parents.map((parent, index) => ({
+    path: resolveConfigPath(parent.path, home, configPath, `projectParents[${index}].path`),
+    ...(parent.portRange === undefined
+      ? {}
+      : {
+          portRange: validateParentPortRange(
+            parent.portRange,
+            rootRange,
+            `projectParents[${index}].portRange`,
+            configPath,
+          ),
+        }),
+  }));
+  validateDistinctParents(resolved, configPath);
+  validateNonOverlappingParentRanges(resolved, configPath);
+  return resolved;
+}
+
+function resolveConfigPath(path: string, home: string, configPath: string, field: string): string {
+  try {
+    return resolveConfiguredPath(path, home);
+  } catch (error) {
+    throw configurationError(configPath, `${field}: ${errorMessage(error)}`, error);
+  }
+}
+
+function validateParentPortRange(
+  range: PortRange,
+  rootRange: PortRange,
+  field: string,
+  configPath: string,
+): PortRange {
+  const validated = validatePortRange(range, field, configPath);
+  if (validated.first < rootRange.first || validated.last > rootRange.last) {
+    throw configurationError(
+      configPath,
+      `${field} must be within root.portRange ${formatPortRange(rootRange)}`,
+    );
+  }
+  return validated;
+}
+
+function validatePortRange(range: PortRange, field: string, configPath: string): PortRange {
+  if (range.first > range.last) {
+    throw configurationError(configPath, `${field}.first must not exceed ${field}.last`);
+  }
+  return range;
+}
+
+function validateDistinctParents(parents: readonly ProjectParent[], configPath: string): void {
+  const seen = new Set<string>();
+  for (const parent of parents) {
+    if (seen.has(parent.path)) {
+      throw configurationError(configPath, `duplicate project parent: ${parent.path}`);
+    }
+    seen.add(parent.path);
+  }
+}
+
+function validateNonOverlappingParentRanges(
+  parents: readonly ProjectParent[],
+  configPath: string,
+): void {
+  const ranges = parents.flatMap((parent) =>
+    parent.portRange === undefined ? [] : [{ parent: parent.path, ...parent.portRange }],
+  );
+  const sorted = ranges.toSorted((left, right) => left.first - right.first);
+  for (let index = 1; index < sorted.length; ++index) {
+    const previous = sorted[index - 1];
+    const current = sorted[index];
+    if (current.first <= previous.last) {
+      throw configurationError(
+        configPath,
+        `project parent port ranges overlap for ${previous.parent} and ${current.parent}`,
+      );
+    }
+  }
+}
+
+function unreservedPortRanges(
+  rootRange: PortRange,
+  parents: readonly ProjectParent[],
+): PortRange[] {
+  const reserved = parents
+    .flatMap((parent) => (parent.portRange === undefined ? [] : [parent.portRange]))
+    .toSorted((left, right) => left.first - right.first);
+  const available: PortRange[] = [];
+  let first = rootRange.first;
+  for (const range of reserved) {
+    if (first < range.first) available.push({ first, last: range.first - 1 });
+    first = range.last + 1;
+  }
+  if (first <= rootRange.last) available.push({ first, last: rootRange.last });
+  return available;
+}
+
+function formatPortRange(range: PortRange): string {
+  return `${range.first}..${range.last}`;
 }
 
 function readJsonFile(path: string, label: string): unknown {
@@ -95,22 +236,6 @@ function readJsonFile(path: string, label: string): unknown {
       `Invalid JSON in ${label} file ${path}: ${errorMessage(error)}`,
       { cause: error },
     );
-  }
-}
-
-function resolveConfigPath(path: string, home: string, configPath: string, field: string): string {
-  try {
-    return resolveConfiguredPath(path, home);
-  } catch (error) {
-    throw configurationError(configPath, `${field}: ${errorMessage(error)}`, error);
-  }
-}
-
-function resolveConfigParents(paths: string[], home: string, configPath: string): string[] {
-  try {
-    return canonicalizeParentPaths(paths, home);
-  } catch (error) {
-    throw configurationError(configPath, `projectParents: ${errorMessage(error)}`, error);
   }
 }
 

--- a/packages/alproject/src/discovery.ts
+++ b/packages/alproject/src/discovery.ts
@@ -86,7 +86,10 @@ export function buildProjectList(
 export function discoverProjects(
   config: Pick<AlprojectConfig, "projectParents">,
 ): ProjectDiscovery {
-  const candidates = config.projectParents.toSorted().flatMap(readDirectoryCandidates);
+  const candidates = config.projectParents
+    .map((parent) => parent.path)
+    .toSorted()
+    .flatMap(readDirectoryCandidates);
   const mainCandidates = candidates.flatMap((candidate) => {
     const gitDirectory = existingGitDirectory(candidate.path);
     return gitDirectory === undefined ? [] : [{ ...candidate, gitDirectory }];

--- a/packages/alproject/src/discovery.ts
+++ b/packages/alproject/src/discovery.ts
@@ -91,7 +91,7 @@ export function discoverProjects(
     .toSorted()
     .flatMap(readDirectoryCandidates);
   const mainCandidates = candidates.flatMap((candidate) => {
-    const gitDirectory = existingGitDirectory(candidate.path);
+    const gitDirectory = mainWorktreeGitDirectory(candidate.path);
     return gitDirectory === undefined ? [] : [{ ...candidate, gitDirectory }];
   });
   const mainsByGitDirectory = new Map(
@@ -136,7 +136,7 @@ function readDirectoryCandidate(parent: string, name: string): DirectoryCandidat
   }
 }
 
-function existingGitDirectory(projectPath: string): string | undefined {
+export function mainWorktreeGitDirectory(projectPath: string): string | undefined {
   const gitPath = join(projectPath, ".git");
   try {
     if (!lstatSync(gitPath).isDirectory()) return;

--- a/packages/alproject/src/mutations.ts
+++ b/packages/alproject/src/mutations.ts
@@ -11,16 +11,17 @@ import {
 import { randomUUID } from "node:crypto";
 import { dirname, join } from "node:path";
 
-import type { AlprojectConfig } from "./config.js";
+import { availablePortRanges, type AlprojectConfig } from "./config.js";
 import { AlprojectError, errorMessage, isNodeError } from "./errors.js";
 import { resolveProjectPath } from "./paths.js";
 import {
   allocateProjectPorts,
   allocationEnd,
+  claimProjectPorts,
   projectPortCount,
   type PortRequest,
 } from "./ports.js";
-import { readRegistry, type Registry, registryPath } from "./registry.js";
+import { type PortAllocation, readRegistry, type Registry, registryPath } from "./registry.js";
 import { type RegistryLockOptions, withRegistryLock } from "./registry-lock.js";
 
 const atomicWriteOperations: AtomicWriteOperations = {
@@ -33,6 +34,7 @@ const atomicWriteOperations: AtomicWriteOperations = {
 };
 
 export interface RegistrationOptions {
+  basePort?: number;
   maxWorkspaces?: number;
   portsPerWorkspace?: number;
 }
@@ -69,16 +71,12 @@ export async function registerProject(
 ): Promise<RegistrationResult> {
   const path = registrationPath(config, inputPath);
   const request = portRequest(options);
-  if (request !== undefined) assertRequestFitsConfiguredRange(config, request);
 
   return mutateRegistry(config, mutationOptions, (registry) => {
     if (registry.projects.some((project) => project.path === path)) {
       throw new AlprojectError("registry", `Project is already registered: ${path}`);
     }
-    const ports =
-      request === undefined
-        ? undefined
-        : allocateProjectPorts(registry.projects, request, config.firstPort, config.lastPort);
+    const ports = allocateRegistrationPorts(config, registry, path, request, options.basePort);
     registry.projects.push(ports === undefined ? { path } : { path, ports });
     return {
       path,
@@ -104,7 +102,7 @@ export async function unregisterProject(
 function registrationPath(config: AlprojectConfig, inputPath: string): string {
   const path = mutationPath(config, inputPath);
   assertMainWorktree(path);
-  if (!config.projectParents.includes(dirname(path))) {
+  if (!config.projectParents.some((parent) => parent.path === dirname(path))) {
     throw new AlprojectError(
       "filesystem",
       `Project must be a direct child of an allowed project parent: ${path}`,
@@ -114,7 +112,7 @@ function registrationPath(config: AlprojectConfig, inputPath: string): string {
 }
 
 function mutationPath(config: Pick<AlprojectConfig, "root">, inputPath: string): string {
-  return resolveProjectPath(inputPath, config.root);
+  return resolveProjectPath(inputPath, config.root.path);
 }
 
 function assertMainWorktree(path: string): void {
@@ -146,6 +144,9 @@ function portRequest(options: RegistrationOptions): PortRequest | undefined {
     options.portsPerWorkspace === undefined ||
     options.maxWorkspaces === undefined
   ) {
+    if (options.basePort !== undefined) {
+      throw new AlprojectError("registry", "basePort requires portsPerWorkspace and maxWorkspaces");
+    }
     return;
   }
   const request = {
@@ -153,18 +154,26 @@ function portRequest(options: RegistrationOptions): PortRequest | undefined {
     portsPerWorkspace: options.portsPerWorkspace,
   };
   projectPortCount(request);
+  if (options.basePort !== undefined) {
+    allocationEnd({ basePort: options.basePort, ...request });
+  }
   return request;
 }
 
-function assertRequestFitsConfiguredRange(config: AlprojectConfig, request: PortRequest): void {
-  const available = config.lastPort - config.firstPort + 1;
-  const requested = projectPortCount(request);
-  if (requested > available) {
-    throw new AlprojectError(
-      "registry",
-      `Requested block of ${requested} ports exceeds configured range ${config.firstPort}..${config.lastPort}`,
-    );
-  }
+function allocateRegistrationPorts(
+  config: AlprojectConfig,
+  registry: Registry,
+  path: string,
+  request: PortRequest | undefined,
+  basePort: number | undefined,
+): PortAllocation | undefined {
+  if (request === undefined) return;
+  const ranges = availablePortRanges(config, path);
+  const allocation =
+    basePort === undefined
+      ? allocateProjectPorts(registry.projects, request, ranges)
+      : claimProjectPorts(registry.projects, { basePort, ...request }, ranges);
+  return allocation;
 }
 
 async function mutateRegistry<T>(

--- a/packages/alproject/src/mutations.ts
+++ b/packages/alproject/src/mutations.ts
@@ -9,11 +9,11 @@ import {
   fsyncSync,
 } from "node:fs";
 import { randomUUID } from "node:crypto";
-import { dirname, isAbsolute, join, normalize, resolve } from "node:path";
+import { dirname, join } from "node:path";
 
 import type { AlprojectConfig } from "./config.js";
 import { AlprojectError, errorMessage, isNodeError } from "./errors.js";
-import { canonicalizePath } from "./paths.js";
+import { resolveProjectPath } from "./paths.js";
 import {
   allocateProjectPorts,
   allocationEnd,
@@ -114,11 +114,7 @@ function registrationPath(config: AlprojectConfig, inputPath: string): string {
 }
 
 function mutationPath(config: Pick<AlprojectConfig, "root">, inputPath: string): string {
-  if (inputPath.length === 0) throw new AlprojectError("filesystem", "Project path is required");
-  const absolutePath = isAbsolute(inputPath)
-    ? normalize(inputPath)
-    : resolve(config.root, inputPath);
-  return canonicalizePath(absolutePath);
+  return resolveProjectPath(inputPath, config.root);
 }
 
 function assertMainWorktree(path: string): void {

--- a/packages/alproject/src/paths.ts
+++ b/packages/alproject/src/paths.ts
@@ -42,10 +42,6 @@ export function resolveConfiguredPath(path: string, home: string): string {
   return canonicalizePath(normalizeAbsolutePath(path, home));
 }
 
-export function canonicalizeParentPaths(paths: readonly string[], home: string): string[] {
-  return [...new Set(paths.map((path) => resolveConfiguredPath(path, home)))];
-}
-
 function isMissingPathError(error: unknown): boolean {
   return isNodeError(error) && (error.code === "ENOENT" || error.code === "ENOTDIR");
 }

--- a/packages/alproject/src/paths.ts
+++ b/packages/alproject/src/paths.ts
@@ -1,5 +1,5 @@
 import { realpathSync } from "node:fs";
-import { isAbsolute, join, normalize } from "node:path";
+import { isAbsolute, join, normalize, resolve } from "node:path";
 
 import { AlprojectError, errorMessage, isNodeError } from "./errors.js";
 
@@ -30,6 +30,12 @@ export function canonicalizePath(path: string): string {
       },
     );
   }
+}
+
+export function resolveProjectPath(path: string, root: string): string {
+  if (path.length === 0) throw new AlprojectError("filesystem", "Project path is required");
+  const absolutePath = isAbsolute(path) ? normalize(path) : resolve(root, path);
+  return canonicalizePath(absolutePath);
 }
 
 export function resolveConfiguredPath(path: string, home: string): string {

--- a/packages/alproject/src/ports.ts
+++ b/packages/alproject/src/ports.ts
@@ -84,6 +84,7 @@ function lowestFreeBase(
   let candidate = firstPort;
   for (const range of ranges.toSorted((left, right) => left.start - right.start)) {
     if (range.end < candidate) continue;
+    if (range.start > lastPort) break;
     if (fitsBefore(candidate, size, range.start - 1)) return candidate;
     candidate = range.end + 1;
   }

--- a/packages/alproject/src/ports.ts
+++ b/packages/alproject/src/ports.ts
@@ -1,4 +1,5 @@
 import { AlprojectError } from "./errors.js";
+import type { PortRange } from "./config.js";
 import type { PortAllocation, ProjectEntry } from "./registry.js";
 
 export interface PortRequest {
@@ -6,7 +7,7 @@ export interface PortRequest {
   portsPerWorkspace: number;
 }
 
-interface PortRange {
+interface AllocatedPortRange {
   end: number;
   start: number;
 }
@@ -14,21 +15,45 @@ interface PortRange {
 export function allocateProjectPorts(
   projects: readonly ProjectEntry[],
   request: PortRequest,
-  firstPort: number,
-  lastPort: number,
+  availableRanges: readonly PortRange[],
 ): PortAllocation {
   const size = projectPortCount(request);
-  const ranges = projects.flatMap((project) =>
+  const allocations = projects.flatMap((project) =>
     project.ports === undefined ? [] : [allocationRange(project.ports)],
   );
-  const basePort = lowestFreeBase(ranges, size, firstPort, lastPort);
-  if (basePort === undefined) {
+  for (const range of availableRanges.toSorted((left, right) => left.first - right.first)) {
+    const basePort = lowestFreeBase(allocations, size, range.first, range.last);
+    if (basePort !== undefined) return { basePort, ...request };
+  }
+  throw new AlprojectError(
+    "registry",
+    `No contiguous block of ${size} ports is available within ${formatPortRanges(availableRanges)}`,
+  );
+}
+
+export function claimProjectPorts(
+  projects: readonly ProjectEntry[],
+  claim: PortAllocation,
+  availableRanges: readonly PortRange[],
+): PortAllocation {
+  const claimedRange = allocationRange(claim);
+  if (!availableRanges.some((range) => containsRange(range, claimedRange))) {
     throw new AlprojectError(
       "registry",
-      `No contiguous block of ${size} ports is available within ${firstPort}..${lastPort}`,
+      `Claimed port range ${formatAllocatedRange(claimedRange)} is outside ${formatPortRanges(availableRanges)}`,
     );
   }
-  return { basePort, ...request };
+  const conflict = projects.find(
+    (project) =>
+      project.ports !== undefined && rangesOverlap(claimedRange, allocationRange(project.ports)),
+  );
+  if (conflict !== undefined) {
+    throw new AlprojectError(
+      "registry",
+      `Claimed port range ${formatAllocatedRange(claimedRange)} is not available because it overlaps ${conflict.path}`,
+    );
+  }
+  return claim;
 }
 
 export function projectPortCount(request: PortRequest): number {
@@ -51,7 +76,7 @@ export function allocationEnd(allocation: PortAllocation): number {
 }
 
 function lowestFreeBase(
-  ranges: readonly PortRange[],
+  ranges: readonly AllocatedPortRange[],
   size: number,
   firstPort: number,
   lastPort: number,
@@ -70,8 +95,25 @@ function fitsBefore(basePort: number, size: number, lastPort: number): boolean {
   return Number.isSafeInteger(end) && end <= lastPort;
 }
 
-function allocationRange(allocation: PortAllocation): PortRange {
+function allocationRange(allocation: PortAllocation): AllocatedPortRange {
   return { end: allocationEnd(allocation), start: allocation.basePort };
+}
+
+function containsRange(available: PortRange, allocation: AllocatedPortRange): boolean {
+  return allocation.start >= available.first && allocation.end <= available.last;
+}
+
+function rangesOverlap(left: AllocatedPortRange, right: AllocatedPortRange): boolean {
+  return left.start <= right.end && right.start <= left.end;
+}
+
+function formatPortRanges(ranges: readonly PortRange[]): string {
+  if (ranges.length === 0) return "the configured port ranges (none available)";
+  return ranges.map((range) => `${range.first}..${range.last}`).join(", ");
+}
+
+function formatAllocatedRange(range: AllocatedPortRange): string {
+  return `${range.start}..${range.end}`;
 }
 
 function assertPositiveSafeInteger(value: number, field: string): void {

--- a/packages/alproject/src/registry.ts
+++ b/packages/alproject/src/registry.ts
@@ -3,7 +3,7 @@ import { isAbsolute, join, normalize } from "node:path";
 
 import { type } from "arktype";
 
-import type { AlprojectConfig } from "./config.js";
+import { availablePortRanges, type AlprojectConfig } from "./config.js";
 import { AlprojectError, errorMessage, isNodeError } from "./errors.js";
 import { canonicalizePath } from "./paths.js";
 import { allocationEnd } from "./ports.js";
@@ -38,7 +38,7 @@ interface PortRange {
 }
 
 export function registryPath(config: Pick<AlprojectConfig, "root">): string {
-  return join(config.root, REGISTRY_FILENAME);
+  return join(config.root.path, REGISTRY_FILENAME);
 }
 
 export function readRegistry(config: AlprojectConfig): Registry {
@@ -107,10 +107,11 @@ function portRange(
       throw registryError(registryFile, `${field} must be a safe integer for ${project.path}`);
     }
   }
-  if (ports.basePort < config.firstPort || ports.basePort > config.lastPort) {
+  const rootRange = config.root.portRange;
+  if (ports.basePort < rootRange.first || ports.basePort > rootRange.last) {
     throw registryError(
       registryFile,
-      `basePort for ${project.path} must be within ${config.firstPort}..${config.lastPort}`,
+      `basePort for ${project.path} must be within ${rootRange.first}..${rootRange.last}`,
     );
   }
 
@@ -120,10 +121,17 @@ function portRange(
   } catch (error) {
     throw registryError(registryFile, errorMessage(error), error);
   }
-  if (end > config.lastPort) {
+  if (end > rootRange.last) {
     throw registryError(
       registryFile,
-      `port allocation for ${project.path} exceeds configured range ending at ${config.lastPort}`,
+      `port allocation for ${project.path} exceeds configured range ending at ${rootRange.last}`,
+    );
+  }
+  const availableRanges = availablePortRanges(config, project.path);
+  if (!availableRanges.some((range) => ports.basePort >= range.first && end <= range.last)) {
+    throw registryError(
+      registryFile,
+      `port allocation for ${project.path} is outside its available parent port range`,
     );
   }
   return { end, path: project.path, start: ports.basePort };

--- a/packages/alproject/src/status.ts
+++ b/packages/alproject/src/status.ts
@@ -67,18 +67,22 @@ function readRemoteHost(projectPath: string): string | null {
     ? ["origin", ...remotes.filter((remote) => remote !== "origin")]
     : remotes;
   for (const remote of orderedRemotes) {
-    const host = remoteHost(runGit(projectPath, "remote", "get-url", remote).trim());
+    const host = remoteHost(runGit(projectPath, "remote", "get-url", "--", remote).trim());
     if (host !== null) return host;
   }
   return null;
 }
 
 function remoteHost(remoteUrl: string): string | null {
+  return urlRemoteHost(remoteUrl) ?? scpRemoteHost(remoteUrl);
+}
+
+function urlRemoteHost(remoteUrl: string): string | null {
   try {
     const host = new URL(remoteUrl).hostname;
     return host.length === 0 ? null : host;
   } catch {
-    return scpRemoteHost(remoteUrl);
+    return null;
   }
 }
 

--- a/packages/alproject/src/status.ts
+++ b/packages/alproject/src/status.ts
@@ -1,11 +1,19 @@
 import { execFileSync } from "node:child_process";
-import { basename } from "node:path";
+import { lstatSync } from "node:fs";
+import { basename, dirname } from "node:path";
 
 import type { AlprojectConfig } from "./config.js";
-import { buildProjectList, type ListedPortAllocation, type ProjectStatus } from "./discovery.js";
-import { AlprojectError, errorMessage } from "./errors.js";
+import {
+  type ListedPortAllocation,
+  mainWorktreeGitDirectory,
+  type ProjectStatus,
+} from "./discovery.js";
+import { AlprojectError, errorMessage, isNodeError } from "./errors.js";
 import { canonicalizePath, resolveProjectPath } from "./paths.js";
-import type { Registry } from "./registry.js";
+import { allocationEnd } from "./ports.js";
+import type { PortAllocation, Registry } from "./registry.js";
+
+const URL_WITH_AUTHORITY = /^[A-Za-z][A-Za-z\d+.-]*:\/\//u;
 
 export interface ProjectDetails {
   name: string;
@@ -28,33 +36,61 @@ export function getProjectStatus(
   inputPath: string,
 ): ProjectDetails {
   const path = resolveProjectPath(inputPath, config.root.path);
-  const project = buildProjectList(config, registry).projects.find(
-    (candidate) => candidate.path === path,
-  );
-  if (project === undefined) {
-    throw new AlprojectError(
-      "filesystem",
-      `Project is neither registered nor discovered: ${path}. Use the canonical main-worktree path.`,
-    );
-  }
-  if (project.status === "missing") {
+  const registration = registry.projects.find((candidate) => candidate.path === path);
+  if (registration !== undefined && isMissingPath(path)) {
     return {
-      name: project.name,
-      path: project.path,
-      ports: project.ports ?? null,
+      name: basename(path),
+      path,
+      ports: listedPorts(registration.ports),
       remoteHost: null,
-      status: project.status,
+      status: "missing",
       worktrees: [],
     };
   }
+  if (mainWorktreeGitDirectory(path) === undefined) {
+    throw projectLookupError(path, registration !== undefined);
+  }
+  if (
+    registration === undefined &&
+    !config.projectParents.some((parent) => parent.path === dirname(path))
+  ) {
+    throw projectLookupError(path, false);
+  }
   return {
-    name: project.name,
-    path: project.path,
-    ports: project.ports ?? null,
-    remoteHost: readRemoteHost(project.path),
-    status: project.status,
-    worktrees: readWorktrees(project.path),
+    name: basename(path),
+    path,
+    ports: listedPorts(registration?.ports),
+    remoteHost: readRemoteHost(path),
+    status: registration === undefined ? "unregistered" : "registered",
+    worktrees: readWorktrees(path),
   };
+}
+
+function isMissingPath(path: string): boolean {
+  try {
+    lstatSync(path);
+    return false;
+  } catch (error) {
+    if (isNodeError(error) && (error.code === "ENOENT" || error.code === "ENOTDIR")) return true;
+    throw new AlprojectError(
+      "filesystem",
+      `Cannot inspect project path ${path}: ${errorMessage(error)}`,
+      {
+        cause: error,
+      },
+    );
+  }
+}
+
+function listedPorts(ports: PortAllocation | undefined): ListedPortAllocation | null {
+  return ports === undefined ? null : { ...ports, endPort: allocationEnd(ports) };
+}
+
+function projectLookupError(path: string, registered: boolean): AlprojectError {
+  const detail = registered
+    ? `Registered project is not a Git main worktree: ${path}. Use the canonical main-worktree path.`
+    : `Project is neither registered nor discovered: ${path}. Use the canonical main-worktree path.`;
+  return new AlprojectError("filesystem", detail);
 }
 
 function readRemoteHost(projectPath: string): string | null {
@@ -74,7 +110,7 @@ function readRemoteHost(projectPath: string): string | null {
 }
 
 function remoteHost(remoteUrl: string): string | null {
-  return urlRemoteHost(remoteUrl) ?? scpRemoteHost(remoteUrl);
+  return URL_WITH_AUTHORITY.test(remoteUrl) ? urlRemoteHost(remoteUrl) : scpRemoteHost(remoteUrl);
 }
 
 function urlRemoteHost(remoteUrl: string): string | null {

--- a/packages/alproject/src/status.ts
+++ b/packages/alproject/src/status.ts
@@ -1,0 +1,131 @@
+import { execFileSync } from "node:child_process";
+import { basename } from "node:path";
+
+import type { AlprojectConfig } from "./config.js";
+import { buildProjectList, type ListedPortAllocation, type ProjectStatus } from "./discovery.js";
+import { AlprojectError, errorMessage } from "./errors.js";
+import { canonicalizePath, resolveProjectPath } from "./paths.js";
+import type { Registry } from "./registry.js";
+
+export interface ProjectDetails {
+  name: string;
+  path: string;
+  ports: ListedPortAllocation | null;
+  remoteHost: string | null;
+  status: ProjectStatus;
+  worktrees: ProjectWorktree[];
+}
+
+export interface ProjectWorktree {
+  branch: string | null;
+  name: string;
+  path: string;
+}
+
+export function getProjectStatus(
+  config: AlprojectConfig,
+  registry: Registry,
+  inputPath: string,
+): ProjectDetails {
+  const path = resolveProjectPath(inputPath, config.root);
+  const project = buildProjectList(config, registry).projects.find(
+    (candidate) => candidate.path === path,
+  );
+  if (project === undefined) {
+    throw new AlprojectError(
+      "filesystem",
+      `Project is neither registered nor discovered: ${path}. Use the canonical main-worktree path.`,
+    );
+  }
+  if (project.status === "missing") {
+    return {
+      name: project.name,
+      path: project.path,
+      ports: project.ports ?? null,
+      remoteHost: null,
+      status: project.status,
+      worktrees: [],
+    };
+  }
+  return {
+    name: project.name,
+    path: project.path,
+    ports: project.ports ?? null,
+    remoteHost: readRemoteHost(project.path),
+    status: project.status,
+    worktrees: readWorktrees(project.path),
+  };
+}
+
+function readRemoteHost(projectPath: string): string | null {
+  const remotes = runGit(projectPath, "remote")
+    .trimEnd()
+    .split("\n")
+    .filter((remote) => remote.length > 0)
+    .toSorted();
+  const orderedRemotes = remotes.includes("origin")
+    ? ["origin", ...remotes.filter((remote) => remote !== "origin")]
+    : remotes;
+  for (const remote of orderedRemotes) {
+    const host = remoteHost(runGit(projectPath, "remote", "get-url", remote).trim());
+    if (host !== null) return host;
+  }
+  return null;
+}
+
+function remoteHost(remoteUrl: string): string | null {
+  try {
+    const host = new URL(remoteUrl).hostname;
+    return host.length === 0 ? null : host;
+  } catch {
+    return scpRemoteHost(remoteUrl);
+  }
+}
+
+function scpRemoteHost(remoteUrl: string): string | null {
+  if (/^[A-Za-z]:[\\/]/u.test(remoteUrl)) return null;
+  const match = /^(?:[^@/:\s]+@)?(\[[^\]]+\]|[^/:\s]+):/u.exec(remoteUrl);
+  return match?.[1] ?? null;
+}
+
+function readWorktrees(projectPath: string): ProjectWorktree[] {
+  return runGit(projectPath, "worktree", "list", "--porcelain", "-z")
+    .split("\0\0")
+    .filter((record) => record.length > 0)
+    .map(parseWorktree);
+}
+
+function parseWorktree(record: string): ProjectWorktree {
+  const fields = record.split("\0");
+  const pathField = fields.find((field) => field.startsWith("worktree "));
+  if (pathField === undefined) {
+    throw new AlprojectError("filesystem", "Git returned a worktree record without a path");
+  }
+  const path = canonicalizePath(pathField.slice("worktree ".length));
+  const branchField = fields.find((field) => field.startsWith("branch "));
+  return {
+    branch: branchField === undefined ? null : shortBranch(branchField.slice("branch ".length)),
+    name: basename(path),
+    path,
+  };
+}
+
+function shortBranch(branch: string): string {
+  const prefix = "refs/heads/";
+  return branch.startsWith(prefix) ? branch.slice(prefix.length) : branch;
+}
+
+function runGit(projectPath: string, ...args: string[]): string {
+  try {
+    return execFileSync("git", ["-C", projectPath, ...args], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+  } catch (error) {
+    throw new AlprojectError(
+      "filesystem",
+      `Cannot inspect Git project ${projectPath}: ${errorMessage(error)}`,
+      { cause: error },
+    );
+  }
+}

--- a/packages/alproject/src/status.ts
+++ b/packages/alproject/src/status.ts
@@ -27,7 +27,7 @@ export function getProjectStatus(
   registry: Registry,
   inputPath: string,
 ): ProjectDetails {
-  const path = resolveProjectPath(inputPath, config.root);
+  const path = resolveProjectPath(inputPath, config.root.path);
   const project = buildProjectList(config, registry).projects.find(
     (candidate) => candidate.path === path,
   );

--- a/packages/alproject/templates/guide.md
+++ b/packages/alproject/templates/guide.md
@@ -2,6 +2,28 @@
 
 Your project registry.
 
+## Configuration
+
+```json
+{
+  "root": {
+    "path": "~/projects",
+    "portRange": { "first": 8000, "last": 9999 }
+  },
+  "projectParents": [
+    { "path": "~/projects" },
+    {
+      "path": "~/work/projects",
+      "portRange": { "first": 9000, "last": 9999 }
+    }
+  ]
+}
+```
+
+`root.path` stores the registry and resolves relative command paths. `root.portRange` defines the inclusive global port range. `projectParents` defaults to the root path.
+
+An optional parent `portRange` reserves part of the global range for that parent's projects. Parent ranges must be inside the global range and cannot overlap. Parents without a dedicated range share the remaining global ports.
+
 ## Commands
 
 ### `alproject list [--json]`
@@ -25,10 +47,12 @@ Register an existing Git main worktree that is a direct child of an allowed pare
 Use both port options to reserve a range:
 
 ```sh
-alproject register <path> --ports-per-workspace <n> --max-workspaces <n>
+alproject register <path> --ports-per-workspace <n> --max-workspaces <n> [--base-port <n>]
 ```
 
-Both values must be positive integers. `max-workspaces` includes the main worktree. Alproject reserves `ports-per-workspace * max-workspaces` ports and selects the lowest contiguous free block in the configured inclusive range. It considers registry reservations rather than listening processes.
+The sizing values must be positive integers. `max-workspaces` includes the main worktree. Alproject reserves `ports-per-workspace * max-workspaces` ports and selects the lowest contiguous free block available to the project's parent. It considers registry reservations rather than listening processes.
+
+Pass `--base-port` to claim an exact range instead. Registration fails when the claimed range is outside the ports available to the project's parent or overlaps an existing reservation.
 
 To change a registration, unregister it first.
 

--- a/packages/alproject/templates/guide.md
+++ b/packages/alproject/templates/guide.md
@@ -10,6 +10,14 @@ Print every project with its name, main path, parent, status, workspace names, a
 
 Pass `--json` for structured output consumed by tools and agents. The labelled output quotes every filesystem-derived value so control characters cannot create false fields.
 
+### `alproject status <path> [--json]`
+
+Print one discovered or registered project with its canonical main path, status, port allocation, remote host, and Git worktrees. Each worktree includes its name, path, and branch. Missing optional values are explicit.
+
+Relative paths resolve from `root`; absolute paths are accepted directly. Pass the main-worktree path. Linked-worktree paths and paths that are neither discovered nor registered produce an actionable error.
+
+Pass `--json` for structured output. Absent port allocations, remote hosts, and detached-worktree branches are `null`.
+
 ### `alproject register <path>`
 
 Register an existing Git main worktree that is a direct child of an allowed parent. Relative paths resolve from `root`; absolute paths are accepted directly.

--- a/packages/alproject/test/cli.test.ts
+++ b/packages/alproject/test/cli.test.ts
@@ -18,6 +18,12 @@ describe("parseAlprojectArgs", () => {
   it("parses every command and global mode", () => {
     expect(parse(["list"])).toMatchObject({ command: "list" });
     expect(parse(["list", "--json"])).toMatchObject({ command: "list", json: true });
+    expect(parse(["status", "project"])).toMatchObject({ command: "status", path: "project" });
+    expect(parse(["status", "project", "--json"])).toMatchObject({
+      command: "status",
+      json: true,
+      path: "project",
+    });
     expect(parse(["register", "project"])).toMatchObject({
       command: "register",
       path: "project",
@@ -42,6 +48,8 @@ describe("parseAlprojectArgs", () => {
     expect(() => parse(["list", "project"])).toThrow("list does not accept a path");
     expect(() => parse(["register"])).toThrow("register requires exactly one path");
     expect(() => parse(["register", "one", "two"])).toThrow("register requires exactly one path");
+    expect(() => parse(["status"])).toThrow("status requires exactly one path");
+    expect(() => parse(["status", "one", "two"])).toThrow("status requires exactly one path");
     expect(() => parse(["unregister"])).toThrow("unregister requires exactly one path");
     expect(() => parse(["unregister", "one", "two"])).toThrow(
       "unregister requires exactly one path",
@@ -72,8 +80,8 @@ describe("parseAlprojectArgs", () => {
     expect(() => parse(["--guide", "--ports-per-workspace", "2"])).toThrow(
       /does not accept command options/,
     );
-    expect(() => parse(["register", "project", "--json"])).toThrow(/only with list/);
-    expect(() => parse(["--json"])).toThrow(/only with list/);
+    expect(() => parse(["register", "project", "--json"])).toThrow(/only with list or status/);
+    expect(() => parse(["--json"])).toThrow(/only with list or status/);
   });
 });
 
@@ -82,6 +90,7 @@ describe("main", () => {
     const stdout = makeSink();
     expect(await run([], { stdout })).toBe(0);
     expect(stdout.text()).toContain("alproject register <path>");
+    expect(stdout.text()).toContain("alproject status <path> [--json]");
     expect(stdout.text()).toContain("alproject --guide");
   });
 
@@ -184,6 +193,47 @@ describe("main", () => {
       path: project,
       status: "unregistered",
     });
+  });
+
+  it("prints human and JSON project status", async () => {
+    const fixture = makeFixture();
+    const project = makeRepository(fixture.root, "project");
+    expect(await run(["register", "project"], { home: fixture.home, stdout: makeSink() })).toBe(0);
+
+    const labelledOutput = makeSink();
+    expect(await run(["status", "project"], { home: fixture.home, stdout: labelledOutput })).toBe(
+      0,
+    );
+    expect(labelledOutput.text()).toContain(`  Main path: ${JSON.stringify(project)}`);
+    expect(labelledOutput.text()).toContain("  Status: registered");
+    expect(labelledOutput.text()).toContain("  Remote host: (none)");
+    expect(labelledOutput.text()).toContain("  Port allocation: (none)");
+    expect(labelledOutput.text()).toContain('  - Name: "project"');
+    expect(labelledOutput.text()).toContain('    Branch: "main"');
+
+    const jsonOutput = makeSink();
+    expect(
+      await run(["status", project, "--json"], { home: fixture.home, stdout: jsonOutput }),
+    ).toBe(0);
+    expect(JSON.parse(jsonOutput.text())).toMatchObject({
+      name: "project",
+      path: project,
+      ports: null,
+      remoteHost: null,
+      status: "registered",
+      worktrees: [{ branch: "main", name: "project", path: project }],
+    });
+  });
+
+  it("writes an actionable status lookup failure only to stderr", async () => {
+    const fixture = makeFixture();
+    mkdirSync(join(fixture.root, "directory"));
+    const stdout = makeSink();
+    const stderr = makeSink();
+
+    expect(await run(["status", "directory"], { home: fixture.home, stderr, stdout })).toBe(1);
+    expect(stdout.text()).toBe("");
+    expect(stderr.text()).toMatch(/neither registered nor discovered.*main-worktree path/);
   });
 
   it("reports duplicate and exhaustion errors only to stderr", async () => {

--- a/packages/alproject/test/cli.test.ts
+++ b/packages/alproject/test/cli.test.ts
@@ -63,6 +63,9 @@ describe("parseAlprojectArgs", () => {
     expect(() => parse(["register", "project", "--ports-per-workspace", "2"])).toThrow(
       /provided together/,
     );
+    expect(() => parse(["register", "project", "--base-port", "8000"])).toThrow(
+      /requires --ports-per-workspace and --max-workspaces/,
+    );
     expect(() =>
       parse(["register", "project", "--ports-per-workspace", "0", "--max-workspaces", "2"]),
     ).toThrow(/positive integer/);
@@ -70,8 +73,17 @@ describe("parseAlprojectArgs", () => {
       /only with register/,
     );
     expect(
-      parse(["register", "project", "--ports-per-workspace", "5", "--max-workspaces", "3"]),
-    ).toMatchObject({ maxWorkspaces: 3, portsPerWorkspace: 5 });
+      parse([
+        "register",
+        "project",
+        "--ports-per-workspace",
+        "5",
+        "--max-workspaces",
+        "3",
+        "--base-port",
+        "8100",
+      ]),
+    ).toMatchObject({ basePort: 8100, maxWorkspaces: 3, portsPerWorkspace: 5 });
   });
 
   it("rejects invalid global-mode combinations", () => {
@@ -90,6 +102,7 @@ describe("main", () => {
     const stdout = makeSink();
     expect(await run([], { stdout })).toBe(0);
     expect(stdout.text()).toContain("alproject register <path>");
+    expect(stdout.text()).toContain("--base-port <n>");
     expect(stdout.text()).toContain("alproject status <path> [--json]");
     expect(stdout.text()).toContain("alproject --guide");
   });
@@ -158,13 +171,22 @@ describe("main", () => {
     const project = makeRepository(fixture.root, "project");
     const registerOutput = makeSink();
     expect(
-      await run(["register", "project", "--ports-per-workspace", "5", "--max-workspaces", "2"], {
-        home: fixture.home,
-        stdout: registerOutput,
-      }),
+      await run(
+        [
+          "register",
+          "project",
+          "--ports-per-workspace",
+          "5",
+          "--max-workspaces",
+          "2",
+          "--base-port",
+          "8010",
+        ],
+        { home: fixture.home, stdout: registerOutput },
+      ),
     ).toBe(0);
     expect(registerOutput.text()).toBe(
-      `Registered project: ${JSON.stringify(project)}\nBase port: 8000\nPort range: 8000..8009\n`,
+      `Registered project: ${JSON.stringify(project)}\nBase port: 8010\nPort range: 8010..8019\n`,
     );
 
     const listOutput = makeSink();
@@ -174,8 +196,8 @@ describe("main", () => {
     expect(listOutput.text()).toContain(`  Parent: ${JSON.stringify(fixture.root)}`);
     expect(listOutput.text()).toContain("  Status: registered");
     expect(listOutput.text()).toContain("  Workspaces: (none)");
-    expect(listOutput.text()).toContain("  Base port: 8000");
-    expect(listOutput.text()).toContain("  Port range: 8000..8009");
+    expect(listOutput.text()).toContain("  Base port: 8010");
+    expect(listOutput.text()).toContain("  Port range: 8010..8019");
 
     const unregisterOutput = makeSink();
     expect(
@@ -348,7 +370,7 @@ function makeFixture(firstPort = 8000, lastPort = 8999): Fixture {
   mkdirSync(root);
   writeFileSync(
     join(home, ".alproject.json"),
-    `${JSON.stringify({ firstPort, lastPort, root })}\n`,
+    `${JSON.stringify({ root: { path: root, portRange: { first: firstPort, last: lastPort } } })}\n`,
   );
   return { home, root };
 }

--- a/packages/alproject/test/config.test.ts
+++ b/packages/alproject/test/config.test.ts
@@ -4,14 +4,14 @@ import { join } from "node:path";
 
 import { afterEach, describe, expect, it } from "vitest";
 
-import { CONFIG_FILENAME, readConfig, readConfigIfPresent } from "../src/config.js";
-import type { AlprojectError } from "../src/errors.js";
 import {
-  canonicalizeParentPaths,
-  canonicalizePath,
-  expandHomePath,
-  normalizeAbsolutePath,
-} from "../src/paths.js";
+  availablePortRanges,
+  CONFIG_FILENAME,
+  readConfig,
+  readConfigIfPresent,
+} from "../src/config.js";
+import type { AlprojectError } from "../src/errors.js";
+import { canonicalizePath, expandHomePath, normalizeAbsolutePath } from "../src/paths.js";
 
 let fixtureDir: string | undefined;
 
@@ -43,29 +43,20 @@ describe("path resolution", () => {
       join(fixture.home, "gone"),
     );
   });
-
-  it("deduplicates canonical parent paths", () => {
-    const fixture = makeFixture();
-    const real = join(fixture.home, "real");
-    const link = join(fixture.home, "link");
-    mkdirSync(real);
-    symlinkSync(real, link);
-
-    expect(canonicalizeParentPaths([real, link, real], fixture.home)).toEqual([realpathSync(real)]);
-  });
 });
 
 describe("readConfig", () => {
   it("loads an omitted projectParents field as the canonical root", () => {
     const fixture = makeFixture();
-    writeConfig(fixture, { firstPort: 8000, lastPort: 9999, root: "~/root" });
+    writeConfig(fixture, configuredRoot("~/root", 8000, 9999));
 
     expect(readConfig(fixture.home)).toEqual({
       configPath: join(fixture.home, CONFIG_FILENAME),
-      firstPort: 8000,
-      lastPort: 9999,
-      projectParents: [realpathSync(fixture.root)],
-      root: realpathSync(fixture.root),
+      projectParents: [{ path: realpathSync(fixture.root) }],
+      root: {
+        path: realpathSync(fixture.root),
+        portRange: { first: 8000, last: 9999 },
+      },
     });
   });
 
@@ -74,31 +65,49 @@ describe("readConfig", () => {
     const otherParent = join(fixture.home, "other");
     mkdirSync(otherParent);
     writeConfig(fixture, {
-      firstPort: 1,
-      lastPort: 65535,
-      projectParents: ["~/other"],
-      root: "~/root",
+      projectParents: [{ path: "~/other" }],
+      ...configuredRoot("~/root", 1, 65535),
     });
 
     const config = readConfig(fixture.home);
-    expect(config.projectParents).toEqual([realpathSync(otherParent)]);
-    expect(config.projectParents).not.toContain(config.root);
+    expect(config.projectParents).toEqual([{ path: realpathSync(otherParent) }]);
+    expect(config.projectParents.map((parent) => parent.path)).not.toContain(config.root.path);
   });
 
-  it("canonicalizes and deduplicates explicit parents", () => {
+  it("rejects canonically duplicate explicit parents", () => {
     const fixture = makeFixture();
     const linkedRoot = join(fixture.home, "linked-root");
     symlinkSync(fixture.root, linkedRoot);
     writeConfig(fixture, {
-      firstPort: 8000,
-      lastPort: 9000,
-      projectParents: ["~/root", "~/linked-root", "~/root/../root"],
-      root: "~/linked-root",
+      projectParents: [{ path: "~/root" }, { path: "~/linked-root" }, { path: "~/root/../root" }],
+      ...configuredRoot("~/linked-root"),
+    });
+
+    expect(() => readConfig(fixture.home)).toThrow(/duplicate project parent/);
+  });
+
+  it("reserves non-overlapping parent port ranges from the shared root range", () => {
+    const fixture = makeFixture();
+    const dedicated = join(fixture.home, "dedicated");
+    const shared = join(fixture.home, "shared");
+    mkdirSync(dedicated);
+    mkdirSync(shared);
+    writeConfig(fixture, {
+      projectParents: [
+        { path: dedicated, portRange: { first: 8200, last: 8299 } },
+        { path: shared },
+      ],
+      ...configuredRoot("~/root", 8000, 8999),
     });
 
     const config = readConfig(fixture.home);
-    expect(config.root).toBe(realpathSync(fixture.root));
-    expect(config.projectParents).toEqual([realpathSync(fixture.root)]);
+    expect(availablePortRanges(config, join(dedicated, "project"))).toEqual([
+      { first: 8200, last: 8299 },
+    ]);
+    expect(availablePortRanges(config, join(shared, "project"))).toEqual([
+      { first: 8000, last: 8199 },
+      { first: 8300, last: 8999 },
+    ]);
   });
 
   it("reports a missing configuration with its path", () => {
@@ -118,24 +127,30 @@ describe("readConfig", () => {
   });
 
   it.each([
-    ["missing root", { firstPort: 8000, lastPort: 9000 }],
-    ["missing first port", { lastPort: 9000, root: "~/root" }],
-    ["missing last port", { firstPort: 8000, root: "~/root" }],
-    ["unknown field", { extra: true, firstPort: 8000, lastPort: 9000, root: "~/root" }],
-    ["empty root", { firstPort: 8000, lastPort: 9000, root: "" }],
-    ["non-string root", { firstPort: 8000, lastPort: 9000, root: 42 }],
-    ["empty parents", { firstPort: 8000, lastPort: 9000, projectParents: [], root: "~/root" }],
-    ["empty parent", { firstPort: 8000, lastPort: 9000, projectParents: [""], root: "~/root" }],
+    ["missing root", {}],
+    ["string root", { root: "~/root" }],
+    ["unknown field", { extra: true, ...configuredRoot("~/root") }],
+    ["empty root path", configuredRoot("")],
+    ["non-string root path", configuredRoot(42)],
+    ["empty parents", { projectParents: [], ...configuredRoot("~/root") }],
+    ["empty parent path", { projectParents: [{ path: "" }], ...configuredRoot("~/root") }],
+    ["string parent", { projectParents: ["~/root"], ...configuredRoot("~/root") }],
+    ["non-array parents", { projectParents: "~/root", ...configuredRoot("~/root") }],
     [
-      "non-array parents",
-      { firstPort: 8000, lastPort: 9000, projectParents: "~/root", root: "~/root" },
+      "partial parent range",
+      {
+        projectParents: [{ path: "~/root", portRange: { first: 8000 } }],
+        ...configuredRoot("~/root"),
+      },
     ],
-    ["non-number first port", { firstPort: "8000", lastPort: 9000, root: "~/root" }],
-    ["non-integer first port", { firstPort: 8000.5, lastPort: 9000, root: "~/root" }],
-    ["first port below range", { firstPort: 0, lastPort: 9000, root: "~/root" }],
-    ["non-integer last port", { firstPort: 8000, lastPort: 9000.5, root: "~/root" }],
-    ["last port above range", { firstPort: 8000, lastPort: 65536, root: "~/root" }],
-    ["reversed ports", { firstPort: 9000, lastPort: 8000, root: "~/root" }],
+    ["missing first port", configuredRange({ last: 9000 })],
+    ["missing last port", configuredRange({ first: 8000 })],
+    ["non-number first port", configuredRange({ first: "8000", last: 9000 })],
+    ["non-integer first port", configuredRange({ first: 8000.5, last: 9000 })],
+    ["first port below range", configuredRange({ first: 0, last: 9000 })],
+    ["non-integer last port", configuredRange({ first: 8000, last: 9000.5 })],
+    ["last port above range", configuredRange({ first: 8000, last: 65536 })],
+    ["reversed ports", configuredRange({ first: 9000, last: 8000 })],
   ])("rejects %s", (_label, value) => {
     const fixture = makeFixture();
     writeConfig(fixture, value);
@@ -144,20 +159,18 @@ describe("readConfig", () => {
 
   it("rejects relative configured paths", () => {
     const fixture = makeFixture();
-    writeConfig(fixture, { firstPort: 8000, lastPort: 9000, root: "root" });
-    expect(() => readConfig(fixture.home)).toThrow(/root: Path must be absolute/);
+    writeConfig(fixture, configuredRoot("root"));
+    expect(() => readConfig(fixture.home)).toThrow(/root\.path: Path must be absolute/);
   });
 
   it.each(["root", "parent"])("rejects a missing %s directory", (missingField) => {
     const fixture = makeFixture();
     const value =
       missingField === "root"
-        ? { firstPort: 8000, lastPort: 9000, root: "~/missing" }
+        ? configuredRoot("~/missing")
         : {
-            firstPort: 8000,
-            lastPort: 9000,
-            projectParents: ["~/missing"],
-            root: "~/root",
+            projectParents: [{ path: "~/missing" }],
+            ...configuredRoot("~/root"),
           };
     writeConfig(fixture, value);
     expect(() => readConfig(fixture.home)).toThrow(/directory is missing or inaccessible/);
@@ -167,8 +180,34 @@ describe("readConfig", () => {
     const fixture = makeFixture();
     const filePath = join(fixture.home, "file");
     writeFileSync(filePath, "not a directory");
-    writeConfig(fixture, { firstPort: 8000, lastPort: 9000, root: filePath });
+    writeConfig(fixture, configuredRoot(filePath));
     expect(() => readConfig(fixture.home)).toThrow(/path is not a directory/);
+  });
+
+  it.each([
+    ["outside root", { first: 7000, last: 8000 }, { first: 8000, last: 9000 }],
+    ["reversed", { first: 8500, last: 8400 }, { first: 8000, last: 9000 }],
+  ])("rejects a parent port range %s", (_label, portRange, rootRange) => {
+    const fixture = makeFixture();
+    writeConfig(fixture, {
+      projectParents: [{ path: "~/root", portRange }],
+      root: { path: "~/root", portRange: rootRange },
+    });
+    expect(() => readConfig(fixture.home)).toThrow(/Invalid configuration/);
+  });
+
+  it("rejects overlapping parent port ranges", () => {
+    const fixture = makeFixture();
+    const other = join(fixture.home, "other");
+    mkdirSync(other);
+    writeConfig(fixture, {
+      projectParents: [
+        { path: "~/root", portRange: { first: 8100, last: 8200 } },
+        { path: other, portRange: { first: 8200, last: 8300 } },
+      ],
+      ...configuredRoot("~/root"),
+    });
+    expect(() => readConfig(fixture.home)).toThrow(/port ranges overlap/);
   });
 });
 
@@ -202,4 +241,12 @@ function makeFixture(): Fixture {
 
 function writeConfig(fixture: Fixture, value: object): void {
   writeFileSync(join(fixture.home, CONFIG_FILENAME), JSON.stringify(value));
+}
+
+function configuredRoot(path: unknown, first = 8000, last = 9000): object {
+  return { root: { path, portRange: { first, last } } };
+}
+
+function configuredRange(portRange: object): object {
+  return { root: { path: "~/root", portRange } };
 }

--- a/packages/alproject/test/discovery.test.ts
+++ b/packages/alproject/test/discovery.test.ts
@@ -203,10 +203,10 @@ function makeFixture(parentOrder = ["parentA", "parentB"]): Fixture {
   return {
     config: {
       configPath: join(fixtureDir, ".alproject.json"),
-      firstPort: 8000,
-      lastPort: 9000,
-      projectParents: parentOrder.map((name) => parents[name as keyof typeof parents]),
-      root,
+      projectParents: parentOrder.map((name) => ({
+        path: parents[name as keyof typeof parents],
+      })),
+      root: { path: root, portRange: { first: 8000, last: 9000 } },
     },
     parentA,
     parentB,

--- a/packages/alproject/test/guide.test.ts
+++ b/packages/alproject/test/guide.test.ts
@@ -29,8 +29,11 @@ describe("renderGuide", () => {
       "alproject register <path>",
       "alproject unregister <path>",
       "--ports-per-workspace",
+      "--base-port",
       "does not delete",
+      "projectParents",
       "remote host",
+      "root.portRange",
     ]) {
       expect(guide).toContain(content);
     }

--- a/packages/alproject/test/guide.test.ts
+++ b/packages/alproject/test/guide.test.ts
@@ -24,11 +24,13 @@ describe("renderGuide", () => {
     expect(guide).toMatch(/^# alproject guide\n/);
     for (const content of [
       "alproject list",
+      "alproject status <path>",
       "--json",
       "alproject register <path>",
       "alproject unregister <path>",
       "--ports-per-workspace",
       "does not delete",
+      "remote host",
     ]) {
       expect(guide).toContain(content);
     }

--- a/packages/alproject/test/mutations.test.ts
+++ b/packages/alproject/test/mutations.test.ts
@@ -72,6 +72,9 @@ describe("registerProject", () => {
     await expect(
       registerProject(fixture.config, project, { maxWorkspaces: 2, portsPerWorkspace: 0 }),
     ).rejects.toThrow(/positive integer/);
+    await expect(registerProject(fixture.config, project, { basePort: 8000 })).rejects.toThrow(
+      /requires portsPerWorkspace and maxWorkspaces/,
+    );
     expect(existsSync(registryPath(fixture.config))).toBe(false);
   });
 
@@ -90,6 +93,42 @@ describe("registerProject", () => {
     expect((await registerProject(fixture.config, b, options)).ports?.basePort).toBe(8010);
     await unregisterProject(fixture.config, a);
     expect((await registerProject(fixture.config, c, options)).ports?.basePort).toBe(8000);
+  });
+
+  it("claims an exact available base port and preserves the registry on conflicts", async () => {
+    const fixture = makeFixture(8000, 8029);
+    const a = makeProject(fixture.root, "a");
+    const b = makeProject(fixture.root, "b");
+    const options = { basePort: 8010, maxWorkspaces: 2, portsPerWorkspace: 5 };
+
+    expect((await registerProject(fixture.config, a, options)).ports).toEqual({
+      basePort: 8010,
+      endPort: 8019,
+      maxWorkspaces: 2,
+      portsPerWorkspace: 5,
+    });
+    const before = readFileSync(registryPath(fixture.config), "utf8");
+    await expect(registerProject(fixture.config, b, options)).rejects.toThrow(/not available/);
+    expect(readFileSync(registryPath(fixture.config), "utf8")).toBe(before);
+  });
+
+  it("reserves dedicated parent ranges from the shared allocation pool", async () => {
+    const fixture = makeFixture(8000, 8029);
+    fixture.config.projectParents[1].portRange = { first: 8010, last: 8019 };
+    const sharedA = makeProject(fixture.root, "shared-a");
+    const sharedB = makeProject(fixture.root, "shared-b");
+    const dedicated = makeProject(fixture.parent, "dedicated");
+    const options = { maxWorkspaces: 2, portsPerWorkspace: 5 };
+
+    await expect(
+      registerProject(fixture.config, sharedA, { basePort: 8010, ...options }),
+    ).rejects.toThrow(/outside/);
+    await expect(
+      registerProject(fixture.config, dedicated, { basePort: 8000, ...options }),
+    ).rejects.toThrow(/outside/);
+    expect((await registerProject(fixture.config, sharedA, options)).ports?.basePort).toBe(8000);
+    expect((await registerProject(fixture.config, sharedB, options)).ports?.basePort).toBe(8020);
+    expect((await registerProject(fixture.config, dedicated, options)).ports?.basePort).toBe(8010);
   });
 
   it("uses registry reservations only and preserves an exhausted registry", async () => {
@@ -248,10 +287,8 @@ function makeFixture(firstPort = 8000, lastPort = 9000): Fixture {
   return {
     config: {
       configPath: join(fixtureDir, ".alproject.json"),
-      firstPort,
-      lastPort,
-      projectParents: [root, parent],
-      root,
+      projectParents: [{ path: root }, { path: parent }],
+      root: { path: root, portRange: { first: firstPort, last: lastPort } },
     },
     parent,
     root,

--- a/packages/alproject/test/ports.test.ts
+++ b/packages/alproject/test/ports.test.ts
@@ -1,12 +1,17 @@
 import { describe, expect, it } from "vitest";
 
-import { allocateProjectPorts, allocationEnd, projectPortCount } from "../src/ports.js";
+import {
+  allocateProjectPorts,
+  allocationEnd,
+  claimProjectPorts,
+  projectPortCount,
+} from "../src/ports.js";
 import type { ProjectEntry } from "../src/registry.js";
 
 describe("project port allocation", () => {
   it("allocates the lowest free range independent of registry order", () => {
     const projects = [allocated("/c", 8040, 10), allocated("/a", 8000, 20)];
-    expect(allocateProjectPorts(projects, request(10), 8000, 8099)).toEqual({
+    expect(allocateProjectPorts(projects, request(10), [range(8000, 8099)])).toEqual({
       basePort: 8020,
       maxWorkspaces: 2,
       portsPerWorkspace: 5,
@@ -14,22 +19,42 @@ describe("project port allocation", () => {
   });
 
   it("fits exactly at both inclusive boundaries", () => {
-    expect(allocateProjectPorts([], request(10), 8000, 8009).basePort).toBe(8000);
+    expect(allocateProjectPorts([], request(10), [range(8000, 8009)]).basePort).toBe(8000);
     expect(
-      allocateProjectPorts([allocated("/a", 8000, 10)], request(10), 8000, 8019).basePort,
+      allocateProjectPorts([allocated("/a", 8000, 10)], request(10), [range(8000, 8019)]).basePort,
     ).toBe(8010);
   });
 
   it("ignores portless registry entries", () => {
-    expect(allocateProjectPorts([{ path: "/portless" }], request(10), 8000, 8009).basePort).toBe(
-      8000,
-    );
+    expect(
+      allocateProjectPorts([{ path: "/portless" }], request(10), [range(8000, 8009)]).basePort,
+    ).toBe(8000);
   });
 
   it("reports exhaustion without returning an overlapping range", () => {
-    expect(() => allocateProjectPorts([allocated("/a", 8000, 10)], request(2), 8000, 8009)).toThrow(
-      /No contiguous block/,
+    expect(() =>
+      allocateProjectPorts([allocated("/a", 8000, 10)], request(2), [range(8000, 8009)]),
+    ).toThrow(/No contiguous block/);
+  });
+
+  it("allocates across disjoint available ranges", () => {
+    expect(
+      allocateProjectPorts([allocated("/a", 8000, 10)], request(10), [
+        range(8000, 8009),
+        range(9000, 9009),
+      ]).basePort,
+    ).toBe(9000);
+  });
+
+  it("claims an exact available range and rejects conflicts or excluded ranges", () => {
+    const claim = { basePort: 8020, ...request(10) };
+    expect(claimProjectPorts([allocated("/a", 8000, 10)], claim, [range(8000, 8099)])).toEqual(
+      claim,
     );
+    expect(() =>
+      claimProjectPorts([allocated("/a", 8025, 10)], claim, [range(8000, 8099)]),
+    ).toThrow(/not available/);
+    expect(() => claimProjectPorts([], claim, [range(8030, 8099)])).toThrow(/outside/);
   });
 
   it("validates multiplication and inclusive-end arithmetic", () => {
@@ -55,4 +80,8 @@ function allocated(path: string, basePort: number, size: number): ProjectEntry {
 
 function request(size: number) {
   return { maxWorkspaces: 2, portsPerWorkspace: size / 2 };
+}
+
+function range(first: number, last: number) {
+  return { first, last };
 }

--- a/packages/alproject/test/ports.test.ts
+++ b/packages/alproject/test/ports.test.ts
@@ -46,6 +46,12 @@ describe("project port allocation", () => {
     ).toBe(9000);
   });
 
+  it("does not allocate beyond the end of the current available range", () => {
+    expect(() =>
+      allocateProjectPorts([allocated("/later", 9500, 100)], request(500), [range(8000, 8099)]),
+    ).toThrow(/No contiguous block/);
+  });
+
   it("claims an exact available range and rejects conflicts or excluded ranges", () => {
     const claim = { basePort: 8020, ...request(10) };
     expect(claimProjectPorts([allocated("/a", 8000, 10)], claim, [range(8000, 8099)])).toEqual(

--- a/packages/alproject/test/registry.test.ts
+++ b/packages/alproject/test/registry.test.ts
@@ -1,6 +1,6 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 
 import { afterEach, describe, expect, it } from "vitest";
 
@@ -141,6 +141,37 @@ describe("readRegistry", () => {
     expect(readRegistry(fixture.config)).toEqual(registry);
   });
 
+  it("rejects an allocation outside its parent-specific port range", () => {
+    const fixture = makeFixture();
+    const project = makeProject(fixture, "project");
+    fixture.config.projectParents[0].portRange = { first: 8500, last: 8599 };
+    writeRegistry(fixture, {
+      projects: [
+        { path: project, ports: { basePort: 8400, maxWorkspaces: 1, portsPerWorkspace: 10 } },
+      ],
+      version: 1,
+    });
+
+    expect(() => readRegistry(fixture.config)).toThrow(/outside its available parent port range/);
+  });
+
+  it("rejects an existing shared allocation inside another parent's reserved range", () => {
+    const fixture = makeFixture();
+    const project = makeProject(fixture, "project");
+    fixture.config.projectParents.push({
+      path: join(dirname(fixture.root), "dedicated"),
+      portRange: { first: 8500, last: 8599 },
+    });
+    writeRegistry(fixture, {
+      projects: [
+        { path: project, ports: { basePort: 8500, maxWorkspaces: 1, portsPerWorkspace: 10 } },
+      ],
+      version: 1,
+    });
+
+    expect(() => readRegistry(fixture.config)).toThrow(/outside its available parent port range/);
+  });
+
   it("rejects overlapping and duplicate port reservations", () => {
     const fixture = makeFixture();
     const projectA = makeProject(fixture, "a");
@@ -189,10 +220,8 @@ function makeFixture(): Fixture {
   return {
     config: {
       configPath: join(fixtureDir, ".alproject.json"),
-      firstPort: 8000,
-      lastPort: 9000,
-      projectParents: [root],
-      root,
+      projectParents: [{ path: root }],
+      root: { path: root, portRange: { first: 8000, last: 9000 } },
     },
     root,
   };

--- a/packages/alproject/test/status.test.ts
+++ b/packages/alproject/test/status.test.ts
@@ -1,0 +1,148 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { AlprojectConfig } from "../src/config.js";
+import type { Registry } from "../src/registry.js";
+import { getProjectStatus } from "../src/status.js";
+
+let fixtureDir: string | undefined;
+
+afterEach(() => {
+  if (fixtureDir !== undefined) rmSync(fixtureDir, { force: true, recursive: true });
+  fixtureDir = undefined;
+});
+
+describe("getProjectStatus", () => {
+  it("reports registration, ports, the preferred remote host, and every worktree", () => {
+    const fixture = makeFixture();
+    const project = makeRepository(fixture.root, "project");
+    const workspace = join(fixture.root, "project-workspace");
+    execGit(project, "worktree", "add", "--quiet", "-b", "feature", workspace);
+    execGit(project, "remote", "add", "backup", "https://gitlab.com/team/project.git");
+    execGit(project, "remote", "add", "origin", "git@github.com:team/project.git");
+    const registry: Registry = {
+      projects: [
+        {
+          path: project,
+          ports: { basePort: 8000, maxWorkspaces: 3, portsPerWorkspace: 4 },
+        },
+      ],
+      version: 1,
+    };
+
+    expect(getProjectStatus(fixture.config, registry, "project")).toEqual({
+      name: "project",
+      path: project,
+      ports: { basePort: 8000, endPort: 8011, maxWorkspaces: 3, portsPerWorkspace: 4 },
+      remoteHost: "github.com",
+      status: "registered",
+      worktrees: [
+        { branch: "main", name: "project", path: project },
+        {
+          branch: "feature",
+          name: "project-workspace",
+          path: realpathSync(workspace),
+        },
+      ],
+    });
+  });
+
+  it("reports explicit absent values for an unregistered project", () => {
+    const fixture = makeFixture();
+    const project = makeRepository(fixture.root, "project");
+
+    expect(getProjectStatus(fixture.config, emptyRegistry(), project)).toEqual({
+      name: "project",
+      path: project,
+      ports: null,
+      remoteHost: null,
+      status: "unregistered",
+      worktrees: [{ branch: "main", name: "project", path: project }],
+    });
+  });
+
+  it("falls back to another remote with a recognizable host", () => {
+    const fixture = makeFixture();
+    const project = makeRepository(fixture.root, "project");
+    execGit(project, "remote", "add", "origin", join(fixture.root, "local.git"));
+    execGit(project, "remote", "add", "backup", "ssh://git@gitlab.com/team/project.git");
+
+    expect(getProjectStatus(fixture.config, emptyRegistry(), project).remoteHost).toBe(
+      "gitlab.com",
+    );
+  });
+
+  it("reports a registered project missing from the filesystem", () => {
+    const fixture = makeFixture();
+    const project = join(fixture.root, "missing");
+    const registry: Registry = { projects: [{ path: project }], version: 1 };
+
+    expect(getProjectStatus(fixture.config, registry, "missing")).toEqual({
+      name: "missing",
+      path: project,
+      ports: null,
+      remoteHost: null,
+      status: "missing",
+      worktrees: [],
+    });
+  });
+
+  it("rejects unknown and linked-worktree paths with main-worktree guidance", () => {
+    const fixture = makeFixture();
+    const project = makeRepository(fixture.root, "project");
+    const workspace = join(fixture.root, "workspace");
+    execGit(project, "worktree", "add", "--quiet", "-b", "feature", workspace);
+    mkdirSync(join(fixture.root, "directory"));
+
+    expect(() => getProjectStatus(fixture.config, emptyRegistry(), "directory")).toThrow(
+      /canonical main-worktree path/,
+    );
+    expect(() => getProjectStatus(fixture.config, emptyRegistry(), workspace)).toThrow(
+      /canonical main-worktree path/,
+    );
+  });
+});
+
+interface Fixture {
+  config: AlprojectConfig;
+  root: string;
+}
+
+function makeFixture(): Fixture {
+  fixtureDir = mkdtempSync(join(tmpdir(), "alproject-status-"));
+  const root = join(fixtureDir, "root");
+  mkdirSync(root);
+  return {
+    config: {
+      configPath: join(fixtureDir, ".alproject.json"),
+      firstPort: 8000,
+      lastPort: 9000,
+      projectParents: [root],
+      root,
+    },
+    root,
+  };
+}
+
+function makeRepository(parent: string, name: string): string {
+  const repository = join(parent, name);
+  execGit(parent, "init", "--quiet", "--initial-branch=main", repository);
+  execGit(repository, "config", "user.name", "Test");
+  execGit(repository, "config", "user.email", "test@example.com");
+  writeFileSync(join(repository, "README.md"), `${name}\n`);
+  execGit(repository, "add", "README.md");
+  execGit(repository, "commit", "--quiet", "-m", "initial");
+  return realpathSync(repository);
+}
+
+function emptyRegistry(): Registry {
+  return { projects: [], version: 1 };
+}
+
+function execGit(cwd: string, ...args: string[]): string {
+  return execFileSync("git", ["-C", cwd, ...args], { encoding: "utf8" }).trim();
+}

--- a/packages/alproject/test/status.test.ts
+++ b/packages/alproject/test/status.test.ts
@@ -139,10 +139,8 @@ function makeFixture(): Fixture {
   return {
     config: {
       configPath: join(fixtureDir, ".alproject.json"),
-      firstPort: 8000,
-      lastPort: 9000,
-      projectParents: [root],
-      root,
+      projectParents: [{ path: root }],
+      root: { path: root, portRange: { first: 8000, last: 9000 } },
     },
     root,
   };

--- a/packages/alproject/test/status.test.ts
+++ b/packages/alproject/test/status.test.ts
@@ -76,6 +76,17 @@ describe("getProjectStatus", () => {
     );
   });
 
+  it("does not treat a hostless URL scheme as an SCP host", () => {
+    const fixture = makeFixture();
+    const project = makeRepository(fixture.root, "project");
+    execGit(project, "remote", "add", "origin", "file:///srv/project.git");
+    execGit(project, "remote", "add", "backup", "https://gitlab.com/team/project.git");
+
+    expect(getProjectStatus(fixture.config, emptyRegistry(), project).remoteHost).toBe(
+      "gitlab.com",
+    );
+  });
+
   it("reads a remote whose name starts with a hyphen", () => {
     const fixture = makeFixture();
     const project = makeRepository(fixture.root, "project");
@@ -109,6 +120,35 @@ describe("getProjectStatus", () => {
       status: "missing",
       worktrees: [],
     });
+  });
+
+  it("inspects a registered project whose parent is no longer configured", () => {
+    const fixture = makeFixture();
+    const project = makeRepository(fixture.root, "project");
+    const configuredParent = join(fixture.root, "other-parent");
+    mkdirSync(configuredParent);
+    fixture.config.projectParents = [{ path: configuredParent }];
+    execGit(project, "remote", "add", "origin", "https://github.com/team/project.git");
+    const registry: Registry = { projects: [{ path: project }], version: 1 };
+
+    expect(getProjectStatus(fixture.config, registry, project)).toMatchObject({
+      path: project,
+      remoteHost: "github.com",
+      status: "registered",
+      worktrees: [{ branch: "main", name: "project", path: project }],
+    });
+  });
+
+  it("rejects an unregistered project outside configured parents", () => {
+    const fixture = makeFixture();
+    const project = makeRepository(fixture.root, "project");
+    const configuredParent = join(fixture.root, "other-parent");
+    mkdirSync(configuredParent);
+    fixture.config.projectParents = [{ path: configuredParent }];
+
+    expect(() => getProjectStatus(fixture.config, emptyRegistry(), project)).toThrow(
+      /neither registered nor discovered/,
+    );
   });
 
   it("rejects unknown and linked-worktree paths with main-worktree guidance", () => {

--- a/packages/alproject/test/status.test.ts
+++ b/packages/alproject/test/status.test.ts
@@ -76,6 +76,26 @@ describe("getProjectStatus", () => {
     );
   });
 
+  it("reads a remote whose name starts with a hyphen", () => {
+    const fixture = makeFixture();
+    const project = makeRepository(fixture.root, "project");
+    execGit(project, "remote", "add", "--", "--push", "https://github.com/team/project.git");
+
+    expect(getProjectStatus(fixture.config, emptyRegistry(), project).remoteHost).toBe(
+      "github.com",
+    );
+  });
+
+  it("reads the host from SCP syntax without a user", () => {
+    const fixture = makeFixture();
+    const project = makeRepository(fixture.root, "project");
+    execGit(project, "remote", "add", "origin", "github.com:team/project.git");
+
+    expect(getProjectStatus(fixture.config, emptyRegistry(), project).remoteHost).toBe(
+      "github.com",
+    );
+  });
+
   it("reports a registered project missing from the filesystem", () => {
     const fixture = makeFixture();
     const project = join(fixture.root, "missing");


### PR DESCRIPTION
- Adds `alproject status <path>` with human-readable and JSON project details, including registration and filesystem status, port allocation, preferred remote host, and Git worktrees.
- Adds exact `--base-port` claims that fail when the requested range is unavailable.
- Adds object-based configuration with optional parent-specific port ranges reserved from the global pool.

Updates command help, README, and the agent guide.