### PR TITLE
feat: rename DEVELOPMENT.md to DEVELOPERS.md

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -1,4 +1,4 @@
-# Development
+# Developer Guide
 
 The everyday workflow of this repository. Run `npm run docmap` for the design documentation.
 

--- a/README.md
+++ b/README.md
@@ -55,3 +55,5 @@ npm install
 npm run build --workspace @paleo/workspace
 npm run workspace -- setup
 ```
+
+The everyday workflow is in [`DEVELOPERS.md`](DEVELOPERS.md).

--- a/alignfirst-developer-tests/README.md
+++ b/alignfirst-developer-tests/README.md
@@ -49,7 +49,7 @@ See the upstream README for all flags. `--parallel K` (or `OPENCLAW_TEST_PARALLE
 
 ## Fixtures
 
-Each scenario starts fresh: [`scripts/reset-fixture.mjs`](scripts/reset-fixture.mjs) (run via `ctx.execInGateway(...)`) materializes three Git repositories on `main`, copied from the committed [`projects-fixture/template/`](projects-fixture/template/). `nimbus` and `lumen` live under `/home/claw/projects`; `orion` lives under the second explicit fixture parent `/home/claw/external-projects`. Each carries a project-specific package name, `DEVELOPERS.md` heading, port block (6500, 6520, and 6540), and an untracked `.plans/` directory for alcode's project gate.
+Each scenario starts fresh: [`scripts/reset-fixture.mjs`](scripts/reset-fixture.mjs) (run via `ctx.execInGateway(...)`) materializes three Git repositories on `main`, copied from the committed [`projects-fixture/template/`](projects-fixture/template/). `nimbus` and `lumen` live under `/home/claw/projects`; `orion` lives under the second explicit fixture parent `/home/claw/external-projects`. Each carries a project-specific package name, `README.md` and `DEVELOPERS.md` headings, port block (6500, 6520, and 6540), and an untracked `.plans/` directory for alcode's project gate.
 
 `/home/claw/lifecycle-projects` resets to an empty allowed parent. The creation scenario uses it for `nova`, isolated from the standard projects. Removal scenarios seed a real linked `nimbus` workspace and a sibling additional directory after reset.
 

