### PR TITLE
feat: allow external base-port allocations

### DIFF
--- a/.changeset/allow-outside-port-range.md
+++ b/.changeset/allow-outside-port-range.md
@@ -1,5 +1,5 @@
 ---
-"@paleo/alproject": minor
+"@paleo/alproject": patch
 ---
 
 Added explicit base-port allocations outside configured port ranges.

--- a/.changeset/allow-outside-port-range.md
+++ b/.changeset/allow-outside-port-range.md
@@ -1,0 +1,5 @@
+---
+"@paleo/alproject": minor
+---
+
+Added explicit base-port allocations outside configured port ranges.

--- a/.changeset/allow-outside-port-range.md
+++ b/.changeset/allow-outside-port-range.md
@@ -1,5 +1,5 @@
 ---
-"@paleo/alproject": patch
+"@paleo/alproject": minor
 ---
 
 Added explicit base-port allocations outside configured port ranges.

--- a/packages/alproject/README.md
+++ b/packages/alproject/README.md
@@ -45,11 +45,13 @@ An optional parent `portRange` reserves part of the global range for projects un
 ```text
 alproject list [--json]
 alproject status <path> [--json]
-alproject register <path> [--ports-per-workspace <n> --max-workspaces <n> [--base-port <n>]]
+alproject register <path> [--ports-per-workspace <n> --max-workspaces <n> [--base-port <n> [--allow-outside-port-range]]]
 alproject unregister <path>
 ```
 
 `status` reports one discovered or registered project. It includes the canonical main path, registration and filesystem status, optional port allocation, preferred remote host, and every Git worktree with its path and branch. Relative paths resolve from `root`; absolute paths are accepted directly. Pass the main-worktree path.
+
+Port options reserve `ports-per-workspace * max-workspaces` ports. `--base-port` claims an exact available range. Add `--allow-outside-port-range` to permit that explicit allocation outside the configured root and parent ranges. The complete allocation must remain within ports 1 through 65535 and cannot overlap another registration.
 
 Run `alproject --guide` for the agent-facing operating guide. When `<root>/alproject-guide.md` exists, the command appends it verbatim after the generic guide — use it to describe how the project parents are organized. An unreadable custom guide is an error.
 

--- a/packages/alproject/README.md
+++ b/packages/alproject/README.md
@@ -1,6 +1,6 @@
 # @paleo/alproject
 
-Discover local Git projects, track explicit registrations, and allocate non-overlapping port ranges.
+Local project registry for the AlignFirst developer. Discover local Git projects, track explicit registrations, and allocate non-overlapping port ranges.
 
 ## Installation
 

--- a/packages/alproject/README.md
+++ b/packages/alproject/README.md
@@ -71,4 +71,6 @@ Discrepancies are informational. Listing never changes files or registrations.
 
 Alproject owns `<root>/alproject-registry.json` and its short-lived lock and temporary sibling files. Edit project files and immutable configuration through their own workflows.
 
+The current registry format uses `"schemaVersion": 2`. Alproject reads legacy version-1 registries and rewrites them in the current format on the next registration or unregistration.
+
 Concurrent mutations wait briefly for a live lock and then fail with an actionable error. Retry after the other command finishes. Alproject reclaims locks whose recorded process identity no longer exists. If registry validation fails, correct the reported field or restore a valid registry before retrying. Failed registration, allocation, locking, and writes preserve the previous registry.