--- a/alignfirst-developer-tests/README.md
+++ b/alignfirst-developer-tests/README.md
@@ -49,7 +49,7 @@ See the upstream README for all flags. `--parallel K` (or `OPENCLAW_TEST_PARALLE
 
 ## Fixtures
 
-Each scenario starts fresh: [`scripts/reset-fixture.mjs`](scripts/reset-fixture.mjs) (run via `ctx.execInGateway(...)`) materializes three Git repositories on `main`, copied from the committed [`projects-fixture/template/`](projects-fixture/template/). `nimbus` and `lumen` live under `/home/claw/projects`; `orion` lives under the second explicit fixture parent `/home/claw/external-projects`. Each carries a project-specific package name, `DEVELOPMENT.md` heading, port block (6500, 6520, and 6540), and an untracked `.plans/` directory for alcode's project gate.
+Each scenario starts fresh: [`scripts/reset-fixture.mjs`](scripts/reset-fixture.mjs) (run via `ctx.execInGateway(...)`) materializes three Git repositories on `main`, copied from the committed [`projects-fixture/template/`](projects-fixture/template/). `nimbus` and `lumen` live under `/home/claw/projects`; `orion` lives under the second explicit fixture parent `/home/claw/external-projects`. Each carries a project-specific package name, `DEVELOPERS.md` heading, port block (6500, 6520, and 6540), and an untracked `.plans/` directory for alcode's project gate.
 
 `/home/claw/lifecycle-projects` resets to an empty allowed parent. The creation scenario uses it for `nova`, isolated from the standard projects. Removal scenarios seed a real linked `nimbus` workspace and a sibling additional directory after reset.
 

--- a/alignfirst-developer-tests/projects-fixture/template/DEVELOPERS.md
+++ b/alignfirst-developer-tests/projects-fixture/template/DEVELOPERS.md
@@ -1,6 +1,4 @@
-# Developing
-
-A small full-stack product monorepo (API + frontend).
+# Developer Guide
 
 ## Stack
 
@@ -29,13 +27,6 @@ pnpm lint       # syntax-check every module
 A **workspace** is a git worktree (with its branch) together with its own dev setup: dedicated ports, config files, a database, and a dev server you can bring up or down. Workspaces are isolated from one another, so you can run several branches in parallel.
 
 Run `pnpm workspace --guide` for the full procedures (creating/removing workspaces, starting/stopping the dev server).
-
-### Fresh Clone
-
-```sh
-pnpm i
-pnpm workspace setup
-```
 
 ## Conventions
 

--- a/alignfirst-developer-tests/projects-fixture/template/README.md
+++ b/alignfirst-developer-tests/projects-fixture/template/README.md
@@ -1,0 +1,12 @@
+# Comparables
+
+A small full-stack product monorepo (API + frontend): region pages and a CSV export.
+
+## Getting started
+
+```sh
+pnpm i
+pnpm workspace setup
+```
+
+The everyday workflow is in [`DEVELOPERS.md`](DEVELOPERS.md).

--- a/alignfirst-developer-tests/scenarios/A07-status-existing-worktree.ts
+++ b/alignfirst-developer-tests/scenarios/A07-status-existing-worktree.ts
@@ -84,7 +84,7 @@ export default async function statusExistingWorktree(ctx: ScenarioContext): Prom
   });
 
   // A status report may be composed from repo/workflow metadata (git, gh, ls,
-  // DEVELOPMENT.md, .plans/) OR via alcode — both are fine, so we don't assert
+  // DEVELOPERS.md, .plans/) OR via alcode — both are fine, so we don't assert
   // how the status was gathered, only that the report is correct (rubric above),
   // lands in the thread, and leaves no stray worktrees / channel leak.
   assertWorktreePaths(ctx, [seededWorktreePath]);

--- a/alignfirst-developer-tests/scenarios/A17-project-creation.ts
+++ b/alignfirst-developer-tests/scenarios/A17-project-creation.ts
@@ -56,7 +56,7 @@ export default async function projectCreation(ctx: ScenarioContext): Promise<voi
       return (
         "Bootstrap complete in the main worktree. Created: package.json, pnpm-lock.yaml, " +
         "app.mjs, home-page.mjs, comparables.mjs, export-handler.mjs, app.test.mjs, " +
-        "DEVELOPMENT.md, docs/, scripts/workspace/ (workspace tooling), local.env.example, " +
+        "README.md, DEVELOPERS.md, docs/, scripts/workspace/ (workspace tooling), local.env.example, " +
         ".gitignore. This minimal scaffold is deliberate and complete — nothing else is " +
         "required before the initial commit on main."
       );

--- a/alignfirst-developer-tests/scenarios/_lib/agent-tool-calls.ts
+++ b/alignfirst-developer-tests/scenarios/_lib/agent-tool-calls.ts
@@ -11,7 +11,7 @@ const READ_VIA_EXEC = /\b(cat|head|tail|less|bat)\b/;
 /**
  * True when the call reads `fileName` — either the `read` tool with a matching
  * `path`, or an `exec` that cats/heads/tails it. `fileName` is matched as a
- * substring, so pass a discriminating suffix like `nimbus/DEVELOPMENT.md`.
+ * substring, so pass a discriminating suffix like `nimbus/DEVELOPERS.md`.
  */
 export function readsFile(call: AgentToolCall, fileName: string): boolean {
   const input = inputOf(call);

--- a/alignfirst-developer-tests/scenarios/_lib/workspace-flow.ts
+++ b/alignfirst-developer-tests/scenarios/_lib/workspace-flow.ts
@@ -63,14 +63,14 @@ export async function runWorkspaceFlow(
   });
 
   // The setup flow's documented prerequisites (project-workspace-setup.md): the
-  // agent must read the project's DEVELOPMENT.md — the worktree-setup entry
+  // agent must read the project's DEVELOPERS.md — the worktree-setup entry
   // point — and run `workspace --guide` to discover the setup commands. The
   // trajectory snapshot flushes only when a session run ends; when queued
   // inbounds and the exec wake coalesce the whole conversation into one run,
   // the flush trails the completion outbound — hence timeouts well past the
   // 30s default.
-  await ctx.waitForAgentToolCall((c) => readsFile(c, `${projectPath}/DEVELOPMENT.md`), {
-    label: "agent reads the project DEVELOPMENT.md",
+  await ctx.waitForAgentToolCall((c) => readsFile(c, `${projectPath}/DEVELOPERS.md`), {
+    label: "agent reads the project DEVELOPERS.md",
     timeoutMs: 120_000,
   });
   await ctx.waitForAgentToolCall((c) => execMatches(c, /workspace\s+--guide/), {

--- a/alignfirst-developer-tests/scripts/reset-fixture.mjs
+++ b/alignfirst-developer-tests/scripts/reset-fixture.mjs
@@ -87,7 +87,7 @@ async function resetFixture({ name, parent, basePort }) {
   runGit(dst, ["init", "-q", "--bare", "-b", BASE_BRANCH, origin], gitEnv);
   runGit(dst, ["remote", "add", "origin", origin], gitEnv);
   runGit(dst, ["push", "-q", "-u", "origin", BASE_BRANCH], gitEnv);
-  // A `production` branch too, so the remote matches DEVELOPMENT.md's convention
+  // A `production` branch too, so the remote matches DEVELOPERS.md's convention
   // (base `main`, production `production`) and `git branch -a` reads realistically.
   runGit(dst, ["push", "-q", "origin", `${BASE_BRANCH}:refs/heads/production`], gitEnv);
   runGit(dst, ["remote", "set-head", "origin", BASE_BRANCH], gitEnv);
@@ -104,11 +104,11 @@ function patchFixture(dst, name, basePort) {
   pkg.name = `@alignfirst-developer-tests/${name}-fixture`;
   writeFileSync(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`);
 
-  const devDocPath = `${dst}/DEVELOPMENT.md`;
+  const devDocPath = `${dst}/DEVELOPERS.md`;
   const capitalized = name.charAt(0).toUpperCase() + name.slice(1);
   const devDoc = readFileSync(devDocPath, "utf8").replace(
-    /^# Developing$/m,
-    `# Developing ${capitalized}`,
+    /^# Developer Guide$/m,
+    `# ${capitalized} Developer Guide`,
   );
   writeFileSync(devDocPath, devDoc);
 

--- a/alignfirst-developer-tests/scripts/reset-fixture.mjs
+++ b/alignfirst-developer-tests/scripts/reset-fixture.mjs
@@ -94,7 +94,7 @@ async function resetFixture({ name, parent, basePort }) {
 }
 
 // Per-name patches applied to the materialized copy of the shared template.
-// The package `name`, the welcome H1 and the port block diverge — the live
+// The package `name`, the entry-point H1s and the port block diverge — the live
 // directory name is what actually matters. Patching only the `name` field of
 // package.json keeps the frozen lockfile valid, so a single build-time install
 // serves both projects.
@@ -104,15 +104,23 @@ function patchFixture(dst, name, basePort) {
   pkg.name = `@alignfirst-developer-tests/${name}-fixture`;
   writeFileSync(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`);
 
-  const devDocPath = `${dst}/DEVELOPERS.md`;
+  // Both entry points name the project, so the three otherwise identical copies
+  // read distinctly — the app itself stays the "Comparables" product.
   const capitalized = name.charAt(0).toUpperCase() + name.slice(1);
-  const devDoc = readFileSync(devDocPath, "utf8").replace(
-    /^# Developer Guide$/m,
-    `# ${capitalized} Developer Guide`,
-  );
-  writeFileSync(devDocPath, devDoc);
+  patchHeading(`${dst}/README.md`, /^# Comparables$/m, `# ${capitalized}`);
+  patchHeading(`${dst}/DEVELOPERS.md`, /^# Developer Guide$/m, `# ${capitalized} Developer Guide`);
 
   patchBasePort(dst, basePort);
+}
+
+// An unmatched pattern would ship an unpersonalized fixture, silently weakening
+// every scenario that asserts which project the agent read. Fail loudly instead.
+function patchHeading(path, pattern, heading) {
+  const content = readFileSync(path, "utf8");
+  if (!pattern.test(content)) {
+    throw new Error(`heading ${pattern} not found in ${path}`);
+  }
+  writeFileSync(path, content.replace(pattern, heading));
 }
 
 // The template is written for the first fixture's block, so the second one has

--- a/alignfirst-developer-tests/workspace/AGENTS.md
+++ b/alignfirst-developer-tests/workspace/AGENTS.md
@@ -8,7 +8,7 @@ When a channel or DM message names a project or a ticket and you are not already
 
 Don't investigate the **code** yourself. Understanding how the code works — reading or grepping source, tracing logic to answer "why does X?" / "should we Y?" — is alcode's job. Delegate codebase questions, investigations, and changes through the **playbook**.
 
-Repo and workflow **metadata** is fair game directly: `git` (status, log, branch, diff, fetch), `gh` (PR/issue state), `ls`, the workspace tooling, `DEVELOPMENT.md`, the `.plans/` listing. A status request on a ticket ("where does ABC-123 stand?") is ticket work — handle it through the **playbook**: combine that metadata with the ticket's spec/summary history (via alcode `read`), never by reading the source.
+Repo and workflow **metadata** is fair game directly: `git` (status, log, branch, diff, fetch), `gh` (PR/issue state), `ls`, the workspace tooling, `DEVELOPERS.md`, the `.plans/` listing. A status request on a ticket ("where does ABC-123 stand?") is ticket work — handle it through the **playbook**: combine that metadata with the ticket's spec/summary history (via alcode `read`), never by reading the source.
 
 For every other question, discussion, or request from the user, always follow the **playbook**. The playbook is your guide for everything.
 

--- a/alignfirst-developer.md
+++ b/alignfirst-developer.md
@@ -148,7 +148,7 @@ Feel free to adapt the other sections. In particular, replace the instructions r
 Before handing a project to an AlignFirst Developer, set it up for autonomous work:
 
 - **Install [`@paleo/workspace`](https://www.npmjs.com/package/@paleo/workspace)** so the agent runs each task in its own isolated git-worktree environment, several branches in parallel. See its [README](packages/workspace/README.md) for setup.
-- **Add a `DEVELOPMENT.md`** at the project root: stack, layout, daily commands, conventions (ticket / branch / commit), and how to find docs. Example: [`projects-fixture/template/DEVELOPMENT.md`](alignfirst-developer-tests/projects-fixture/template/DEVELOPMENT.md).
+- **Add a `DEVELOPERS.md`** at the project root: stack, layout, daily commands, conventions (ticket / branch / commit), and how to find docs. Example: [`projects-fixture/template/DEVELOPERS.md`](alignfirst-developer-tests/projects-fixture/template/DEVELOPERS.md).
 - **Register the main worktree with `alproject`** after its `.git` directory exists. Use both port-allocation options when its workspace setup requires them.
 
 ## Contribute

--- a/docs/alignfirst-developer/writing-instructions-for-openclaw.md
+++ b/docs/alignfirst-developer/writing-instructions-for-openclaw.md
@@ -48,7 +48,7 @@ This is why the channel session's starter is the only place the handoff values c
 
 When step 1 of a procedure produces a value (project name, ticket id, branch name) and a later step would use it, restate the value in the later step's required output. "State X, then post an ack" leaves room for the agent to drop X from the ack. Collapse to: "Post `<form including X>`".
 
-This is a common cause of an otherwise-correct run failing an assertion. Concrete example from `A1-new-work-to-be-done`: after the user supplied a ticket in-thread, the ack had to restate both project and ticket and announce workspace setup. The agent's tool-call trace confirms it read the whole chain correctly (dispatcher → `working-session.md` → `project-workspace-setup.md` → the project's `DEVELOPMENT.md` → `workspace --guide`), yet the ack still came out as *"Simple UI tweak → AAD workflow. Je lance ça."* — naming the internal AlignFirst protocol instead of the setup signal. The reads happened; the ack form was the gap.
+This is a common cause of an otherwise-correct run failing an assertion. Concrete example from `A1-new-work-to-be-done`: after the user supplied a ticket in-thread, the ack had to restate both project and ticket and announce workspace setup. The agent's tool-call trace confirms it read the whole chain correctly (dispatcher → `working-session.md` → `project-workspace-setup.md` → the project's `DEVELOPERS.md` → `workspace --guide`), yet the ack still came out as *"Simple UI tweak → AAD workflow. Je lance ça."* — naming the internal AlignFirst protocol instead of the setup signal. The reads happened; the ack form was the gap.
 
 ## The other side: a value already on screen gets dropped
 

--- a/packages/openclaw-test/test/trajectory-log.test.ts
+++ b/packages/openclaw-test/test/trajectory-log.test.ts
@@ -99,7 +99,7 @@ describe("aggregateAgentToolCalls", () => {
         sessionKey: thread,
         ts: "2026-01-01T00:00:09Z",
         turns: [
-          { calls: [["t1", "read", { path: "~/projects/nimbus/DEVELOPMENT.md" }]] },
+          { calls: [["t1", "read", { path: "~/projects/nimbus/DEVELOPERS.md" }]] },
           { calls: [["t2", "exec", { command: "pnpm workspace --guide" }]] },
         ],
       }),
@@ -109,7 +109,7 @@ describe("aggregateAgentToolCalls", () => {
     expect(calls.find((c) => c.toolUseId === "c1")?.sessionKey).toBe(channel);
     expect(calls.find((c) => c.toolUseId === "t1")?.sessionKey).toBe(thread);
     expect(calls.find((c) => c.toolUseId === "t1")?.input).toEqual({
-      path: "~/projects/nimbus/DEVELOPMENT.md",
+      path: "~/projects/nimbus/DEVELOPERS.md",
     });
     expect(calls.find((c) => c.toolUseId === "t1")?.result).toEqual({
       isError: false,

--- a/skills/alignfirst-developer-openclaw-playbook/SKILL.md
+++ b/skills/alignfirst-developer-openclaw-playbook/SKILL.md
@@ -4,7 +4,7 @@ description: "Operating-instructions dispatcher for an AlignFirst Developer runn
 license: CC0 1.0
 metadata:
   author: Paleo
-  version: "0.25.0"
+  version: "0.26.0"
   repository: https://github.com/paleo/alignfirst
 ---
 
@@ -38,13 +38,6 @@ One caveat everywhere: only the message that **ends your turn** is guaranteed to
 
 PROJECT_PATH anchors project-file reads, main-worktree Git commands, workspace tooling, and lifecycle delegation. After workspace setup, use the returned linked-worktree path for branch work and `alcode`. Linked worktrees may live under any configured project parent.
 
-Inside a project, each entry point targets a reader:
-
-- `DEVELOPMENT.md` — the autonomous AI developer: you.
-- `README.md` — the human developer, and the one-time setup of a fresh clone.
-- `AGENTS.md` (`{PROJECT_PATH}/AGENTS.md`) — the coding agent (alcode).
-- The rest of the documentation (`docs/`, …) — everybody.
-
 Channel/DM: obtain PROJECT and PROJECT_PATH from `alproject list --json`, following the channel procedure. Never rely on memorized names.
 
 Thread: PROJECT, PROJECT_PATH, and TICKET_ID are fixed for ordinary workspace work. Recover them via `message action: "read"` from the starter, which carries the project, project path, ticket, audience, and task. Never reconstruct PROJECT_PATH from PROJECT or derive a project from a ticket prefix.
@@ -56,7 +49,7 @@ You are an autonomous programmer. Instructions reach you from two places, and "t
 - **This skill and the OpenClaw workspace files** (auto-loaded into your context) address you as an assistant: "the user" is the person in the chat.
 - **A project's files** (under its PROJECT_PATH) address programmers and their coding agents. You are the programmer, and alcode's user is you. When a project's `docs/` says "ask the user" or "let the user decide", it is an instruction for alcode (and the user is you).
 
-Exception: a project's `DEVELOPMENT.md` addresses you directly.
+Exception: a project's `DEVELOPERS.md` addresses the coding agent's user — you.
 
 ## Who you're talking to
 

--- a/skills/alignfirst-developer-openclaw-playbook/references/project-lifecycle.md
+++ b/skills/alignfirst-developer-openclaw-playbook/references/project-lifecycle.md
@@ -23,7 +23,7 @@ The direct main-worktree bootstrap is the creation exception. It ends with the i
 
 Removal requires the registered PROJECT_PATH selected before the thread opened or supplied by the user.
 
-1. Refresh `alproject list --json` and resolve the registered project at PROJECT_PATH. Read `{PROJECT_PATH}/DEVELOPMENT.md`, then run and read the project workspace guide it names.
+1. Refresh `alproject list --json` and resolve the registered project at PROJECT_PATH. Read `{PROJECT_PATH}/DEVELOPERS.md`, then run and read the project workspace guide it names.
 2. Use the project workspace tooling to enumerate every registered linked workspace and its exact absolute path. Include the exact PROJECT_PATH for the main worktree.
 3. Show the user the complete linked-worktree path list and the main-worktree path. Wait for explicit confirmation of those exact paths.
 4. Remove each confirmed linked workspace through the project workspace tooling. Stop immediately if any removal fails; keep the main worktree and registration intact.

--- a/skills/alignfirst-developer-openclaw-playbook/references/project-workspace-setup.md
+++ b/skills/alignfirst-developer-openclaw-playbook/references/project-workspace-setup.md
@@ -5,7 +5,7 @@ The setup phase of a working session: get the workspace ready before handling th
 ## Prerequisites — run both now, before Step 1
 
 - `alcode --openclaw-guide` (`exec`) — the delegation manual. Required every time you run this procedure, status requests included; do not skip it because no coding seems planned.
-- read `{PROJECT_PATH}/DEVELOPMENT.md` — how to create a worktree or a branch.
+- read `{PROJECT_PATH}/DEVELOPERS.md` — how to create a worktree or a branch.
 
 ## Step 1 — Requirements
 
@@ -39,12 +39,12 @@ That single call is the whole exception. The post right after it, and every one 
 
 The workspace tooling owns worktrees. Run its main-worktree commands from PROJECT_PATH. Create, reuse, and tear worktrees down through its commands only — never `git worktree add`/`remove`/`prune`, never `rm -rf` on a worktree directory, never a branch checked out by hand outside a workspace. A worktree the tooling doesn't know about is invisible to every other session.
 
-A project whose `DEVELOPMENT.md` has no workspaces section is not set up for you. Stop there and tell the user the project needs the workspace system installed, offering to run the setup with the `alignfirst-setup-guide` skill.
+A project whose `DEVELOPERS.md` has no workspaces section is not set up for you. Stop there and tell the user the project needs the workspace system installed, offering to run the setup with the `alignfirst-setup-guide` skill.
 
 First, check what already exists for the {TICKET_ID} — two checks, both required:
 
 - **Branch**: from PROJECT_PATH, list the branches, local and remote (`git branch -a`), and look for one matching the {TICKET_ID}. No match means no branch yet — an answer, not a failure.
-- **Registered workspaces**: `DEVELOPMENT.md` names the project's guide command (`workspace --guide`, with the project's own runner). It gives the commands to **list registered workspaces** and to **set up a workspace** — on an existing branch, or on a new one. Use them.
+- **Registered workspaces**: `DEVELOPERS.md` names the project's guide command (`workspace --guide`, with the project's own runner). It gives the commands to **list registered workspaces** and to **set up a workspace** — on an existing branch, or on a new one. Use them.
 
 Never assume the branch is new; `git worktree list` alone does not answer the branch question.
 

--- a/skills/alignfirst-developer-openclaw-playbook/references/working-session.md
+++ b/skills/alignfirst-developer-openclaw-playbook/references/working-session.md
@@ -85,7 +85,17 @@ For the `.plans/` directory's task directories, cycles, filenames, and artifact 
 
 ### Hand-written changes in `.plans/`
 
-Some projects share `.plans/` through a sync command, documented in `DEVELOPMENT.md`. After writing or editing a file there yourself, run the sync. A change written by alcode needs nothing — alcode syncs its own.
+Some projects share `.plans/` through a sync command, documented in `DEVELOPERS.md`. After writing or editing a file there yourself, run the sync. A change written by alcode needs nothing — alcode syncs its own.
+
+### The project's entry points
+
+A project has up to three entry points:
+
+- `README.md` — presentation, getting-started procedure…
+- `DEVELOPERS.md` — the coding agent's user, human or AI: you.
+- `AGENTS.md` — the coding agent (alcode).
+
+The rest of the documentation (`docs/`, …) addresses everybody.
 
 ### The project's documentation
 
@@ -110,7 +120,7 @@ Running the dev-server from the main worktree is fine.
 
 After a project's initial commit exists, editing the codebase happens on another branch in a linked worktree. If you need one and it doesn't exist yet, follow the [`project-workspace-setup.md`](./project-workspace-setup.md) instructions to set it up.
 
-Worktrees belong to the workspace tooling. Every creation, reuse, and teardown goes through its commands — run the guide `DEVELOPMENT.md` points to (`workspace --guide`) to get them. `git worktree add`/`remove`/`prune` and deleting a worktree directory are out of bounds, and so is a hand-made branch checkout outside a workspace. The registry is what makes a worktree visible to the other sessions and to the dev-server tooling.
+Worktrees belong to the workspace tooling. Every creation, reuse, and teardown goes through its commands — run the guide `DEVELOPERS.md` points to (`workspace --guide`) to get them. `git worktree add`/`remove`/`prune` and deleting a worktree directory are out of bounds, and so is a hand-made branch checkout outside a workspace. The registry is what makes a worktree visible to the other sessions and to the dev-server tooling.
 
 ### Updating a branch with the base branch
 
@@ -178,7 +188,7 @@ When the user brings up acceptance testing, first be sure who runs it — ask wh
 
 ### Improving project docs
 
-When you learn something non-obvious about how to work in a project — a command, a quirk, a convention not yet written down — offer to capture it in the project's `DEVELOPMENT.md`. Propose the improvement to the user, ask for confirmation, then have alcode make the edit.
+When you learn something non-obvious about how to work in a project — a command, a quirk, a convention not yet written down — offer to capture it in the project's `DEVELOPERS.md`. Propose the improvement to the user, ask for confirmation, then have alcode make the edit.
 
 ### Commit & push cadence
 

--- a/skills/alignfirst-setup-guide/SKILL.md
+++ b/skills/alignfirst-setup-guide/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Requires git and a Node.js package manager (npm, pnpm, yarn, or b
 license: CC0 1.0
 metadata:
   author: Paleo
-  version: "0.25.4"
+  version: "0.26.0"
   repository: https://github.com/paleo/alignfirst
 ---
 
@@ -24,15 +24,17 @@ Pick any combination. Each has its own reference; this skill investigates the re
 
 A project has up to three Markdown entry points, one per reader:
 
-- `README.md` — the human developer, and the one-time setup of a fresh clone (machine installation, plans repository link, main-worktree bootstrap).
+- `README.md` — the presentation and the getting-started procedure (machine installation, plans repository link, main-worktree bootstrap).
 - `AGENTS.md` (or `CLAUDE.md`) — the coding agent (Claude Code, alcode). The Step 3 references write their agent instructions here.
-- `DEVELOPMENT.md` — the AI developer: an autonomous bot. Recurring operating knowledge only; setup-once procedures belong in `README.md`. It must reference neither `README.md` nor `AGENTS.md`.
+- `DEVELOPERS.md` — the coding agent's user, human or AI. Recurring operating knowledge only; setup-once procedures belong in `README.md`. It must reference neither `README.md` nor `AGENTS.md`.
+
+`DEVELOPERS.md` is an AlignFirst convention, so write it only for a project an AI bot will drive. Once present, it serves every developer of the project.
 
 The rest of the documentation (`docs/`, served by docmap) addresses everybody. The entry points are read every session, `docs/` on demand — so anything consulted occasionally goes there, including multi-step procedures such as creating a merge request or writing a changeset. Move the whole procedure and leave no summary behind in an entry point.
 
 Inside an entry point, add each new fact to the line that already describes its subject, rather than opening a section for it.
 
-A project is **bot-ready** when the workspace system is installed, the alignfirst skills section in `AGENTS.md` is written, and `DEVELOPMENT.md` covers: the stack, the layout, the daily commands, the conventions (ticket, branch, commit), a workspaces section pointing at the `workspace --guide` command, and how to browse the docs (docmap).
+A project is **bot-ready** when the workspace system is installed, the alignfirst skills section in `AGENTS.md` is written, and `DEVELOPERS.md` covers: the stack, the layout, the daily commands, the conventions (ticket, branch, commit), a workspaces section pointing at the `workspace --guide` command, and how to browse the docs (docmap).
 
 Follow these four steps in order. Do not skip ahead: complete each before starting the next.
 
@@ -47,7 +49,7 @@ Then detect each tool's existing footprint:
 - **docmap**: a `docmap` script, a `@paleo/docmap` dependency, or a `docs/` directory.
 - **workspace**: a `workspace` script or a `@paleo/workspace` dependency.
 - **alignfirst skills**: an installed alignfirst skill, a `.plans/` directory, or an `## AlignFirst` section in `AGENTS.md` / `CLAUDE.md`.
-- **bot readiness**: a `DEVELOPMENT.md` at the project root.
+- **bot readiness**: a `DEVELOPERS.md` at the project root.
 
 ## Step 2 — Discuss
 
@@ -63,7 +65,7 @@ Require a clean working tree first (`git status`). If it isn't clean, stop and a
 - [workspace-setup.md](references/workspace-setup.md) — implement the worktree system (adapt the [asset scripts](assets/), install `@paleo/workspace`).
 - [alignfirst-skills-setup.md](references/alignfirst-skills-setup.md) — install the AlignFirst skills and configure the project. For a team sharing plans through a dedicated repository, continue with [plans-share-setup.md](references/plans-share-setup.md).
 
-**Bot-ready setup**: finish by creating or completing `DEVELOPMENT.md` ([entry-point files](#the-entry-point-files)), reusing Step 1's detections and the sections the references wrote to `AGENTS.md`.
+**Bot-ready setup**: finish by creating or completing `DEVELOPERS.md` ([entry-point files](#the-entry-point-files)), reusing Step 1's detections and the sections the references wrote to `AGENTS.md`.
 
 **Upgrading from an older AlignFirst** (v1/v2): route through [alignfirst-upgrade.md](references/alignfirst-upgrade.md), which detects the version and follows [alignfirst-upgrade-from-v1.md](references/alignfirst-upgrade-from-v1.md) or [alignfirst-upgrade-from-v2.md](references/alignfirst-upgrade-from-v2.md).
 

--- a/skills/alignfirst-setup-guide/references/docmap-bootstrapping.md
+++ b/skills/alignfirst-setup-guide/references/docmap-bootstrapping.md
@@ -28,7 +28,7 @@ Aim for 40–80 lines per document. If a topic is too broad, split it.
 
 An entry point is read every session; `docs/` is read on demand. A procedure earns a document when it is followed occasionally and has several steps — the reader pays for it only when the task comes up, and there is room to write it properly.
 
-Left in `AGENTS.md` or `DEVELOPMENT.md`, the same procedure gets compressed to a command or two, which is the useless half: the agent learns that a changeset exists, but not which packages to declare, which bump to pick, or what the CI rejects. It also tends to reappear in `README.md` in a third wording, and the three copies drift.
+Left in `AGENTS.md` or `DEVELOPERS.md`, the same procedure gets compressed to a command or two, which is the useless half: the agent learns that a changeset exists, but not which packages to declare, which bump to pick, or what the CI rejects. It also tends to reappear in `README.md` in a third wording, and the three copies drift.
 
 So move the whole procedure into `docs/` and leave nothing behind — no summary line, no pointer. Docmap already indexes the document, and the `read_when` entries fire when the task arises.
 

--- a/skills/alignfirst-setup-guide/references/plans-share-setup.md
+++ b/skills/alignfirst-setup-guide/references/plans-share-setup.md
@@ -47,7 +47,7 @@ Create the plans repository on the team's git host (recommended name: `{team-nam
    >
    > After every change in `.plans/`, synchronize the plans: `npm run plans:sync`.
 
-5. On a bot-driven project, add the sync instruction to `DEVELOPMENT.md` as well, on the `.plans/` entry of its layout section:
+5. On a bot-driven project, add the sync instruction to `DEVELOPERS.md` as well, on the `.plans/` entry of its layout section:
 
    > - `.plans/` — task plans. Symlinked across worktrees, and into a clone of the team plans repository so plans are shared with the team. Run `npm run plans:sync` after changing anything under it.
 

--- a/skills/alignfirst-setup-guide/references/workspace-setup.md
+++ b/skills/alignfirst-setup-guide/references/workspace-setup.md
@@ -193,11 +193,11 @@ The system only works if agents know about it. The CLI self-documents via `works
   Always ignore the `.local-wt`, `.plans` directories when searching the codebase.
   ```
 
-On a bot-driven project, `DEVELOPMENT.md` carries the same workspaces section: the bot reads that file to learn how to create a worktree or a branch. Same two parts, same limit — the definition and the pointer to `--guide`, never the command list.
+On a bot-driven project, `DEVELOPERS.md` carries the same workspaces section: its developers, the bot included, read that file to learn how to create a worktree or a branch. Same two parts, same limit — the definition and the pointer to `--guide`, never the command list.
 
 ### Project-specific facts the guide can't know
 
-Record only repo-specific facts, in whatever entry point developers and agents already read (`README.md`, `AGENTS.md`, `DEVELOPMENT.md`):
+Record only repo-specific facts, in whatever entry point developers and agents already read (`README.md`, `AGENTS.md`, `DEVELOPERS.md`):
 
 1. **URLs to open after `dev` starts** (admin UI, auto-login), with the dynamic port.
 2. **Any project quirk** — extra build steps, a non-obvious log path.
@@ -208,7 +208,7 @@ The port layout is not one of them either: the block table, what raising `perWor
 
 ## The bot contract
 
-An OpenClaw bot creates every worktree through the workspace system; its playbook offers no hand-made fallback, so a project it drives must have the system installed. `@paleo/workspace` satisfies the contract below as shipped. A reimplementation must provide the same behavior, whatever its language and runner: the playbook reads the invocation from `DEVELOPMENT.md`, so the command's name and prefix are free while its behavior is fixed.
+An OpenClaw bot creates every worktree through the workspace system; its playbook offers no hand-made fallback, so a project it drives must have the system installed. `@paleo/workspace` satisfies the contract below as shipped. A reimplementation must provide the same behavior, whatever its language and runner: the playbook reads the invocation from `DEVELOPERS.md`, so the command's name and prefix are free while its behavior is fixed.
 
 | Requirement | Why the bot needs it |
 | --- | --- |
@@ -239,6 +239,6 @@ Items marked *(ports)* drop out without a port scheme, items marked *(dev server
 - [ ] **Add the `workspace` npm script**, and the `dev` one *(dev server)* (don't reuse the app's dev name).
 - [ ] **Set `maxConcurrentDevServers`** (default `5`). *(dev server)*
 - [ ] **Update `.gitignore`** for your shared and per-worktree directories.
-- [ ] **Wire agents** — a search-ignore line, a workspaces section pointing at `workspace --guide` (in `DEVELOPMENT.md` too on a bot-driven project), the conventions, and the project-specific facts.
+- [ ] **Wire agents** — a search-ignore line, a workspaces section pointing at `workspace --guide` (in `DEVELOPERS.md` too on a bot-driven project), the conventions, and the project-specific facts.
 - [ ] **Check [the bot contract](#the-bot-contract)** on a bot-driven project. Automatic with `@paleo/workspace`; a matter of verification in a reimplementation.
 - [ ] **Verify the whole lifecycle** on a throwaway branch: `workspace setup -c <branch>`, then check the linked worktree's gitignored files carry its own ports, start its dev server *(dev server)*, and finish with `workspace remove`. A wrapper that merely loads proves nothing.


### PR DESCRIPTION
- The `DEVELOPMENT.md` entry point is renamed `DEVELOPERS.md` everywhere: root file, fixture template, skills, docs and test harness.
- The three entry points are reframed in the playbook (`working-session.md`) and the setup guide: `README.md` — presentation and getting started; `DEVELOPERS.md` — the coding agent's user, human or AI; `AGENTS.md` — the coding agent.
- The fixture template gains a `README.md` carrying the getting-started procedure; the default `DEVELOPERS.md` title is `Developer Guide`.
- Skill versions: `alignfirst-developer-openclaw-playbook` 0.26.0, `alignfirst-setup-guide` 0.26.0.