--- a/packages/alproject/src/cli.ts
+++ b/packages/alproject/src/cli.ts
@@ -29,6 +29,7 @@ export interface Output {
 }
 
 export interface AlprojectArgs {
+  allowOutsidePortRange: boolean;
   basePort?: number;
   command?: string;
   guide: boolean;
@@ -41,6 +42,7 @@ export interface AlprojectArgs {
 }
 
 interface PortOptionValues {
+  "allow-outside-port-range"?: boolean;
   "base-port"?: string;
   "max-workspaces"?: string;
   "ports-per-workspace"?: string;
@@ -93,6 +95,7 @@ export async function main(options: MainOptions = {}): Promise<number> {
     }
     if (args.command === "register" && args.path !== undefined) {
       const result = await registerProject(config, args.path, {
+        allowOutsidePortRange: args.allowOutsidePortRange,
         basePort: args.basePort,
         maxWorkspaces: args.maxWorkspaces,
         portsPerWorkspace: args.portsPerWorkspace,
@@ -117,6 +120,7 @@ export function parseAlprojectArgs(argv: string[]): AlprojectArgs {
     allowPositionals: true,
     args: argv.slice(2),
     options: {
+      "allow-outside-port-range": { default: false, type: "boolean" },
       "base-port": { type: "string" },
       guide: { default: false, type: "boolean" },
       help: { default: false, short: "h", type: "boolean" },
@@ -141,6 +145,7 @@ export function parseAlprojectArgs(argv: string[]): AlprojectArgs {
       throw new Error(`${selectedModes[0]} does not accept command options`);
     }
     return {
+      allowOutsidePortRange: false,
       guide: values.guide === true,
       help: values.help === true,
       json: false,
@@ -154,7 +159,13 @@ export function parseAlprojectArgs(argv: string[]): AlprojectArgs {
     if (hasPortOptions(values)) {
       throw new Error("Port options are valid only with register");
     }
-    return { guide: false, help: false, json: false, version: false };
+    return {
+      allowOutsidePortRange: false,
+      guide: false,
+      help: false,
+      json: false,
+      version: false,
+    };
   }
   if (!isCommand(command)) throw new Error(`Unknown command: ${command}`);
   validateCommandPaths(command, path, extraPaths);
@@ -168,13 +179,18 @@ export function parseAlprojectArgs(argv: string[]): AlprojectArgs {
   );
   const maxWorkspaces = parsePositiveInteger("--max-workspaces", values["max-workspaces"]);
   const basePort = parsePositiveInteger("--base-port", values["base-port"]);
+  const allowOutsidePortRange = values["allow-outside-port-range"] === true;
   if ((portsPerWorkspace === undefined) !== (maxWorkspaces === undefined)) {
     throw new Error("--ports-per-workspace and --max-workspaces must be provided together");
   }
   if (basePort !== undefined && portsPerWorkspace === undefined) {
     throw new Error("--base-port requires --ports-per-workspace and --max-workspaces");
   }
+  if (allowOutsidePortRange && basePort === undefined) {
+    throw new Error("--allow-outside-port-range requires --base-port");
+  }
   return {
+    allowOutsidePortRange,
     basePort,
     command,
     guide: false,
@@ -189,6 +205,7 @@ export function parseAlprojectArgs(argv: string[]): AlprojectArgs {
 
 function hasPortOptions(values: PortOptionValues): boolean {
   return (
+    values["allow-outside-port-range"] === true ||
     values["base-port"] !== undefined ||
     values["ports-per-workspace"] !== undefined ||
     values["max-workspaces"] !== undefined
@@ -244,13 +261,15 @@ function renderHelp(): string {
 Usage:
   alproject list [--json]
   alproject status <path> [--json]
-  alproject register <path> [--ports-per-workspace <n> --max-workspaces <n> [--base-port <n>]]
+  alproject register <path> [--ports-per-workspace <n> --max-workspaces <n> [--base-port <n> [--allow-outside-port-range]]]
   alproject unregister <path>
 
 Options:
   --guide              Print the complete guide
   -h, --help           Print this help
   --json               Print structured list or status output
+  --allow-outside-port-range
+                       Permit an explicit allocation outside configured ranges
   -v, --version        Print the alproject version
 
 Run \`alproject --guide\` for configuration and operational procedures.

--- a/packages/alproject/src/mutations.ts
+++ b/packages/alproject/src/mutations.ts
@@ -34,6 +34,7 @@ const atomicWriteOperations: AtomicWriteOperations = {
 };
 
 export interface RegistrationOptions {
+  allowOutsidePortRange?: boolean;
   basePort?: number;
   maxWorkspaces?: number;
   portsPerWorkspace?: number;
@@ -45,6 +46,7 @@ export interface RegistrationResult {
 }
 
 export interface RegistrationPorts extends PortRequest {
+  allowOutsidePortRange?: true;
   basePort: number;
   endPort: number;
 }
@@ -76,7 +78,14 @@ export async function registerProject(
     if (registry.projects.some((project) => project.path === path)) {
       throw new AlprojectError("registry", `Project is already registered: ${path}`);
     }
-    const ports = allocateRegistrationPorts(config, registry, path, request, options.basePort);
+    const ports = allocateRegistrationPorts(
+      config,
+      registry,
+      path,
+      request,
+      options.basePort,
+      options.allowOutsidePortRange === true,
+    );
     registry.projects.push(ports === undefined ? { path } : { path, ports });
     return {
       path,
@@ -131,6 +140,9 @@ function assertMainWorktree(path: string): void {
 }
 
 function portRequest(options: RegistrationOptions): PortRequest | undefined {
+  if (options.allowOutsidePortRange === true && options.basePort === undefined) {
+    throw new AlprojectError("registry", "allowOutsidePortRange requires basePort");
+  }
   const hasPortsPerWorkspace = options.portsPerWorkspace !== undefined;
   const hasMaxWorkspaces = options.maxWorkspaces !== undefined;
   if (hasPortsPerWorkspace !== hasMaxWorkspaces) {
@@ -166,13 +178,22 @@ function allocateRegistrationPorts(
   path: string,
   request: PortRequest | undefined,
   basePort: number | undefined,
+  allowOutsidePortRange: boolean,
 ): PortAllocation | undefined {
   if (request === undefined) return;
   const ranges = availablePortRanges(config, path);
   const allocation =
     basePort === undefined
       ? allocateProjectPorts(registry.projects, request, ranges)
-      : claimProjectPorts(registry.projects, { basePort, ...request }, ranges);
+      : claimProjectPorts(
+          registry.projects,
+          {
+            basePort,
+            ...request,
+            ...(allowOutsidePortRange ? { allowOutsidePortRange: true } : {}),
+          },
+          ranges,
+        );
   return allocation;
 }
 

--- a/packages/alproject/src/ports.ts
+++ b/packages/alproject/src/ports.ts
@@ -2,6 +2,8 @@ import { AlprojectError } from "./errors.js";
 import type { PortRange } from "./config.js";
 import type { PortAllocation, ProjectEntry } from "./registry.js";
 
+const MAX_PORT = 65_535;
+
 export interface PortRequest {
   maxWorkspaces: number;
   portsPerWorkspace: number;
@@ -37,7 +39,10 @@ export function claimProjectPorts(
   availableRanges: readonly PortRange[],
 ): PortAllocation {
   const claimedRange = allocationRange(claim);
-  if (!availableRanges.some((range) => containsRange(range, claimedRange))) {
+  if (
+    claim.allowOutsidePortRange !== true &&
+    !availableRanges.some((range) => containsRange(range, claimedRange))
+  ) {
     throw new AlprojectError(
       "registry",
       `Claimed port range ${formatAllocatedRange(claimedRange)} is outside ${formatPortRanges(availableRanges)}`,
@@ -72,7 +77,11 @@ export function allocationEnd(allocation: PortAllocation): number {
   if (allocation.basePort > Number.MAX_SAFE_INTEGER - size + 1) {
     throw new AlprojectError("registry", "Requested port allocation end exceeds safe arithmetic");
   }
-  return allocation.basePort + size - 1;
+  const end = allocation.basePort + size - 1;
+  if (end > MAX_PORT) {
+    throw new AlprojectError("registry", `Requested port allocation exceeds port ${MAX_PORT}`);
+  }
+  return end;
 }
 
 function lowestFreeBase(

--- a/packages/alproject/src/registry.ts
+++ b/packages/alproject/src/registry.ts
@@ -12,6 +12,7 @@ export const REGISTRY_FILENAME = "alproject-registry.json";
 
 const portsSchema = type({
   "+": "reject",
+  "allowOutsidePortRange?": "true",
   basePort: "number.integer >= 1",
   maxWorkspaces: "number.integer >= 1",
   portsPerWorkspace: "number.integer >= 1",
@@ -102,17 +103,11 @@ function portRange(
 ): PortRange {
   const ports = project.ports;
   if (ports === undefined) throw new Error("Port allocation is required");
-  for (const [field, value] of Object.entries(ports)) {
+  for (const field of ["basePort", "maxWorkspaces", "portsPerWorkspace"] as const) {
+    const value = ports[field];
     if (!Number.isSafeInteger(value)) {
       throw registryError(registryFile, `${field} must be a safe integer for ${project.path}`);
     }
-  }
-  const rootRange = config.root.portRange;
-  if (ports.basePort < rootRange.first || ports.basePort > rootRange.last) {
-    throw registryError(
-      registryFile,
-      `basePort for ${project.path} must be within ${rootRange.first}..${rootRange.last}`,
-    );
   }
 
   let end: number;
@@ -121,20 +116,39 @@ function portRange(
   } catch (error) {
     throw registryError(registryFile, errorMessage(error), error);
   }
+  if (ports.allowOutsidePortRange !== true) {
+    validateConfiguredPortRange(ports, project.path, config, registryFile, end);
+  }
+  return { end, path: project.path, start: ports.basePort };
+}
+
+function validateConfiguredPortRange(
+  ports: PortAllocation,
+  projectPath: string,
+  config: AlprojectConfig,
+  registryFile: string,
+  end: number,
+): void {
+  const rootRange = config.root.portRange;
+  if (ports.basePort < rootRange.first || ports.basePort > rootRange.last) {
+    throw registryError(
+      registryFile,
+      `basePort for ${projectPath} must be within ${rootRange.first}..${rootRange.last}`,
+    );
+  }
   if (end > rootRange.last) {
     throw registryError(
       registryFile,
-      `port allocation for ${project.path} exceeds configured range ending at ${rootRange.last}`,
+      `port allocation for ${projectPath} exceeds configured range ending at ${rootRange.last}`,
     );
   }
-  const availableRanges = availablePortRanges(config, project.path);
+  const availableRanges = availablePortRanges(config, projectPath);
   if (!availableRanges.some((range) => ports.basePort >= range.first && end <= range.last)) {
     throw registryError(
       registryFile,
-      `port allocation for ${project.path} is outside its available parent port range`,
+      `port allocation for ${projectPath} is outside its available parent port range`,
     );
   }
-  return { end, path: project.path, start: ports.basePort };
 }
 
 function validateNonOverlappingRanges(ranges: PortRange[], registryFile: string): void {

--- a/packages/alproject/src/registry.ts
+++ b/packages/alproject/src/registry.ts
@@ -10,6 +10,11 @@ import { allocationEnd } from "./ports.js";
 
 export const REGISTRY_FILENAME = "alproject-registry.json";
 
+const integerPortFields = [
+  "basePort",
+  "maxWorkspaces",
+  "portsPerWorkspace",
+] satisfies readonly (keyof PortAllocation)[];
 const portsSchema = type({
   "+": "reject",
   "allowOutsidePortRange?": "true",
@@ -25,7 +30,7 @@ const projectEntrySchema = type({
 const registrySchema = type({
   "+": "reject",
   projects: projectEntrySchema.array(),
-  version: "1",
+  schemaVersion: "2",
 });
 
 export type PortAllocation = typeof portsSchema.infer;
@@ -45,14 +50,26 @@ export function registryPath(config: Pick<AlprojectConfig, "root">): string {
 export function readRegistry(config: AlprojectConfig): Registry {
   const path = registryPath(config);
   const rawRegistry = readRegistryFile(path);
-  if (rawRegistry === undefined) return { projects: [], version: 1 };
+  if (rawRegistry === undefined) return { projects: [], schemaVersion: 2 };
 
-  const registry = registrySchema(rawRegistry);
+  const registry = registrySchema(migrateLegacyRegistry(rawRegistry));
   if (registry instanceof type.errors) {
     throw registryError(path, registry.summary);
   }
   validateRegistry(registry, config, path);
   return registry;
+}
+
+function migrateLegacyRegistry(rawRegistry: unknown): unknown {
+  if (!isRecord(rawRegistry) || rawRegistry.version !== 1 || "schemaVersion" in rawRegistry) {
+    return rawRegistry;
+  }
+  const { version: _version, ...registry } = rawRegistry;
+  return { ...registry, schemaVersion: 2 };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function readRegistryFile(path: string): unknown {
@@ -103,7 +120,7 @@ function portRange(
 ): PortRange {
   const ports = project.ports;
   if (ports === undefined) throw new Error("Port allocation is required");
-  for (const field of ["basePort", "maxWorkspaces", "portsPerWorkspace"] as const) {
+  for (const field of integerPortFields) {
     const value = ports[field];
     if (!Number.isSafeInteger(value)) {
       throw registryError(registryFile, `${field} must be a safe integer for ${project.path}`);

--- a/packages/alproject/templates/guide.md
+++ b/packages/alproject/templates/guide.md
@@ -47,12 +47,14 @@ Register an existing Git main worktree that is a direct child of an allowed pare
 Use both port options to reserve a range:
 
 ```sh
-alproject register <path> --ports-per-workspace <n> --max-workspaces <n> [--base-port <n>]
+alproject register <path> --ports-per-workspace <n> --max-workspaces <n> [--base-port <n> [--allow-outside-port-range]]
 ```
 
 The sizing values must be positive integers. `max-workspaces` includes the main worktree. Alproject reserves `ports-per-workspace * max-workspaces` ports and selects the lowest contiguous free block available to the project's parent. It considers registry reservations rather than listening processes.
 
 Pass `--base-port` to claim an exact range instead. Registration fails when the claimed range is outside the ports available to the project's parent or overlaps an existing reservation.
+
+Add `--allow-outside-port-range` to permit an explicit allocation outside the configured root and parent ranges. The complete allocation must remain within ports 1 through 65535. Existing reservations remain unavailable.
 
 To change a registration, unregister it first.
 

--- a/packages/alproject/test/cli.test.ts
+++ b/packages/alproject/test/cli.test.ts
@@ -82,8 +82,18 @@ describe("parseAlprojectArgs", () => {
         "3",
         "--base-port",
         "8100",
+        "--allow-outside-port-range",
       ]),
-    ).toMatchObject({ basePort: 8100, maxWorkspaces: 3, portsPerWorkspace: 5 });
+    ).toMatchObject({
+      allowOutsidePortRange: true,
+      basePort: 8100,
+      maxWorkspaces: 3,
+      portsPerWorkspace: 5,
+    });
+    expect(() => parse(["register", "project", "--allow-outside-port-range"])).toThrow(
+      /requires --base-port/,
+    );
+    expect(() => parse(["list", "--allow-outside-port-range"])).toThrow(/only with register/);
   });
 
   it("rejects invalid global-mode combinations", () => {
@@ -103,6 +113,7 @@ describe("main", () => {
     expect(await run([], { stdout })).toBe(0);
     expect(stdout.text()).toContain("alproject register <path>");
     expect(stdout.text()).toContain("--base-port <n>");
+    expect(stdout.text()).toContain("--allow-outside-port-range");
     expect(stdout.text()).toContain("alproject status <path> [--json]");
     expect(stdout.text()).toContain("alproject --guide");
   });
@@ -214,6 +225,40 @@ describe("main", () => {
       name: "project",
       path: project,
       status: "unregistered",
+    });
+  });
+
+  it("registers an explicit allocation outside configured ranges", async () => {
+    const fixture = makeFixture(8000, 8009);
+    const project = makeRepository(fixture.root, "external");
+    const stdout = makeSink();
+
+    expect(
+      await run(
+        [
+          "register",
+          "external",
+          "--ports-per-workspace",
+          "5",
+          "--max-workspaces",
+          "2",
+          "--base-port",
+          "9000",
+          "--allow-outside-port-range",
+        ],
+        { home: fixture.home, stdout },
+      ),
+    ).toBe(0);
+    expect(stdout.text()).toContain("Port range: 9000..9009");
+
+    const jsonOutput = makeSink();
+    expect(
+      await run(["status", project, "--json"], { home: fixture.home, stdout: jsonOutput }),
+    ).toBe(0);
+    expect(JSON.parse(jsonOutput.text()).ports).toMatchObject({
+      allowOutsidePortRange: true,
+      basePort: 9000,
+      endPort: 9009,
     });
   });
 

--- a/packages/alproject/test/discovery.test.ts
+++ b/packages/alproject/test/discovery.test.ts
@@ -132,7 +132,7 @@ describe("buildProjectList", () => {
         },
         { path: missing },
       ],
-      version: 1,
+      schemaVersion: 2,
     };
     const registryPath = join(fixture.root, "alproject-registry.json");
     writeFileSync(registryPath, `${JSON.stringify(registry, undefined, 2)}\n`);
@@ -167,7 +167,7 @@ describe("buildProjectList", () => {
   it("reports a moved project as one missing and one unregistered record", () => {
     const fixture = makeFixture();
     const original = makeRepository(fixture.parentA, "original");
-    const registry: Registry = { projects: [{ path: original }], version: 1 };
+    const registry: Registry = { projects: [{ path: original }], schemaVersion: 2 };
     const moved = join(fixture.parentA, "moved");
     renameSync(original, moved);
 

--- a/packages/alproject/test/guide.test.ts
+++ b/packages/alproject/test/guide.test.ts
@@ -30,6 +30,7 @@ describe("renderGuide", () => {
       "alproject unregister <path>",
       "--ports-per-workspace",
       "--base-port",
+      "--allow-outside-port-range",
       "does not delete",
       "projectParents",
       "remote host",

--- a/packages/alproject/test/mutations.test.ts
+++ b/packages/alproject/test/mutations.test.ts
@@ -75,6 +75,9 @@ describe("registerProject", () => {
     await expect(registerProject(fixture.config, project, { basePort: 8000 })).rejects.toThrow(
       /requires portsPerWorkspace and maxWorkspaces/,
     );
+    await expect(
+      registerProject(fixture.config, project, { allowOutsidePortRange: true }),
+    ).rejects.toThrow(/requires basePort/);
     expect(existsSync(registryPath(fixture.config))).toBe(false);
   });
 
@@ -110,6 +113,46 @@ describe("registerProject", () => {
     const before = readFileSync(registryPath(fixture.config), "utf8");
     await expect(registerProject(fixture.config, b, options)).rejects.toThrow(/not available/);
     expect(readFileSync(registryPath(fixture.config), "utf8")).toBe(before);
+  });
+
+  it("claims and persists an exact range outside configured ranges only with an override", async () => {
+    const fixture = makeFixture(8000, 8009);
+    fixture.config.projectParents[1].portRange = { first: 8000, last: 8009 };
+    const project = makeProject(fixture.parent, "external");
+    const request = { basePort: 9000, maxWorkspaces: 2, portsPerWorkspace: 5 };
+
+    await expect(registerProject(fixture.config, project, request)).rejects.toThrow(/outside/);
+    await expect(
+      registerProject(fixture.config, project, {
+        allowOutsidePortRange: true,
+        ...request,
+      }),
+    ).resolves.toEqual({
+      path: project,
+      ports: {
+        allowOutsidePortRange: true,
+        basePort: 9000,
+        endPort: 9009,
+        maxWorkspaces: 2,
+        portsPerWorkspace: 5,
+      },
+    });
+    expect(readRegistry(fixture.config).projects[0].ports?.allowOutsidePortRange).toBe(true);
+  });
+
+  it("keeps overlap checks for allocations outside configured ranges", async () => {
+    const fixture = makeFixture(8000, 8009);
+    const a = makeProject(fixture.root, "a");
+    const b = makeProject(fixture.root, "b");
+    const options = {
+      allowOutsidePortRange: true,
+      basePort: 9000,
+      maxWorkspaces: 1,
+      portsPerWorkspace: 10,
+    };
+
+    await registerProject(fixture.config, a, options);
+    await expect(registerProject(fixture.config, b, options)).rejects.toThrow(/overlaps/);
   });
 
   it("reserves dedicated parent ranges from the shared allocation pool", async () => {

--- a/packages/alproject/test/mutations.test.ts
+++ b/packages/alproject/test/mutations.test.ts
@@ -237,7 +237,24 @@ describe("atomic registry mutation", () => {
 
     const content = readFileSync(registryPath(fixture.config), "utf8");
     expect(content.endsWith("\n")).toBe(true);
-    expect(JSON.parse(content)).toEqual({ projects: [{ path: project }], version: 1 });
+    expect(JSON.parse(content)).toEqual({ projects: [{ path: project }], schemaVersion: 2 });
+  });
+
+  it("rewrites a legacy registry with schema version 2", async () => {
+    const fixture = makeFixture();
+    const legacy = makeProject(fixture.root, "legacy");
+    const project = makeProject(fixture.root, "project");
+    writeFileSync(
+      registryPath(fixture.config),
+      `${JSON.stringify({ projects: [{ path: legacy }], version: 1 })}\n`,
+    );
+
+    await registerProject(fixture.config, project);
+
+    expect(JSON.parse(readFileSync(registryPath(fixture.config), "utf8"))).toEqual({
+      projects: [{ path: legacy }, { path: project }],
+      schemaVersion: 2,
+    });
   });
 
   it("syncs the registry file and its parent directory", async () => {

--- a/packages/alproject/test/ports.test.ts
+++ b/packages/alproject/test/ports.test.ts
@@ -6,7 +6,7 @@ import {
   claimProjectPorts,
   projectPortCount,
 } from "../src/ports.js";
-import type { ProjectEntry } from "../src/registry.js";
+import type { PortAllocation, ProjectEntry } from "../src/registry.js";
 
 describe("project port allocation", () => {
   it("allocates the lowest free range independent of registry order", () => {
@@ -63,6 +63,19 @@ describe("project port allocation", () => {
     expect(() => claimProjectPorts([], claim, [range(8030, 8099)])).toThrow(/outside/);
   });
 
+  it("claims a range outside configured ranges only with an override", () => {
+    const claim: PortAllocation = {
+      allowOutsidePortRange: true,
+      basePort: 9000,
+      ...request(10),
+    };
+
+    expect(claimProjectPorts([], claim, [range(8000, 8099)])).toEqual(claim);
+    expect(() =>
+      claimProjectPorts([allocated("/a", 9005, 10)], claim, [range(8000, 8099)]),
+    ).toThrow(/overlaps/);
+  });
+
   it("validates multiplication and inclusive-end arithmetic", () => {
     expect(() =>
       projectPortCount({ maxWorkspaces: 2, portsPerWorkspace: Number.MAX_SAFE_INTEGER }),
@@ -77,6 +90,9 @@ describe("project port allocation", () => {
     expect(() => projectPortCount({ maxWorkspaces: 0, portsPerWorkspace: 1 })).toThrow(
       /positive integer/,
     );
+    expect(() =>
+      allocationEnd({ basePort: 65_535, maxWorkspaces: 1, portsPerWorkspace: 2 }),
+    ).toThrow(/exceeds port 65535/);
   });
 });
 

--- a/packages/alproject/test/registry.test.ts
+++ b/packages/alproject/test/registry.test.ts
@@ -56,6 +56,23 @@ describe("readRegistry", () => {
     ["non-string project path", { projects: [{ path: 42 }], version: 1 }],
     ["non-object ports", { projects: [{ path: "/project", ports: 42 }], version: 1 }],
     [
+      "false port-range override",
+      {
+        projects: [
+          {
+            path: "/project",
+            ports: {
+              allowOutsidePortRange: false,
+              basePort: 8000,
+              maxWorkspaces: 1,
+              portsPerWorkspace: 1,
+            },
+          },
+        ],
+        version: 1,
+      },
+    ],
+    [
       "unknown port field",
       {
         projects: [
@@ -139,6 +156,50 @@ describe("readRegistry", () => {
     };
     writeRegistry(fixture, registry);
     expect(readRegistry(fixture.config)).toEqual(registry);
+  });
+
+  it("accepts a marked allocation outside configured ranges", () => {
+    const fixture = makeFixture();
+    const project = makeProject(fixture, "external");
+    fixture.config.projectParents[0].portRange = { first: 8500, last: 8599 };
+    const registry = {
+      projects: [
+        {
+          path: project,
+          ports: {
+            allowOutsidePortRange: true,
+            basePort: 9001,
+            maxWorkspaces: 1,
+            portsPerWorkspace: 10,
+          },
+        },
+      ],
+      version: 1,
+    };
+    writeRegistry(fixture, registry);
+
+    expect(readRegistry(fixture.config)).toEqual(registry);
+  });
+
+  it("rejects an override allocation beyond the TCP port range", () => {
+    const fixture = makeFixture();
+    const project = makeProject(fixture, "external");
+    writeRegistry(fixture, {
+      projects: [
+        {
+          path: project,
+          ports: {
+            allowOutsidePortRange: true,
+            basePort: 65_535,
+            maxWorkspaces: 1,
+            portsPerWorkspace: 2,
+          },
+        },
+      ],
+      version: 1,
+    });
+
+    expect(() => readRegistry(fixture.config)).toThrow(/exceeds port 65535/);
   });
 
   it("rejects an allocation outside its parent-specific port range", () => {

--- a/packages/alproject/test/registry.test.ts
+++ b/packages/alproject/test/registry.test.ts
@@ -15,13 +15,13 @@ afterEach(() => {
 });
 
 describe("readRegistry", () => {
-  it("returns an empty version-1 registry when the file is absent", () => {
+  it("returns an empty schema-version-2 registry when the file is absent", () => {
     const fixture = makeFixture();
-    expect(readRegistry(fixture.config)).toEqual({ projects: [], version: 1 });
+    expect(readRegistry(fixture.config)).toEqual({ projects: [], schemaVersion: 2 });
     expect(registryPath(fixture.config)).toBe(join(fixture.root, REGISTRY_FILENAME));
   });
 
-  it("reads valid portless and allocated projects", () => {
+  it("reads valid schema-version-2 projects", () => {
     const fixture = makeFixture();
     const projectA = makeProject(fixture, "a");
     const projectB = makeProject(fixture, "b");
@@ -33,11 +33,22 @@ describe("readRegistry", () => {
           ports: { basePort: 8000, maxWorkspaces: 2, portsPerWorkspace: 10 },
         },
       ],
-      version: 1,
+      schemaVersion: 2,
     };
     writeRegistry(fixture, registry);
 
     expect(readRegistry(fixture.config)).toEqual(registry);
+  });
+
+  it("migrates a legacy version-1 registry", () => {
+    const fixture = makeFixture();
+    const project = makeProject(fixture, "legacy");
+    writeRegistry(fixture, { projects: [{ path: project }], version: 1 });
+
+    expect(readRegistry(fixture.config)).toEqual({
+      projects: [{ path: project }],
+      schemaVersion: 2,
+    });
   });
 
   it("reports malformed JSON with the registry path", () => {
@@ -47,7 +58,9 @@ describe("readRegistry", () => {
   });
 
   it.each([
-    ["unsupported version", { projects: [], version: 2 }],
+    ["unsupported legacy version", { projects: [], version: 2 }],
+    ["unsupported schema version", { projects: [], schemaVersion: 1 }],
+    ["both version fields", { projects: [], schemaVersion: 2, version: 1 }],
     ["missing projects", { version: 1 }],
     ["non-array projects", { projects: {}, version: 1 }],
     ["unknown registry field", { extra: true, projects: [], version: 1 }],
@@ -107,13 +120,13 @@ describe("readRegistry", () => {
     const fixture = makeFixture();
     writeRegistry(fixture, {
       projects: [{ path: "relative" }],
-      version: 1,
+      schemaVersion: 2,
     });
     expect(() => readRegistry(fixture.config)).toThrow(/project path must be absolute/);
 
     writeRegistry(fixture, {
       projects: [{ path: `${fixture.root}/missing/../project` }],
-      version: 1,
+      schemaVersion: 2,
     });
     expect(() => readRegistry(fixture.config)).toThrow(/project path must be canonical/);
   });
@@ -152,7 +165,7 @@ describe("readRegistry", () => {
       projects: [
         { path: project, ports: { basePort: 8991, maxWorkspaces: 2, portsPerWorkspace: 5 } },
       ],
-      version: 1,
+      schemaVersion: 2,
     };
     writeRegistry(fixture, registry);
     expect(readRegistry(fixture.config)).toEqual(registry);
@@ -174,7 +187,7 @@ describe("readRegistry", () => {
           },
         },
       ],
-      version: 1,
+      schemaVersion: 2,
     };
     writeRegistry(fixture, registry);
 

--- a/packages/alproject/test/status.test.ts
+++ b/packages/alproject/test/status.test.ts
@@ -31,7 +31,7 @@ describe("getProjectStatus", () => {
           ports: { basePort: 8000, maxWorkspaces: 3, portsPerWorkspace: 4 },
         },
       ],
-      version: 1,
+      schemaVersion: 2,
     };
 
     expect(getProjectStatus(fixture.config, registry, "project")).toEqual({
@@ -110,7 +110,7 @@ describe("getProjectStatus", () => {
   it("reports a registered project missing from the filesystem", () => {
     const fixture = makeFixture();
     const project = join(fixture.root, "missing");
-    const registry: Registry = { projects: [{ path: project }], version: 1 };
+    const registry: Registry = { projects: [{ path: project }], schemaVersion: 2 };
 
     expect(getProjectStatus(fixture.config, registry, "missing")).toEqual({
       name: "missing",
@@ -129,7 +129,7 @@ describe("getProjectStatus", () => {
     mkdirSync(configuredParent);
     fixture.config.projectParents = [{ path: configuredParent }];
     execGit(project, "remote", "add", "origin", "https://github.com/team/project.git");
-    const registry: Registry = { projects: [{ path: project }], version: 1 };
+    const registry: Registry = { projects: [{ path: project }], schemaVersion: 2 };
 
     expect(getProjectStatus(fixture.config, registry, project)).toMatchObject({
       path: project,
@@ -198,7 +198,7 @@ function makeRepository(parent: string, name: string): string {
 }
 
 function emptyRegistry(): Registry {
-  return { projects: [], version: 1 };
+  return { projects: [], schemaVersion: 2 };
 }
 
 function execGit(cwd: string, ...args: string[]): string {


### PR DESCRIPTION
Adds `--allow-outside-port-range` for explicit base-port allocations outside configured root and parent ranges. Retains overlap checks and TCP port limits, persists the override in project data, and documents its usage.

Closes #59